### PR TITLE
feat(cli): add advanced command hint to help output

### DIFF
--- a/internal/app/azldev/app.go
+++ b/internal/app/azldev/app.go
@@ -155,6 +155,7 @@ lives), or use -C to point to one.`,
 
 	app.cmd.SetHelpCommandGroupID(CommandGroupMeta)
 	app.cmd.SetCompletionCommandGroupID(CommandGroupMeta)
+	app.addAdvancedCommandHint()
 
 	// Define global flags and configuration settings.
 	app.cmd.PersistentFlags().BoolVarP(&app.verbose, "verbose", "v", false, "enable verbose output")
@@ -177,6 +178,20 @@ lives), or use -C to point to one.`,
 		false, "do not fail on unknown fields in TOML config files")
 
 	return app
+}
+
+// addAdvancedCommandHint customizes the root help output to include a hint about
+// the hidden "advanced" command group.
+func (a *App) addAdvancedCommandHint() {
+	defaultHelp := a.cmd.HelpFunc()
+	a.cmd.SetHelpFunc(func(cmd *cobra.Command, args []string) {
+		defaultHelp(cmd, args)
+
+		if cmd == cmd.Root() {
+			fmt.Fprintln(cmd.OutOrStdout(),
+				`Use "azldev advanced --help" for additional tools (mock, mcp, wget).`)
+		}
+	})
 }
 
 // Returns the names of the app's commands. The optional provided list of ancestors

--- a/internal/app/azldev/app.go
+++ b/internal/app/azldev/app.go
@@ -180,18 +180,16 @@ lives), or use -C to point to one.`,
 	return app
 }
 
-// addAdvancedCommandHint customizes the root help output to include a hint about
-// the hidden "advanced" command group.
+// addAdvancedCommandHint embeds a hint about the hidden "advanced" command group
+// into the root command's usage template so that DisableExtraNewlines handles
+// trailing whitespace consistently.
 func (a *App) addAdvancedCommandHint() {
-	defaultHelp := a.cmd.HelpFunc()
-	a.cmd.SetHelpFunc(func(cmd *cobra.Command, args []string) {
-		defaultHelp(cmd, args)
-
-		if cmd == cmd.Root() {
-			fmt.Fprintln(cmd.OutOrStdout(),
-				`Use "azldev advanced --help" for additional tools (mock, mcp, wget).`)
-		}
-	})
+	tmpl := a.cmd.UsageTemplate()
+	tmpl = strings.TrimSuffix(tmpl, "\n")
+	tmpl += `{{if not .HasParent}}
+Use "{{.CommandPath}} advanced --help" for additional tools (mock, mcp, wget).{{end}}
+`
+	a.cmd.SetUsageTemplate(tmpl)
 }
 
 // Returns the names of the app's commands. The optional provided list of ancestors

--- a/scenario/__snapshots__/TestSnapshotsContainer_--bogus-flag_stderr_1.snap
+++ b/scenario/__snapshots__/TestSnapshotsContainer_--bogus-flag_stderr_1.snap
@@ -31,6 +31,7 @@ Flags:
       --version                   version for azldev
 
 Use "azldev [command] --help" for more information about a command.
+Use "azldev advanced --help" for additional tools (mock, mcp, wget).
 
 
 ##:##:## ERR Error: unknown flag: --bogus-flag

--- a/scenario/__snapshots__/TestSnapshotsContainer_--help_stdout_1.snap
+++ b/scenario/__snapshots__/TestSnapshotsContainer_--help_stdout_1.snap
@@ -39,3 +39,5 @@ Flags:
 
 Use "azldev [command] --help" for more information about a command.
 
+Use "azldev advanced --help" for additional tools (mock, mcp, wget).
+

--- a/scenario/__snapshots__/TestSnapshotsContainer_--help_stdout_1.snap
+++ b/scenario/__snapshots__/TestSnapshotsContainer_--help_stdout_1.snap
@@ -38,6 +38,5 @@ Flags:
       --version                   version for azldev
 
 Use "azldev [command] --help" for more information about a command.
-
 Use "azldev advanced --help" for additional tools (mock, mcp, wget).
 

--- a/scenario/__snapshots__/TestSnapshotsContainer_help_stdout_1.snap
+++ b/scenario/__snapshots__/TestSnapshotsContainer_help_stdout_1.snap
@@ -39,3 +39,5 @@ Flags:
 
 Use "azldev [command] --help" for more information about a command.
 
+Use "azldev advanced --help" for additional tools (mock, mcp, wget).
+

--- a/scenario/__snapshots__/TestSnapshotsContainer_help_stdout_1.snap
+++ b/scenario/__snapshots__/TestSnapshotsContainer_help_stdout_1.snap
@@ -38,6 +38,5 @@ Flags:
       --version                   version for azldev
 
 Use "azldev [command] --help" for more information about a command.
-
 Use "azldev advanced --help" for additional tools (mock, mcp, wget).
 

--- a/scenario/__snapshots__/TestSnapshots_--bogus-flag_stderr_1.snap
+++ b/scenario/__snapshots__/TestSnapshots_--bogus-flag_stderr_1.snap
@@ -31,6 +31,7 @@ Flags:
       --version                   version for azldev
 
 Use "azldev [command] --help" for more information about a command.
+Use "azldev advanced --help" for additional tools (mock, mcp, wget).
 
 
 ##:##:## ERR Error: unknown flag: --bogus-flag

--- a/scenario/__snapshots__/TestSnapshots_--help_stdout_1.snap
+++ b/scenario/__snapshots__/TestSnapshots_--help_stdout_1.snap
@@ -39,3 +39,5 @@ Flags:
 
 Use "azldev [command] --help" for more information about a command.
 
+Use "azldev advanced --help" for additional tools (mock, mcp, wget).
+

--- a/scenario/__snapshots__/TestSnapshots_--help_stdout_1.snap
+++ b/scenario/__snapshots__/TestSnapshots_--help_stdout_1.snap
@@ -38,6 +38,5 @@ Flags:
       --version                   version for azldev
 
 Use "azldev [command] --help" for more information about a command.
-
 Use "azldev advanced --help" for additional tools (mock, mcp, wget).
 

--- a/scenario/__snapshots__/TestSnapshots_--help_with_color_stdout_1.snap
+++ b/scenario/__snapshots__/TestSnapshots_--help_with_color_stdout_1.snap
@@ -39,3 +39,4 @@ Meta commands:
 
 Use "[1;3mazldev[0m [command] --help" for more information about a command.
 
+Use "azldev advanced --help" for additional tools (mock, mcp, wget).

--- a/scenario/__snapshots__/TestSnapshots_--help_with_color_stdout_1.snap
+++ b/scenario/__snapshots__/TestSnapshots_--help_with_color_stdout_1.snap
@@ -38,5 +38,5 @@ Meta commands:
       [1;36m--version[0m                   version for azldev
 
 Use "[1;3mazldev[0m [command] --help" for more information about a command.
+Use "[1;3mazldev[0m advanced --help" for additional tools (mock, mcp, wget).
 
-Use "azldev advanced --help" for additional tools (mock, mcp, wget).

--- a/scenario/__snapshots__/TestSnapshots_help_stdout_1.snap
+++ b/scenario/__snapshots__/TestSnapshots_help_stdout_1.snap
@@ -39,3 +39,5 @@ Flags:
 
 Use "azldev [command] --help" for more information about a command.
 
+Use "azldev advanced --help" for additional tools (mock, mcp, wget).
+

--- a/scenario/__snapshots__/TestSnapshots_help_stdout_1.snap
+++ b/scenario/__snapshots__/TestSnapshots_help_stdout_1.snap
@@ -38,6 +38,5 @@ Flags:
       --version                   version for azldev
 
 Use "azldev [command] --help" for more information about a command.
-
 Use "azldev advanced --help" for additional tools (mock, mcp, wget).
 


### PR DESCRIPTION
## Summary
- Adds a hint line at the bottom of `azldev --help` output: `Use "azldev advanced --help" for additional tools (mock, mcp, wget).`
- Improves discoverability of the hidden `advanced` command group without fully unhiding it
- Updates help output snapshots to match

Closes #33

## Test plan
- [x] `mage unit` passes
- [x] `mage check all` passes
- [x] CI scenario tests pass with updated snapshots