### PR TITLE
refactor: expose CLI main function externally

### DIFF
--- a/cmd/azldev/azldev.go
+++ b/cmd/azldev/azldev.go
@@ -4,42 +4,9 @@
 package main
 
 import (
-	"os"
-
-	"github.com/microsoft/azure-linux-dev-tools/internal/app/azldev"
-	"github.com/microsoft/azure-linux-dev-tools/internal/app/azldev/cmds/advanced"
-	"github.com/microsoft/azure-linux-dev-tools/internal/app/azldev/cmds/component"
-	"github.com/microsoft/azure-linux-dev-tools/internal/app/azldev/cmds/config"
-	"github.com/microsoft/azure-linux-dev-tools/internal/app/azldev/cmds/docs"
-	"github.com/microsoft/azure-linux-dev-tools/internal/app/azldev/cmds/image"
-	"github.com/microsoft/azure-linux-dev-tools/internal/app/azldev/cmds/project"
-	"github.com/microsoft/azure-linux-dev-tools/internal/app/azldev/cmds/version"
+	"github.com/microsoft/azure-linux-dev-tools/pkg/app/azldev_cli"
 )
 
 func main() {
-	// Instantiate the main CLI app instance.
-	app := InstantiateApp()
-
-	// Execute! We'll get back an exit code that we will exit with.
-	ret := app.Execute(os.Args[1:])
-
-	os.Exit(ret)
-}
-
-// Constructs a new instance of the main CLI application, with all subcommands registered.
-func InstantiateApp() *azldev.App {
-	// Instantiate the main CLI application.
-	app := azldev.NewApp(azldev.DefaultFileSystemFactory(), azldev.DefaultOSEnvFactory())
-
-	// Give top level command packages an opportunity to register their commands (or in some cases,
-	// request post-init callbacks).
-	advanced.OnAppInit(app)
-	component.OnAppInit(app)
-	config.OnAppInit(app)
-	docs.OnAppInit(app)
-	image.OnAppInit(app)
-	project.OnAppInit(app)
-	version.OnAppInit(app)
-
-	return app
+	azldev_cli.Main()
 }

--- a/pkg/app/azldev_cli/azldev.go
+++ b/pkg/app/azldev_cli/azldev.go
@@ -1,0 +1,45 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+package azldev_cli
+
+import (
+	"os"
+
+	"github.com/microsoft/azure-linux-dev-tools/internal/app/azldev"
+	"github.com/microsoft/azure-linux-dev-tools/internal/app/azldev/cmds/advanced"
+	"github.com/microsoft/azure-linux-dev-tools/internal/app/azldev/cmds/component"
+	"github.com/microsoft/azure-linux-dev-tools/internal/app/azldev/cmds/config"
+	"github.com/microsoft/azure-linux-dev-tools/internal/app/azldev/cmds/docs"
+	"github.com/microsoft/azure-linux-dev-tools/internal/app/azldev/cmds/image"
+	"github.com/microsoft/azure-linux-dev-tools/internal/app/azldev/cmds/project"
+	"github.com/microsoft/azure-linux-dev-tools/internal/app/azldev/cmds/version"
+)
+
+func Main() {
+	// Instantiate the main CLI app instance.
+	app := InstantiateApp()
+
+	// Execute! We'll get back an exit code that we will exit with.
+	ret := app.Execute(os.Args[1:])
+
+	os.Exit(ret)
+}
+
+// Constructs a new instance of the main CLI application, with all subcommands registered.
+func InstantiateApp() *azldev.App {
+	// Instantiate the main CLI application.
+	app := azldev.NewApp(azldev.DefaultFileSystemFactory(), azldev.DefaultOSEnvFactory())
+
+	// Give top level command packages an opportunity to register their commands (or in some cases,
+	// request post-init callbacks).
+	advanced.OnAppInit(app)
+	component.OnAppInit(app)
+	config.OnAppInit(app)
+	docs.OnAppInit(app)
+	image.OnAppInit(app)
+	project.OnAppInit(app)
+	version.OnAppInit(app)
+
+	return app
+}

--- a/pkg/app/azldev_cli/azldev_test.go
+++ b/pkg/app/azldev_cli/azldev_test.go
@@ -1,18 +1,18 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-package main_test
+package azldev_cli_test
 
 import (
 	"testing"
 
-	main "github.com/microsoft/azure-linux-dev-tools/cmd/azldev"
+	azldev_cli "github.com/microsoft/azure-linux-dev-tools/pkg/app/azldev_cli"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
 func TestInstantiateApp(t *testing.T) {
-	app := main.InstantiateApp()
+	app := azldev_cli.InstantiateApp()
 	if assert.NotNil(t, app) {
 		topLevelCommandNames, err := app.CommandNames()
 		require.NoError(t, err)


### PR DESCRIPTION
Transitional support to enable wrapping the `azldev` main function externally for build reasons.