### PR TITLE
feat(config): rename publish channel field to publish-channel and PublishChannel

### DIFF
--- a/docs/user/how-to/inspect-package-config.md
+++ b/docs/user/how-to/inspect-package-config.md
@@ -28,14 +28,14 @@ azldev package list -a
 Example output:
 
 ```
-╭──────────────────┬────────────────┬───────────┬──────────────╮
+╭──────────────────┬────────────────┬───────────┬─────────────────╮
 │ PACKAGE          │ GROUP          │ COMPONENT │ PUBLISH CHANNEL │
-├──────────────────┼────────────────┼───────────┼──────────────┤
-│ curl-debugsource │ debug-packages │           │ rpm-debug    │
-│ libcurl          │ base-packages  │           │ rpm-base     │
-│ libcurl-devel    │ devel-packages │ curl      │ rpm-base     │
-│ wget2-wget       │                │ wget2     │ rpm-base     │
-╰──────────────────┴────────────────┴───────────┴──────────────╯
+├──────────────────┼────────────────┼───────────┼─────────────────┤
+│ curl-debugsource │ debug-packages │           │ rpm-debug       │
+│ libcurl          │ base-packages  │           │ rpm-base        │
+│ libcurl-devel    │ devel-packages │ curl      │ rpm-base        │
+│ wget2-wget       │                │ wget2     │ rpm-base        │
+╰──────────────────┴────────────────┴───────────┴─────────────────╯
 ```
 
 ### Column meanings

--- a/docs/user/how-to/inspect-package-config.md
+++ b/docs/user/how-to/inspect-package-config.md
@@ -29,7 +29,7 @@ Example output:
 
 ```
 ╭──────────────────┬────────────────┬───────────┬──────────────╮
-│ PACKAGE          │ GROUP          │ COMPONENT │ CHANNEL      │
+│ PACKAGE          │ GROUP          │ COMPONENT │ PUBLISH CHANNEL │
 ├──────────────────┼────────────────┼───────────┼──────────────┤
 │ curl-debugsource │ debug-packages │           │ rpm-debug    │
 │ libcurl          │ base-packages  │           │ rpm-base     │
@@ -45,7 +45,7 @@ Example output:
 | **Package** | Binary package name (RPM `Name` tag) |
 | **Group** | Package-group whose `packages` list contains this package, if any |
 | **Component** | Component that has an explicit `packages.<name>` override for this package, if any |
-| **Channel** | Effective publish channel after all config layers are applied |
+| **Publish Channel** | Effective publish channel after all config layers are applied |
 
 > **Note:** A non-empty **Component** column means the component has an explicit
 > per-package entry in its `packages` map — it does **not** mean "the component
@@ -84,7 +84,7 @@ azldev package list -a -q -O json
     "packageName": "libcurl",
     "group": "base-packages",
     "component": "",
-    "channel": "rpm-base"
+    "publishChannel": "rpm-base"
   },
   ...
 ]

--- a/internal/app/azldev/cmds/component/build.go
+++ b/internal/app/azldev/cmds/component/build.go
@@ -52,7 +52,7 @@ type RPMResult struct {
 
 	// Channel is the resolved publish channel from project config.
 	// Empty when no channel is configured for this package.
-	Channel string `json:"channel" table:"Channel"`
+	Channel string `json:"publishChannel" table:"Publish Channel"`
 }
 
 // ComponentBuildResults summarizes the results of building a single component.
@@ -68,7 +68,7 @@ type ComponentBuildResults struct {
 
 	// RPMChannels holds the resolved publish channel for each RPM, parallel to [RPMPaths].
 	// Empty string means no channel was configured for that package.
-	RPMChannels []string `json:"rpmChannels" table:"Channels"`
+	RPMChannels []string `json:"rpmChannels" table:"Publish Channels"`
 
 	// RPMs contains enriched per-RPM information including the resolved publish channel.
 	RPMs []RPMResult `json:"rpms" table:"-"`

--- a/internal/app/azldev/cmds/pkg/list.go
+++ b/internal/app/azldev/cmds/pkg/list.go
@@ -86,7 +86,7 @@ type PackageListResult struct {
 
 	// Channel is the resolved publish channel after applying all config layers.
 	// Empty means no channel has been configured.
-	Channel string `json:"channel" table:"Channel"`
+	Channel string `json:"publishChannel" table:"Publish Channel"`
 }
 
 // buildComponentPackageIndex builds a map from binary package name to the component


### PR DESCRIPTION
This pull request changes the naming of the publish channel field from `channel` to `publish-channel` in JSON and table output:
- **azldev package list**: JSON key `channel` -> `publishChannel`,
  table header `CHANNEL` -> `PUBLISH CHANNEL`
- **azldev component build**: JSON key `channel` -> `publishChannel`,
  table header `Channel` -> `Publish Channel` (per-RPM result);
  table header `Channels` -> `Publish Channels` (per-component summary)
- Update inspect-package-config.md doc examples to match
<img width="1389" height="724" alt="image" src="https://github.com/user-attachments/assets/21b25480-9f94-4a03-ade6-8e4ffc7d0fb2" />
