### PR TITLE
refactor(lockfile): split to per-component lock files

### DIFF
--- a/docs/user/reference/cli/azldev_component_update.md
+++ b/docs/user/reference/cli/azldev_component_update.md
@@ -6,10 +6,10 @@ Resolve and lock upstream commits for components
 
 ### Synopsis
 
-Resolve upstream commit hashes for components and write them to azldev.lock.
+Resolve upstream commit hashes for components and write them to per-component lock files.
 
 For upstream components, this resolves the effective commit hash using the
-distro snapshot time or explicit pin, then records it in the lock file.
+distro snapshot time or explicit pin, then records it in locks/<name>.lock.
 Subsequent commands (render, build) use the locked commit for deterministic,
 reproducible results.
 

--- a/internal/app/azldev/cmds/component/update.go
+++ b/internal/app/azldev/cmds/component/update.go
@@ -116,7 +116,10 @@ func saveComponentLocks(store *lockfile.Store, results []UpdateResult) error {
 			continue
 		}
 
-		lock := store.GetOrNew(results[idx].Component)
+		lock, lockErr := store.GetOrNew(results[idx].Component)
+		if lockErr != nil {
+			return fmt.Errorf("loading lock for %#q:\n%w", results[idx].Component, lockErr)
+		}
 
 		// Set import-commit on first lock creation (write-once).
 		if lock.ImportCommit == "" && results[idx].UpstreamCommit != "" {
@@ -242,22 +245,41 @@ func resolveUpstreamCommitsParallel(
 			results[idx].UpstreamCommit = commitHash
 
 			// Check existing lock to determine if the commit changed.
-			existingLock, loadErr := store.Get(comp.GetName())
-			if loadErr != nil {
-				// No existing lock = new component, always changed.
-				results[idx].Changed = true
-
-				return
-			}
-
-			results[idx].PreviousCommit = existingLock.UpstreamCommit
-			results[idx].Changed = existingLock.UpstreamCommit != commitHash
+			checkLockChanged(store, comp.GetName(), &results[idx])
 		}()
 	}
 
 	waitGroup.Wait()
 
 	return results
+}
+
+// checkLockChanged compares the resolved commit against the existing lock file
+// to determine if the component changed. Distinguishes "not found" (new
+// component) from real errors (corrupt lock file).
+func checkLockChanged(store *lockfile.Store, componentName string, result *UpdateResult) {
+	exists, existsErr := store.Exists(componentName)
+	if existsErr != nil {
+		result.Error = fmt.Sprintf("checking lock: %v", existsErr)
+
+		return
+	}
+
+	if !exists {
+		result.Changed = true
+
+		return
+	}
+
+	existingLock, loadErr := store.Get(componentName)
+	if loadErr != nil {
+		result.Error = fmt.Sprintf("loading lock: %v", loadErr)
+
+		return
+	}
+
+	result.PreviousCommit = existingLock.UpstreamCommit
+	result.Changed = existingLock.UpstreamCommit != result.UpstreamCommit
 }
 
 func resolveOneUpstreamCommit(

--- a/internal/app/azldev/cmds/component/update.go
+++ b/internal/app/azldev/cmds/component/update.go
@@ -160,12 +160,12 @@ func checkUpdateResults(env *azldev.Env, results []UpdateResult) error {
 			"errors", len(failedNames))
 
 		return fmt.Errorf(
-			"%d component(s) failed to resolve; lock file not updated:\n  %s",
+			"%d component(s) failed to resolve; lock files not updated:\n  %s",
 			len(failedNames), strings.Join(failedNames, "\n  "))
 	}
 
 	if env.Context().Err() != nil {
-		return errors.New("update cancelled; lock file not updated")
+		return errors.New("update cancelled; lock files not updated")
 	}
 
 	slog.Info("Update complete",

--- a/internal/app/azldev/cmds/component/update.go
+++ b/internal/app/azldev/cmds/component/update.go
@@ -7,7 +7,6 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
-	"path/filepath"
 	"strings"
 	"sync"
 
@@ -35,10 +34,10 @@ func NewUpdateCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "update",
 		Short: "Resolve and lock upstream commits for components",
-		Long: `Resolve upstream commit hashes for components and write them to azldev.lock.
+		Long: `Resolve upstream commit hashes for components and write them to per-component lock files.
 
 For upstream components, this resolves the effective commit hash using the
-distro snapshot time or explicit pin, then records it in the lock file.
+distro snapshot time or explicit pin, then records it in locks/<name>.lock.
 Subsequent commands (render, build) use the locked commit for deterministic,
 reproducible results.
 
@@ -78,7 +77,7 @@ type UpdateResult struct {
 }
 
 // UpdateComponents resolves upstream commits for all selected components and
-// writes the results to azldev.lock.
+// writes the results to per-component lock files under locks/.
 func UpdateComponents(env *azldev.Env, options *UpdateComponentOptions) ([]UpdateResult, error) {
 	resolver := components.NewResolver(env)
 
@@ -92,31 +91,46 @@ func UpdateComponents(env *azldev.Env, options *UpdateComponentOptions) ([]Updat
 		return nil, errors.New("no components matched the filter")
 	}
 
-	// Load existing lock file or create a new one.
-	lockPath := filepath.Join(env.ProjectDir(), lockfile.FileName)
-
-	lock, loadErr := lockfile.Load(env.FS(), lockPath)
-	if loadErr != nil {
-		slog.Debug("No existing lock file, creating new one", "error", loadErr)
-
-		lock = lockfile.New()
-	}
-
 	// Resolve upstream commits in parallel.
-	results := resolveUpstreamCommitsParallel(env, comps, lock)
+	store := env.LockStore()
+	results := resolveUpstreamCommitsParallel(env, comps, store)
 
 	// Check results and bail on errors/cancellation before saving.
 	if err := checkUpdateResults(env, results); err != nil {
 		return results, err
 	}
 
-	// Write updated lock file only on full success.
-	if saveErr := lock.Save(env.FS(), lockPath); saveErr != nil {
-		return results, fmt.Errorf("saving lock file:\n%w", saveErr)
+	// Write per-component lock files only on full success.
+	if err := saveComponentLocks(store, results); err != nil {
+		return results, err
 	}
 
 	// Filter results for table output: only show changed components.
 	return filterChangedResults(results), nil
+}
+
+// saveComponentLocks writes a lock file for each changed component.
+func saveComponentLocks(store *lockfile.Store, results []UpdateResult) error {
+	for idx := range results {
+		if !results[idx].Changed || results[idx].Error != "" || results[idx].Skipped {
+			continue
+		}
+
+		lock := store.GetOrNew(results[idx].Component)
+
+		// Set import-commit on first lock creation (write-once).
+		if lock.ImportCommit == "" && results[idx].UpstreamCommit != "" {
+			lock.ImportCommit = results[idx].UpstreamCommit
+		}
+
+		lock.UpstreamCommit = results[idx].UpstreamCommit
+
+		if saveErr := store.Save(results[idx].Component, lock); saveErr != nil {
+			return fmt.Errorf("saving lock file for %#q:\n%w", results[idx].Component, saveErr)
+		}
+	}
+
+	return nil
 }
 
 // checkUpdateResults counts results, logs a summary, and returns an error if any
@@ -175,7 +189,7 @@ func filterChangedResults(results []UpdateResult) []UpdateResult {
 func resolveUpstreamCommitsParallel(
 	env *azldev.Env,
 	comps []components.Component,
-	lock *lockfile.LockFile,
+	store *lockfile.Store,
 ) []UpdateResult {
 	results := make([]UpdateResult, len(comps))
 
@@ -183,8 +197,6 @@ func resolveUpstreamCommitsParallel(
 	defer cancel()
 
 	var waitGroup sync.WaitGroup
-
-	var lockMutex sync.Mutex
 
 	// Each resolution involves a metadata-only git clone, in practice highly-parallelizable.
 	semaphore := make(chan struct{}, env.FastConcurrency())
@@ -229,17 +241,17 @@ func resolveUpstreamCommitsParallel(
 
 			results[idx].UpstreamCommit = commitHash
 
-			lockMutex.Lock()
-			defer lockMutex.Unlock()
+			// Check existing lock to determine if the commit changed.
+			existingLock, loadErr := store.Get(comp.GetName())
+			if loadErr != nil {
+				// No existing lock = new component, always changed.
+				results[idx].Changed = true
 
-			previous, hasPrevious := lock.GetUpstreamCommit(comp.GetName())
-			if hasPrevious {
-				results[idx].PreviousCommit = previous
+				return
 			}
 
-			results[idx].Changed = !hasPrevious || previous != commitHash
-
-			lock.SetUpstreamCommit(comp.GetName(), commitHash)
+			results[idx].PreviousCommit = existingLock.UpstreamCommit
+			results[idx].Changed = existingLock.UpstreamCommit != commitHash
 		}()
 	}
 

--- a/internal/app/azldev/cmds/component/update.go
+++ b/internal/app/azldev/cmds/component/update.go
@@ -93,6 +93,10 @@ func UpdateComponents(env *azldev.Env, options *UpdateComponentOptions) ([]Updat
 
 	// Resolve upstream commits in parallel.
 	store := env.LockStore()
+	if store == nil {
+		return nil, errors.New("no project directory configured; cannot update lock files")
+	}
+
 	results := resolveUpstreamCommitsParallel(env, comps, store)
 
 	// Check results and bail on errors/cancellation before saving.
@@ -111,6 +115,8 @@ func UpdateComponents(env *azldev.Env, options *UpdateComponentOptions) ([]Updat
 
 // saveComponentLocks writes a lock file for each changed component.
 func saveComponentLocks(store *lockfile.Store, results []UpdateResult) error {
+	saved := make([]string, 0, len(results))
+
 	for idx := range results {
 		if !results[idx].Changed || results[idx].Error != "" || results[idx].Skipped {
 			continue
@@ -121,16 +127,17 @@ func saveComponentLocks(store *lockfile.Store, results []UpdateResult) error {
 			return fmt.Errorf("loading lock for %#q:\n%w", results[idx].Component, lockErr)
 		}
 
-		// Set import-commit on first lock creation (write-once).
-		if lock.ImportCommit == "" && results[idx].UpstreamCommit != "" {
-			lock.ImportCommit = results[idx].UpstreamCommit
-		}
-
 		lock.UpstreamCommit = results[idx].UpstreamCommit
 
 		if saveErr := store.Save(results[idx].Component, lock); saveErr != nil {
+			if len(saved) > 0 {
+				slog.Info("Lock files saved before failure", "components", saved)
+			}
+
 			return fmt.Errorf("saving lock file for %#q:\n%w", results[idx].Component, saveErr)
 		}
+
+		saved = append(saved, results[idx].Component)
 	}
 
 	return nil

--- a/internal/app/azldev/env.go
+++ b/internal/app/azldev/env.go
@@ -153,7 +153,7 @@ func NewEnv(ctx context.Context, options EnvOptions) *Env {
 		fixSuggestions: []string{},
 
 		// Lock store: created when we have a project directory.
-		lockStore: newLockStore(options.ProjectDir, options.Interfaces.FileSystemFactory),
+		lockStore: newLockStore(options.ProjectDir, options.Config, options.Interfaces.FileSystemFactory),
 	}
 }
 
@@ -361,13 +361,25 @@ func (env *Env) LockReader() lockfile.LockReader {
 }
 
 // newLockStore creates a lock store if a project directory and filesystem are
-// available. Returns nil otherwise.
-func newLockStore(projectDir string, fsFactory opctx.FileSystemFactory) *lockfile.Store {
+// available. Uses the configured lock-dir from project config, falling back
+// to the default locks/ directory under the project root.
+func newLockStore(
+	projectDir string,
+	config *projectconfig.ProjectConfig,
+	fsFactory opctx.FileSystemFactory,
+) *lockfile.Store {
 	if projectDir == "" || fsFactory == nil {
 		return nil
 	}
 
-	return lockfile.NewStore(fsFactory.FS(), projectDir)
+	lockDir := filepath.Join(projectDir, lockfile.LockDir)
+
+	// If the project config specifies a lock directory, use it instead of the default.
+	if config != nil && config.Project.LockDir != "" {
+		lockDir = config.Project.LockDir
+	}
+
+	return lockfile.NewStore(fsFactory.FS(), lockDir)
 }
 
 // CPUBoundConcurrency returns the recommended concurrency limit for CPU-bound tasks.

--- a/internal/app/azldev/env.go
+++ b/internal/app/azldev/env.go
@@ -342,9 +342,21 @@ func (env *Env) PrintFixSuggestions() {
 	slog.Warn(boxEdgeString)
 }
 
-// LockStore returns the lock store for this environment. Returns nil if no
-// project directory is configured.
+// LockStore returns the full lock store (read + write) for this environment.
+// Use this only in commands that write lock files (e.g., component update).
+// Returns nil if no project directory is configured.
 func (env *Env) LockStore() *lockfile.Store {
+	return env.lockStore
+}
+
+// LockReader returns read-only access to lock files. Use this for commands
+// that consume lock state but should not modify it (e.g., render, build).
+// Returns nil if no project directory is configured.
+func (env *Env) LockReader() lockfile.LockReader {
+	if env.lockStore == nil {
+		return nil
+	}
+
 	return env.lockStore
 }
 

--- a/internal/app/azldev/env.go
+++ b/internal/app/azldev/env.go
@@ -20,6 +20,7 @@ import (
 	"github.com/charmbracelet/x/term"
 	"github.com/mattn/go-isatty"
 	"github.com/microsoft/azure-linux-dev-tools/internal/global/opctx"
+	"github.com/microsoft/azure-linux-dev-tools/internal/lockfile"
 	"github.com/microsoft/azure-linux-dev-tools/internal/projectconfig"
 )
 
@@ -92,6 +93,10 @@ type Env struct {
 	// Fix suggestion: a list of human readable hints that will be printed after an error to help the user
 	// resolve the issue. Printed in FIFO order.
 	fixSuggestions []string
+
+	// lockStore provides cached access to per-component lock files.
+	// Nil when no project directory is configured.
+	lockStore *lockfile.Store
 }
 
 // Constructs a new [Env] using specified options.
@@ -146,6 +151,9 @@ func NewEnv(ctx context.Context, options EnvOptions) *Env {
 
 		// No fix suggestions to start.
 		fixSuggestions: []string{},
+
+		// Lock store: created when we have a project directory.
+		lockStore: newLockStore(options.ProjectDir, options.Interfaces.FileSystemFactory),
 	}
 }
 
@@ -332,6 +340,22 @@ func (env *Env) PrintFixSuggestions() {
 	}
 
 	slog.Warn(boxEdgeString)
+}
+
+// LockStore returns the lock store for this environment. Returns nil if no
+// project directory is configured.
+func (env *Env) LockStore() *lockfile.Store {
+	return env.lockStore
+}
+
+// newLockStore creates a lock store if a project directory and filesystem are
+// available. Returns nil otherwise.
+func newLockStore(projectDir string, fsFactory opctx.FileSystemFactory) *lockfile.Store {
+	if projectDir == "" || fsFactory == nil {
+		return nil
+	}
+
+	return lockfile.NewStore(fsFactory.FS(), projectDir)
 }
 
 // CPUBoundConcurrency returns the recommended concurrency limit for CPU-bound tasks.

--- a/internal/lockfile/lockfile.go
+++ b/internal/lockfile/lockfile.go
@@ -4,8 +4,7 @@
 // Package lockfile reads and writes per-component lock files under the locks/
 // directory. Each component gets its own <name>.lock TOML file that pins
 // resolved upstream commits and tracks component identity for deterministic
-// builds. Lock files are managed by [azldev component update] and
-// [azldev component bump].
+// builds. Lock files are managed by [azldev component update].
 package lockfile
 
 import (

--- a/internal/lockfile/lockfile.go
+++ b/internal/lockfile/lockfile.go
@@ -1,14 +1,16 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-// Package lockfile reads and writes azldev.lock files, which pin resolved
-// upstream commit hashes for deterministic builds. The lock file is a TOML
-// file at the project root, managed by [azldev component update].
+// Package lockfile reads and writes per-component lock files under the locks/
+// directory. Each component gets its own <name>.lock TOML file that pins
+// resolved upstream commits and tracks component identity for deterministic
+// builds. Lock files are managed by [azldev component update] and
+// [azldev component bump].
 package lockfile
 
 import (
 	"fmt"
-	"strings"
+	"path/filepath"
 
 	"github.com/microsoft/azure-linux-dev-tools/internal/global/opctx"
 	"github.com/microsoft/azure-linux-dev-tools/internal/utils/fileperms"
@@ -16,134 +18,128 @@ import (
 	toml "github.com/pelletier/go-toml/v2"
 )
 
-// FileName is the lock file name, placed at the project root.
-const FileName = "azldev.lock"
+// LockDir is the directory under the project root where per-component lock
+// files are stored.
+const LockDir = "locks"
+
+// lockFileExtension is the file extension for lock files.
+const lockFileExtension = ".lock"
 
 // currentVersion is the lock file format version.
 const currentVersion = 1
 
-// LockFile holds the parsed contents of an azldev.lock file.
-type LockFile struct {
-	// Version is the lock file format version.
-	Version int `toml:"version" comment:"azldev.lock - Managed by azldev component update. Do not edit manually."`
-	// Components maps component name → locked state.
-	Components map[string]ComponentLock `toml:"components"`
-}
-
 // ComponentLock holds the locked state for a single component.
-// Upstream components have [ComponentLock.UpstreamCommit] set to the resolved
-// commit hash. Local components have an entry but with an empty commit field.
 type ComponentLock struct {
-	// UpstreamCommit is the resolved full commit hash from the upstream dist-git.
+	// Version is the lock file format version.
+	Version int `toml:"version" comment:"Managed by azldev component update. Do not edit manually."`
+
+	// ImportCommit is the upstream commit hash at the time of initial import
+	// (fork point). Upstream changelog up to this commit is inherited verbatim.
+	// Write-once: set on first import, never changed afterwards.
+	// Empty for local components.
+	ImportCommit string `toml:"import-commit,omitempty"`
+
+	// UpstreamCommit is the current resolved upstream commit hash.
+	// Updated by 'component update' when upstream sources are re-resolved.
 	// Empty for local components.
 	UpstreamCommit string `toml:"upstream-commit,omitempty"`
+
+	// ManualBump is an extra rebuild counter for mass-rebuild scenarios.
+	// Almost always 0. Incrementing this changes the component's fingerprint,
+	// triggering a new release without any other input change.
+	ManualBump int `toml:"manual-bump,omitempty"`
+
+	// InputFingerprint is the hash of all render inputs (config, overlays,
+	// upstream-commit, manual-bump, distro release version). Recomputed on
+	// every update. Used to detect when inputs have changed.
+	InputFingerprint string `toml:"input-fingerprint,omitempty"`
+
+	// ResolutionInputHash is a hash of the config inputs that affect upstream
+	// commit resolution (snapshot timestamp, distro reference, explicit pin).
+	// Used for offline staleness detection: if the current config's resolution
+	// inputs produce a different hash than what's stored, the lock may be stale
+	// and `component update` will need to re-resolve the upstream commit via
+	// network.
+	//
+	// This enables a fast offline check without re-resolving upstream commits:
+	//   - Hash matches → resolution inputs unchanged, lock is probably fresh
+	//   - Hash differs → resolution inputs changed, run update to re-resolve
+	//
+	// Not yet populated in v1 — reserved for future use.
+	ResolutionInputHash string `toml:"resolution-input-hash,omitempty"`
 }
 
-// New creates an empty lock file with the current format version.
-func New() *LockFile {
-	return &LockFile{
-		Version:    currentVersion,
-		Components: make(map[string]ComponentLock),
+// New creates a new empty component lock with the current format version.
+func New() *ComponentLock {
+	return &ComponentLock{
+		Version: currentVersion,
 	}
 }
 
-// Load reads and parses a lock file from the given path. Returns an error if the
-// file cannot be read or parsed, or if the format version is unsupported.
-func Load(fs opctx.FS, path string) (*LockFile, error) {
+// LockPath returns the path to a component's lock file given the project root
+// and component name.
+func LockPath(projectDir, componentName string) string {
+	return filepath.Join(projectDir, LockDir, componentName+lockFileExtension)
+}
+
+// Load reads and parses a per-component lock file from the given path.
+// Returns an error if the file cannot be read or parsed, or if the format
+// version is unsupported.
+func Load(fs opctx.FS, path string) (*ComponentLock, error) {
 	data, err := fileutils.ReadFile(fs, path)
 	if err != nil {
 		return nil, fmt.Errorf("reading lock file %#q:\n%w", path, err)
 	}
 
-	var lockFile LockFile
-	if err := toml.Unmarshal(data, &lockFile); err != nil {
+	var lock ComponentLock
+	if err := toml.Unmarshal(data, &lock); err != nil {
 		return nil, fmt.Errorf("parsing lock file %#q:\n%w", path, err)
 	}
 
-	if lockFile.Version != currentVersion {
+	if lock.Version != currentVersion {
 		return nil, fmt.Errorf(
-			// Backwards compatibility is a future consideration if we need to make non-compatible changes.
-			// For now, we can just error on unsupported versions.
 			"unsupported lock file version %d in %#q (expected %d)",
-			lockFile.Version, path, currentVersion)
+			lock.Version, path, currentVersion)
 	}
 
-	if lockFile.Components == nil {
-		lockFile.Components = make(map[string]ComponentLock)
-	}
-
-	return &lockFile, nil
+	return &lock, nil
 }
 
-// Save writes the lock file to the given path. [toml.Marshal] sorts map keys
-// alphabetically, producing deterministic output. Additionally, we post-process the output to insert extra blank lines
-// between component entries, which helps reduce git merge conflicts when parallel PRs modify adjacent entries.
-func (lockFile *LockFile) Save(fs opctx.FS, path string) error {
-	data, err := toml.Marshal(lockFile)
+// Save writes the component lock file to the given path, creating parent
+// directories as needed.
+func (lock *ComponentLock) Save(fs opctx.FS, path string) error {
+	dir := filepath.Dir(path)
+	if err := fileutils.MkdirAll(fs, dir); err != nil {
+		return fmt.Errorf("creating lock directory %#q:\n%w", dir, err)
+	}
+
+	data, err := toml.Marshal(lock)
 	if err != nil {
 		return fmt.Errorf("marshaling lock file:\n%w", err)
 	}
 
-	// Post-process: insert extra blank lines before each [components.<name>] header.
-	// This helps reduce git merge conflicts when parallel PRs modify adjacent entries.
-	output := addPerComponentPadding(string(data))
-
-	if err := fileutils.WriteFile(fs, path, []byte(output), fileperms.PublicFile); err != nil {
+	if err := fileutils.WriteFile(fs, path, data, fileperms.PublicFile); err != nil {
 		return fmt.Errorf("writing lock file %#q:\n%w", path, err)
 	}
 
 	return nil
 }
 
-// addPerComponentPadding inserts extra blank lines between component entries in the marshaled TOML output. This
-// padding prevents git merge conflicts when parallel PRs add, remove, or modify adjacent component entries — git's
-// default 3-line diff context won't overlap between padded entries.
-//
-// This is a best-effort approach, and won't prevent all conflicts (e.g. if two PRs modify the same component entry),
-// but it should help in the common case of parallel PRs modifying different components.
-// The other option would be to have each component in a separate file, but that adds complexity and overhead
-// to the loading process, and clutters the project with more files. The files cannot live in the rendered specs
-// directory since they are required to detect changes in package state and would be removed by the rendering process or
-// a manual folder removal.
-func addPerComponentPadding(tomlData string) string {
-	const prefix = "[components."
-
-	var result strings.Builder
-
-	result.Grow(len(tomlData))
-
-	for line := range strings.SplitSeq(tomlData, "\n") {
-		if strings.HasPrefix(strings.TrimSpace(line), prefix) {
-			// Add extra blank lines before each component section header.
-			result.WriteString("\n\n")
-		}
-
-		result.WriteString(line)
-		result.WriteString("\n")
+// Exists checks whether a lock file exists at the given path.
+func Exists(fs opctx.FS, path string) (bool, error) {
+	exists, err := fileutils.Exists(fs, path)
+	if err != nil {
+		return false, fmt.Errorf("checking lock file %#q:\n%w", path, err)
 	}
 
-	return result.String()
+	return exists, nil
 }
 
-// SetUpstreamCommit sets the locked upstream commit for a component.
-func (lockFile *LockFile) SetUpstreamCommit(componentName, commitHash string) {
-	if lockFile.Components == nil {
-		lockFile.Components = make(map[string]ComponentLock)
+// Remove deletes a lock file at the given path.
+func Remove(fs opctx.FS, path string) error {
+	if err := fs.Remove(path); err != nil {
+		return fmt.Errorf("removing lock file %#q:\n%w", path, err)
 	}
 
-	entry := lockFile.Components[componentName]
-	entry.UpstreamCommit = commitHash
-	lockFile.Components[componentName] = entry
-}
-
-// GetUpstreamCommit returns the locked upstream commit for a component.
-// Returns empty string and false if the component has no lock entry or
-// if the entry has an empty upstream commit.
-func (lockFile *LockFile) GetUpstreamCommit(componentName string) (string, bool) {
-	entry, ok := lockFile.Components[componentName]
-	if !ok || entry.UpstreamCommit == "" {
-		return "", false
-	}
-
-	return entry.UpstreamCommit, true
+	return nil
 }

--- a/internal/lockfile/lockfile.go
+++ b/internal/lockfile/lockfile.go
@@ -75,14 +75,14 @@ func New() *ComponentLock {
 	}
 }
 
-// LockPath returns the path to a component's lock file given the project root
-// and component name.
-func LockPath(projectDir, componentName string) (string, error) {
+// LockPath returns the path to a component's lock file given the lock
+// directory and component name.
+func LockPath(lockDir, componentName string) (string, error) {
 	if err := fileutils.ValidateFilename(componentName); err != nil {
 		return "", fmt.Errorf("validating component name %#q for lock file path:\n%w", componentName, err)
 	}
 
-	return filepath.Join(projectDir, LockDir, componentName+lockFileExtension), nil
+	return filepath.Join(lockDir, componentName+lockFileExtension), nil
 }
 
 // Load reads and parses a per-component lock file from the given path.

--- a/internal/lockfile/lockfile.go
+++ b/internal/lockfile/lockfile.go
@@ -77,8 +77,12 @@ func New() *ComponentLock {
 
 // LockPath returns the path to a component's lock file given the project root
 // and component name.
-func LockPath(projectDir, componentName string) string {
-	return filepath.Join(projectDir, LockDir, componentName+lockFileExtension)
+func LockPath(projectDir, componentName string) (string, error) {
+	if err := fileutils.ValidateFilename(componentName); err != nil {
+		return "", fmt.Errorf("validating component name %#q for lock file path:\n%w", componentName, err)
+	}
+
+	return filepath.Join(projectDir, LockDir, componentName+lockFileExtension), nil
 }
 
 // Load reads and parses a per-component lock file from the given path.

--- a/internal/lockfile/lockfile_test.go
+++ b/internal/lockfile/lockfile_test.go
@@ -30,7 +30,8 @@ func TestNew(t *testing.T) {
 }
 
 func TestLockPath(t *testing.T) {
-	path := lockfile.LockPath("/project", "curl")
+	path, err := lockfile.LockPath("/project", "curl")
+	require.NoError(t, err)
 	assert.Equal(t, filepath.Join("/project", "locks", "curl.lock"), path)
 }
 
@@ -38,7 +39,8 @@ func TestLockPathDistantProjectDir(t *testing.T) {
 	// Simulates -C /some/distant/repo being passed to azldev.
 	distantDir := "/some/distant/repo"
 
-	path := lockfile.LockPath(distantDir, "curl")
+	path, err := lockfile.LockPath(distantDir, "curl")
+	require.NoError(t, err)
 	assert.Equal(t, filepath.Join(distantDir, "locks", "curl.lock"), path)
 
 	// Save and load from the distant path to verify full round-trip.
@@ -64,9 +66,34 @@ func TestLockPathDistantProjectDir(t *testing.T) {
 	assert.False(t, exists, "lock file should not appear under default project dir")
 }
 
+func TestInvalidPath(t *testing.T) {
+	tests := []struct {
+		name          string
+		componentName string
+	}{
+		{name: "dot", componentName: "."},
+		{name: "dotdot", componentName: ".."},
+		{name: "empty", componentName: ""},
+		{name: "path traversal", componentName: "../escape"},
+		{name: "absolute path", componentName: "/etc/passwd"},
+		{name: "has directory", componentName: "sub/component"},
+		{name: "whitespace", componentName: "has space"},
+		{name: "backslash", componentName: "foo\\bar"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := lockfile.LockPath("/project", tc.componentName)
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), "validating component name")
+		})
+	}
+}
+
 func TestSaveAndLoad(t *testing.T) {
 	memFS := afero.NewMemMapFs()
-	lockPath := lockfile.LockPath(testProjectDir, "curl")
+	lockPath, err := lockfile.LockPath(testProjectDir, "curl")
+	require.NoError(t, err)
 
 	original := lockfile.New()
 	original.UpstreamCommit = "a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2"
@@ -88,7 +115,8 @@ func TestSaveAndLoad(t *testing.T) {
 
 func TestSaveCreatesDirectory(t *testing.T) {
 	memFS := afero.NewMemMapFs()
-	lockPath := lockfile.LockPath(testProjectDir, "newpkg")
+	lockPath, err := lockfile.LockPath(testProjectDir, "newpkg")
+	require.NoError(t, err)
 
 	lock := lockfile.New()
 	lock.UpstreamCommit = testCommitHash
@@ -103,14 +131,15 @@ func TestSaveCreatesDirectory(t *testing.T) {
 
 func TestLoadUnsupportedVersion(t *testing.T) {
 	memFS := afero.NewMemMapFs()
-	lockPath := lockfile.LockPath(testProjectDir, "bad")
+	lockPath, err := lockfile.LockPath(testProjectDir, "bad")
+	require.NoError(t, err)
 
 	content := "version = 99\n"
 
 	require.NoError(t, fileutils.MkdirAll(memFS, filepath.Dir(lockPath)))
 	require.NoError(t, fileutils.WriteFile(memFS, lockPath, []byte(content), fileperms.PublicFile))
 
-	_, err := lockfile.Load(memFS, lockPath)
+	_, err = lockfile.Load(memFS, lockPath)
 	assert.ErrorContains(t, err, "unsupported lock file version")
 }
 
@@ -123,18 +152,20 @@ func TestLoadMissingFile(t *testing.T) {
 
 func TestLoadInvalidTOML(t *testing.T) {
 	memFS := afero.NewMemMapFs()
-	lockPath := lockfile.LockPath(testProjectDir, "bad")
+	lockPath, err := lockfile.LockPath(testProjectDir, "bad")
+	require.NoError(t, err)
 
 	require.NoError(t, fileutils.MkdirAll(memFS, filepath.Dir(lockPath)))
 	require.NoError(t, fileutils.WriteFile(memFS, lockPath, []byte("not valid toml {{{"), fileperms.PublicFile))
 
-	_, err := lockfile.Load(memFS, lockPath)
+	_, err = lockfile.Load(memFS, lockPath)
 	assert.ErrorContains(t, err, "parsing lock file")
 }
 
 func TestSaveContainsVersion(t *testing.T) {
 	memFS := afero.NewMemMapFs()
-	lockPath := lockfile.LockPath(testProjectDir, "test")
+	lockPath, err := lockfile.LockPath(testProjectDir, "test")
+	require.NoError(t, err)
 
 	lock := lockfile.New()
 	require.NoError(t, lock.Save(memFS, lockPath))
@@ -147,7 +178,8 @@ func TestSaveContainsVersion(t *testing.T) {
 
 func TestLocalComponentRoundTrip(t *testing.T) {
 	memFS := afero.NewMemMapFs()
-	lockPath := lockfile.LockPath(testProjectDir, "local-pkg")
+	lockPath, err := lockfile.LockPath(testProjectDir, "local-pkg")
+	require.NoError(t, err)
 
 	// Local component: no upstream commit, no import commit.
 	original := lockfile.New()
@@ -165,7 +197,8 @@ func TestLocalComponentRoundTrip(t *testing.T) {
 
 func TestExists(t *testing.T) {
 	memFS := afero.NewMemMapFs()
-	lockPath := lockfile.LockPath(testProjectDir, "curl")
+	lockPath, err := lockfile.LockPath(testProjectDir, "curl")
+	require.NoError(t, err)
 
 	exists, err := lockfile.Exists(memFS, lockPath)
 	require.NoError(t, err)
@@ -183,7 +216,8 @@ func TestExists(t *testing.T) {
 
 func TestRemove(t *testing.T) {
 	memFS := afero.NewMemMapFs()
-	lockPath := lockfile.LockPath(testProjectDir, "curl")
+	lockPath, err := lockfile.LockPath(testProjectDir, "curl")
+	require.NoError(t, err)
 
 	lock := lockfile.New()
 	require.NoError(t, lock.Save(memFS, lockPath))
@@ -207,12 +241,16 @@ func TestMultipleComponentsIndependentFiles(t *testing.T) {
 		lock := lockfile.New()
 		lock.UpstreamCommit = name + "-commit"
 
-		require.NoError(t, lock.Save(memFS, lockfile.LockPath(testProjectDir, name)))
+		lockPath, err := lockfile.LockPath(testProjectDir, name)
+		require.NoError(t, err)
+		require.NoError(t, lock.Save(memFS, lockPath))
 	}
 
 	// Load each independently and verify.
 	for _, name := range []string{"curl", "bash", "vim"} {
-		loaded, err := lockfile.Load(memFS, lockfile.LockPath(testProjectDir, name))
+		lockPath, err := lockfile.LockPath(testProjectDir, name)
+		require.NoError(t, err)
+		loaded, err := lockfile.Load(memFS, lockPath)
 		require.NoError(t, err)
 		assert.Equal(t, name+"-commit", loaded.UpstreamCommit)
 	}
@@ -220,7 +258,8 @@ func TestMultipleComponentsIndependentFiles(t *testing.T) {
 
 func TestImportCommitPreservedOnRewrite(t *testing.T) {
 	memFS := afero.NewMemMapFs()
-	lockPath := lockfile.LockPath(testProjectDir, "curl")
+	lockPath, err := lockfile.LockPath(testProjectDir, "curl")
+	require.NoError(t, err)
 
 	// First write: set import-commit and upstream-commit to same value (initial import).
 	original := lockfile.New()
@@ -249,7 +288,8 @@ func TestImportCommitPreservedOnRewrite(t *testing.T) {
 
 func TestResolutionInputHashRoundTrip(t *testing.T) {
 	memFS := afero.NewMemMapFs()
-	lockPath := lockfile.LockPath(testProjectDir, "curl")
+	lockPath, err := lockfile.LockPath(testProjectDir, "curl")
+	require.NoError(t, err)
 
 	// v2 field: currently stubbed but should survive round-trip.
 	lock := lockfile.New()
@@ -265,7 +305,8 @@ func TestResolutionInputHashRoundTrip(t *testing.T) {
 
 func TestOmitEmptyFields(t *testing.T) {
 	memFS := afero.NewMemMapFs()
-	lockPath := lockfile.LockPath(testProjectDir, "local-pkg")
+	lockPath, err := lockfile.LockPath(testProjectDir, "local-pkg")
+	require.NoError(t, err)
 
 	// Local component: only version and fingerprint set.
 	lock := lockfile.New()
@@ -321,13 +362,14 @@ func TestStoreGetOrNew_CorruptLock_ReturnsError(t *testing.T) {
 	store := lockfile.NewStore(memFS, testProjectDir)
 
 	// Write corrupt content to the lock file path.
-	lockPath := lockfile.LockPath(testProjectDir, "corrupt")
+	lockPath, err := lockfile.LockPath(testProjectDir, "corrupt")
+	require.NoError(t, err)
 
 	require.NoError(t, fileutils.MkdirAll(memFS, filepath.Dir(lockPath)))
 	require.NoError(t, fileutils.WriteFile(memFS, lockPath, []byte("not valid toml {{{"), fileperms.PublicFile))
 
 	// GetOrNew should error, NOT silently create a new lock.
-	_, err := store.GetOrNew("corrupt")
+	_, err = store.GetOrNew("corrupt")
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "loading existing lock")
 }

--- a/internal/lockfile/lockfile_test.go
+++ b/internal/lockfile/lockfile_test.go
@@ -5,7 +5,6 @@ package lockfile_test
 
 import (
 	"path/filepath"
-	"strings"
 	"testing"
 
 	"github.com/microsoft/azure-linux-dev-tools/internal/lockfile"
@@ -16,101 +15,99 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-const testProjectDir = "/project"
+const (
+	testProjectDir = "/project"
+	testCommitHash = "aaaa"
+)
 
 func TestNew(t *testing.T) {
-	lf := lockfile.New()
-	assert.Equal(t, 1, lf.Version)
-	assert.NotNil(t, lf.Components)
-	assert.Empty(t, lf.Components)
+	lock := lockfile.New()
+	assert.Equal(t, 1, lock.Version)
+	assert.Empty(t, lock.UpstreamCommit)
+	assert.Empty(t, lock.ImportCommit)
+	assert.Zero(t, lock.ManualBump)
+	assert.Empty(t, lock.InputFingerprint)
 }
 
-func TestSetAndGetUpstreamCommit(t *testing.T) {
-	lf := lockfile.New()
-
-	lf.SetUpstreamCommit("curl", "a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2")
-
-	commit, ok := lf.GetUpstreamCommit("curl")
-	assert.True(t, ok)
-	assert.Equal(t, "a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2", commit)
+func TestLockPath(t *testing.T) {
+	path := lockfile.LockPath("/project", "curl")
+	assert.Equal(t, filepath.Join("/project", "locks", "curl.lock"), path)
 }
 
-func TestGetUpstreamCommitMissing(t *testing.T) {
-	lf := lockfile.New()
+func TestLockPathDistantProjectDir(t *testing.T) {
+	// Simulates -C /some/distant/repo being passed to azldev.
+	distantDir := "/some/distant/repo"
 
-	commit, ok := lf.GetUpstreamCommit("nonexistent")
-	assert.False(t, ok)
-	assert.Empty(t, commit)
+	path := lockfile.LockPath(distantDir, "curl")
+	assert.Equal(t, filepath.Join(distantDir, "locks", "curl.lock"), path)
+
+	// Save and load from the distant path to verify full round-trip.
+	memFS := afero.NewMemMapFs()
+
+	lock := lockfile.New()
+	lock.UpstreamCommit = "distant-commit"
+
+	require.NoError(t, lock.Save(memFS, path))
+
+	loaded, err := lockfile.Load(memFS, path)
+	require.NoError(t, err)
+	assert.Equal(t, "distant-commit", loaded.UpstreamCommit)
+
+	// Verify the file actually ended up under the distant dir, not cwd.
+	exists, err := lockfile.Exists(memFS, filepath.Join(distantDir, "locks", "curl.lock"))
+	require.NoError(t, err)
+	assert.True(t, exists)
+
+	// And NOT under the default project dir.
+	exists, err = lockfile.Exists(memFS, filepath.Join(testProjectDir, "locks", "curl.lock"))
+	require.NoError(t, err)
+	assert.False(t, exists, "lock file should not appear under default project dir")
 }
 
 func TestSaveAndLoad(t *testing.T) {
 	memFS := afero.NewMemMapFs()
-	lockPath := filepath.Join(testProjectDir, lockfile.FileName)
+	lockPath := lockfile.LockPath(testProjectDir, "curl")
 
-	require.NoError(t, fileutils.MkdirAll(memFS, testProjectDir))
-
-	// Create and save a lock file.
 	original := lockfile.New()
-	original.SetUpstreamCommit("curl", "aaaa")
-	original.SetUpstreamCommit("bash", "bbbb")
-	original.SetUpstreamCommit("vim", "cccc")
+	original.UpstreamCommit = "a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2"
+	original.ImportCommit = "0000111122223333444455556666777788889999"
+	original.ManualBump = 2
+	original.InputFingerprint = "sha256:abcdef1234567890"
 
 	require.NoError(t, original.Save(memFS, lockPath))
 
-	// Load it back.
 	loaded, err := lockfile.Load(memFS, lockPath)
 	require.NoError(t, err)
 
 	assert.Equal(t, 1, loaded.Version)
-
-	commit, found := loaded.GetUpstreamCommit("curl")
-	assert.True(t, found)
-	assert.Equal(t, "aaaa", commit)
-
-	commit, found = loaded.GetUpstreamCommit("bash")
-	assert.True(t, found)
-	assert.Equal(t, "bbbb", commit)
-
-	commit, found = loaded.GetUpstreamCommit("vim")
-	assert.True(t, found)
-	assert.Equal(t, "cccc", commit)
+	assert.Equal(t, "a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2", loaded.UpstreamCommit)
+	assert.Equal(t, "0000111122223333444455556666777788889999", loaded.ImportCommit)
+	assert.Equal(t, 2, loaded.ManualBump)
+	assert.Equal(t, "sha256:abcdef1234567890", loaded.InputFingerprint)
 }
 
-func TestSaveSortsComponents(t *testing.T) {
+func TestSaveCreatesDirectory(t *testing.T) {
 	memFS := afero.NewMemMapFs()
-	lockPath := filepath.Join(testProjectDir, lockfile.FileName)
+	lockPath := lockfile.LockPath(testProjectDir, "newpkg")
 
-	require.NoError(t, fileutils.MkdirAll(memFS, testProjectDir))
+	lock := lockfile.New()
+	lock.UpstreamCommit = testCommitHash
 
-	lockFile := lockfile.New()
-	// Insert in non-alphabetical order.
-	lockFile.SetUpstreamCommit("zlib", "zzzz")
-	lockFile.SetUpstreamCommit("curl", "aaaa")
-	lockFile.SetUpstreamCommit("bash", "bbbb")
+	require.NoError(t, lock.Save(memFS, lockPath))
 
-	require.NoError(t, lockFile.Save(memFS, lockPath))
-
-	data, err := fileutils.ReadFile(memFS, lockPath)
+	// Verify the file was created.
+	loaded, err := lockfile.Load(memFS, lockPath)
 	require.NoError(t, err)
-
-	content := string(data)
-
-	// bash should appear before curl, which should appear before zlib.
-	bashIdx := strings.Index(content, "[components.bash]")
-	curlIdx := strings.Index(content, "[components.curl]")
-	zlibIdx := strings.Index(content, "[components.zlib]")
-
-	assert.Less(t, bashIdx, curlIdx, "bash should come before curl")
-	assert.Less(t, curlIdx, zlibIdx, "curl should come before zlib")
+	assert.Equal(t, testCommitHash, loaded.UpstreamCommit)
 }
 
 func TestLoadUnsupportedVersion(t *testing.T) {
 	memFS := afero.NewMemMapFs()
-	lockPath := filepath.Join(testProjectDir, lockfile.FileName)
+	lockPath := lockfile.LockPath(testProjectDir, "bad")
 
 	content := "version = 99\n"
 
-	require.NoError(t, fileutils.MkdirAll(memFS, testProjectDir))
+	require.NoError(t, fileutils.MkdirAll(memFS, filepath.Dir(lockPath)))
 	require.NoError(t, fileutils.WriteFile(memFS, lockPath, []byte(content), fileperms.PublicFile))
 
 	_, err := lockfile.Load(memFS, lockPath)
@@ -120,15 +117,15 @@ func TestLoadUnsupportedVersion(t *testing.T) {
 func TestLoadMissingFile(t *testing.T) {
 	fs := afero.NewMemMapFs()
 
-	_, err := lockfile.Load(fs, "/nonexistent/azldev.lock")
+	_, err := lockfile.Load(fs, "/nonexistent/locks/curl.lock")
 	assert.Error(t, err)
 }
 
 func TestLoadInvalidTOML(t *testing.T) {
 	memFS := afero.NewMemMapFs()
-	lockPath := filepath.Join(testProjectDir, lockfile.FileName)
+	lockPath := lockfile.LockPath(testProjectDir, "bad")
 
-	require.NoError(t, fileutils.MkdirAll(memFS, testProjectDir))
+	require.NoError(t, fileutils.MkdirAll(memFS, filepath.Dir(lockPath)))
 	require.NoError(t, fileutils.WriteFile(memFS, lockPath, []byte("not valid toml {{{"), fileperms.PublicFile))
 
 	_, err := lockfile.Load(memFS, lockPath)
@@ -137,48 +134,152 @@ func TestLoadInvalidTOML(t *testing.T) {
 
 func TestSaveContainsVersion(t *testing.T) {
 	memFS := afero.NewMemMapFs()
-	lockPath := filepath.Join(testProjectDir, lockfile.FileName)
+	lockPath := lockfile.LockPath(testProjectDir, "test")
 
-	require.NoError(t, fileutils.MkdirAll(memFS, testProjectDir))
-
-	lockFile := lockfile.New()
-	require.NoError(t, lockFile.Save(memFS, lockPath))
+	lock := lockfile.New()
+	require.NoError(t, lock.Save(memFS, lockPath))
 
 	data, err := fileutils.ReadFile(memFS, lockPath)
 	require.NoError(t, err)
 
 	assert.Contains(t, string(data), "version = 1")
-	assert.Contains(t, string(data), "# azldev.lock")
 }
 
-func TestRoundTripLocalComponent(t *testing.T) {
+func TestLocalComponentRoundTrip(t *testing.T) {
 	memFS := afero.NewMemMapFs()
-	lockPath := filepath.Join(testProjectDir, lockfile.FileName)
+	lockPath := lockfile.LockPath(testProjectDir, "local-pkg")
 
-	require.NoError(t, fileutils.MkdirAll(memFS, testProjectDir))
-
-	// Create a lock file with a local component (empty upstream commit)
-	// alongside an upstream component.
+	// Local component: no upstream commit, no import commit.
 	original := lockfile.New()
-	original.SetUpstreamCommit("curl", "aaaa")
-	original.Components["local-pkg"] = lockfile.ComponentLock{}
+	original.InputFingerprint = "sha256:localfp"
 
 	require.NoError(t, original.Save(memFS, lockPath))
 
-	// Load it back and verify both entries survived.
 	loaded, err := lockfile.Load(memFS, lockPath)
 	require.NoError(t, err)
 
-	// Upstream component round-trips with its commit.
-	commit, found := loaded.GetUpstreamCommit("curl")
-	assert.True(t, found)
-	assert.Equal(t, "aaaa", commit)
+	assert.Empty(t, loaded.UpstreamCommit)
+	assert.Empty(t, loaded.ImportCommit)
+	assert.Equal(t, "sha256:localfp", loaded.InputFingerprint)
+}
 
-	// Local component has an entry but no upstream commit.
-	_, hasEntry := loaded.Components["local-pkg"]
-	assert.True(t, hasEntry, "local component entry should survive round-trip")
+func TestExists(t *testing.T) {
+	memFS := afero.NewMemMapFs()
+	lockPath := lockfile.LockPath(testProjectDir, "curl")
 
-	commit, found = loaded.GetUpstreamCommit("local-pkg")
-	assert.False(t, found, "local component should not have an upstream commit")
-	assert.Empty(t, commit)
+	exists, err := lockfile.Exists(memFS, lockPath)
+	require.NoError(t, err)
+	assert.False(t, exists)
+
+	lock := lockfile.New()
+	lock.UpstreamCommit = testCommitHash
+
+	require.NoError(t, lock.Save(memFS, lockPath))
+
+	exists, err = lockfile.Exists(memFS, lockPath)
+	require.NoError(t, err)
+	assert.True(t, exists)
+}
+
+func TestRemove(t *testing.T) {
+	memFS := afero.NewMemMapFs()
+	lockPath := lockfile.LockPath(testProjectDir, "curl")
+
+	lock := lockfile.New()
+	require.NoError(t, lock.Save(memFS, lockPath))
+
+	exists, err := lockfile.Exists(memFS, lockPath)
+	require.NoError(t, err)
+	assert.True(t, exists)
+
+	require.NoError(t, lockfile.Remove(memFS, lockPath))
+
+	exists, err = lockfile.Exists(memFS, lockPath)
+	require.NoError(t, err)
+	assert.False(t, exists)
+}
+
+func TestMultipleComponentsIndependentFiles(t *testing.T) {
+	memFS := afero.NewMemMapFs()
+
+	// Save three different components.
+	for _, name := range []string{"curl", "bash", "vim"} {
+		lock := lockfile.New()
+		lock.UpstreamCommit = name + "-commit"
+
+		require.NoError(t, lock.Save(memFS, lockfile.LockPath(testProjectDir, name)))
+	}
+
+	// Load each independently and verify.
+	for _, name := range []string{"curl", "bash", "vim"} {
+		loaded, err := lockfile.Load(memFS, lockfile.LockPath(testProjectDir, name))
+		require.NoError(t, err)
+		assert.Equal(t, name+"-commit", loaded.UpstreamCommit)
+	}
+}
+
+func TestImportCommitPreservedOnRewrite(t *testing.T) {
+	memFS := afero.NewMemMapFs()
+	lockPath := lockfile.LockPath(testProjectDir, "curl")
+
+	// First write: set import-commit and upstream-commit to same value (initial import).
+	original := lockfile.New()
+	original.ImportCommit = "initial-import-commit"
+	original.UpstreamCommit = "initial-import-commit"
+
+	require.NoError(t, original.Save(memFS, lockPath))
+
+	// Simulate what update does: load, update upstream-commit, preserve import-commit.
+	loaded, err := lockfile.Load(memFS, lockPath)
+	require.NoError(t, err)
+
+	// Import-commit should not be changed — it's write-once.
+	assert.Equal(t, "initial-import-commit", loaded.ImportCommit)
+
+	loaded.UpstreamCommit = "newer-upstream-commit"
+
+	require.NoError(t, loaded.Save(memFS, lockPath))
+
+	// Reload and verify import-commit survived while upstream-commit moved.
+	reloaded, err := lockfile.Load(memFS, lockPath)
+	require.NoError(t, err)
+	assert.Equal(t, "initial-import-commit", reloaded.ImportCommit, "import-commit should be preserved")
+	assert.Equal(t, "newer-upstream-commit", reloaded.UpstreamCommit, "upstream-commit should be updated")
+}
+
+func TestResolutionInputHashRoundTrip(t *testing.T) {
+	memFS := afero.NewMemMapFs()
+	lockPath := lockfile.LockPath(testProjectDir, "curl")
+
+	// v2 field: currently stubbed but should survive round-trip.
+	lock := lockfile.New()
+	lock.UpstreamCommit = testCommitHash
+	lock.ResolutionInputHash = "sha256:resolution-inputs"
+
+	require.NoError(t, lock.Save(memFS, lockPath))
+
+	loaded, err := lockfile.Load(memFS, lockPath)
+	require.NoError(t, err)
+	assert.Equal(t, "sha256:resolution-inputs", loaded.ResolutionInputHash)
+}
+
+func TestOmitEmptyFields(t *testing.T) {
+	memFS := afero.NewMemMapFs()
+	lockPath := lockfile.LockPath(testProjectDir, "local-pkg")
+
+	// Local component: only version and fingerprint set.
+	lock := lockfile.New()
+	lock.InputFingerprint = "sha256:local"
+
+	require.NoError(t, lock.Save(memFS, lockPath))
+
+	data, err := fileutils.ReadFile(memFS, lockPath)
+	require.NoError(t, err)
+
+	content := string(data)
+	assert.NotContains(t, content, "import-commit", "empty import-commit should be omitted")
+	assert.NotContains(t, content, "upstream-commit", "empty upstream-commit should be omitted")
+	assert.NotContains(t, content, "manual-bump", "zero manual-bump should be omitted")
+	assert.NotContains(t, content, "resolution-input-hash", "empty resolution-input-hash should be omitted")
+	assert.Contains(t, content, "input-fingerprint")
 }

--- a/internal/lockfile/lockfile_test.go
+++ b/internal/lockfile/lockfile_test.go
@@ -388,8 +388,13 @@ func TestStoreGet_Caching(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, testCommitHash, first.UpstreamCommit)
 
-	// Second get should return cached (same pointer).
+	// Second get should return equal data from cache.
 	second, err := store.Get("curl")
 	require.NoError(t, err)
-	assert.Same(t, first, second, "second Get should return cached instance")
+	assert.Equal(t, first.UpstreamCommit, second.UpstreamCommit)
+
+	// Returns copies — mutating one should not affect the other.
+	first.UpstreamCommit = "mutated"
+	assert.NotEqual(t, first.UpstreamCommit, second.UpstreamCommit,
+		"Get should return copies, not shared pointers")
 }

--- a/internal/lockfile/lockfile_test.go
+++ b/internal/lockfile/lockfile_test.go
@@ -17,6 +17,7 @@ import (
 
 const (
 	testProjectDir = "/project"
+	testLockDir    = testProjectDir + "/" + lockfile.LockDir
 	testCommitHash = "aaaa"
 )
 
@@ -30,18 +31,19 @@ func TestNew(t *testing.T) {
 }
 
 func TestLockPath(t *testing.T) {
-	path, err := lockfile.LockPath("/project", "curl")
+	path, err := lockfile.LockPath("/project/locks", "curl")
 	require.NoError(t, err)
-	assert.Equal(t, filepath.Join("/project", "locks", "curl.lock"), path)
+	assert.Equal(t, filepath.Join("/project/locks", "curl.lock"), path)
 }
 
 func TestLockPathDistantProjectDir(t *testing.T) {
-	// Simulates -C /some/distant/repo being passed to azldev.
-	distantDir := "/some/distant/repo"
+	// Simulates -C /some/distant/repo being passed to azldev — lock dir
+	// would be resolved to /some/distant/repo/locks by the config layer.
+	distantLockDir := "/some/distant/repo/locks"
 
-	path, err := lockfile.LockPath(distantDir, "curl")
+	path, err := lockfile.LockPath(distantLockDir, "curl")
 	require.NoError(t, err)
-	assert.Equal(t, filepath.Join(distantDir, "locks", "curl.lock"), path)
+	assert.Equal(t, filepath.Join(distantLockDir, "curl.lock"), path)
 
 	// Save and load from the distant path to verify full round-trip.
 	memFS := afero.NewMemMapFs()
@@ -56,14 +58,14 @@ func TestLockPathDistantProjectDir(t *testing.T) {
 	assert.Equal(t, "distant-commit", loaded.UpstreamCommit)
 
 	// Verify the file actually ended up under the distant dir, not cwd.
-	exists, err := lockfile.Exists(memFS, filepath.Join(distantDir, "locks", "curl.lock"))
+	exists, err := lockfile.Exists(memFS, filepath.Join(distantLockDir, "curl.lock"))
 	require.NoError(t, err)
 	assert.True(t, exists)
 
-	// And NOT under the default project dir.
-	exists, err = lockfile.Exists(memFS, filepath.Join(testProjectDir, "locks", "curl.lock"))
+	// And NOT under the default lock dir.
+	exists, err = lockfile.Exists(memFS, filepath.Join(testLockDir, "curl.lock"))
 	require.NoError(t, err)
-	assert.False(t, exists, "lock file should not appear under default project dir")
+	assert.False(t, exists, "lock file should not appear under default lock dir")
 }
 
 func TestInvalidPath(t *testing.T) {
@@ -92,7 +94,7 @@ func TestInvalidPath(t *testing.T) {
 
 func TestSaveAndLoad(t *testing.T) {
 	memFS := afero.NewMemMapFs()
-	lockPath, err := lockfile.LockPath(testProjectDir, "curl")
+	lockPath, err := lockfile.LockPath(testLockDir, "curl")
 	require.NoError(t, err)
 
 	original := lockfile.New()
@@ -115,7 +117,7 @@ func TestSaveAndLoad(t *testing.T) {
 
 func TestSaveCreatesDirectory(t *testing.T) {
 	memFS := afero.NewMemMapFs()
-	lockPath, err := lockfile.LockPath(testProjectDir, "newpkg")
+	lockPath, err := lockfile.LockPath(testLockDir, "newpkg")
 	require.NoError(t, err)
 
 	lock := lockfile.New()
@@ -131,7 +133,7 @@ func TestSaveCreatesDirectory(t *testing.T) {
 
 func TestLoadUnsupportedVersion(t *testing.T) {
 	memFS := afero.NewMemMapFs()
-	lockPath, err := lockfile.LockPath(testProjectDir, "bad")
+	lockPath, err := lockfile.LockPath(testLockDir, "bad")
 	require.NoError(t, err)
 
 	content := "version = 99\n"
@@ -152,7 +154,7 @@ func TestLoadMissingFile(t *testing.T) {
 
 func TestLoadInvalidTOML(t *testing.T) {
 	memFS := afero.NewMemMapFs()
-	lockPath, err := lockfile.LockPath(testProjectDir, "bad")
+	lockPath, err := lockfile.LockPath(testLockDir, "bad")
 	require.NoError(t, err)
 
 	require.NoError(t, fileutils.MkdirAll(memFS, filepath.Dir(lockPath)))
@@ -164,7 +166,7 @@ func TestLoadInvalidTOML(t *testing.T) {
 
 func TestSaveContainsVersion(t *testing.T) {
 	memFS := afero.NewMemMapFs()
-	lockPath, err := lockfile.LockPath(testProjectDir, "test")
+	lockPath, err := lockfile.LockPath(testLockDir, "test")
 	require.NoError(t, err)
 
 	lock := lockfile.New()
@@ -178,7 +180,7 @@ func TestSaveContainsVersion(t *testing.T) {
 
 func TestLocalComponentRoundTrip(t *testing.T) {
 	memFS := afero.NewMemMapFs()
-	lockPath, err := lockfile.LockPath(testProjectDir, "local-pkg")
+	lockPath, err := lockfile.LockPath(testLockDir, "local-pkg")
 	require.NoError(t, err)
 
 	// Local component: no upstream commit, no import commit.
@@ -197,7 +199,7 @@ func TestLocalComponentRoundTrip(t *testing.T) {
 
 func TestExists(t *testing.T) {
 	memFS := afero.NewMemMapFs()
-	lockPath, err := lockfile.LockPath(testProjectDir, "curl")
+	lockPath, err := lockfile.LockPath(testLockDir, "curl")
 	require.NoError(t, err)
 
 	exists, err := lockfile.Exists(memFS, lockPath)
@@ -216,7 +218,7 @@ func TestExists(t *testing.T) {
 
 func TestRemove(t *testing.T) {
 	memFS := afero.NewMemMapFs()
-	lockPath, err := lockfile.LockPath(testProjectDir, "curl")
+	lockPath, err := lockfile.LockPath(testLockDir, "curl")
 	require.NoError(t, err)
 
 	lock := lockfile.New()
@@ -241,14 +243,14 @@ func TestMultipleComponentsIndependentFiles(t *testing.T) {
 		lock := lockfile.New()
 		lock.UpstreamCommit = name + "-commit"
 
-		lockPath, err := lockfile.LockPath(testProjectDir, name)
+		lockPath, err := lockfile.LockPath(testLockDir, name)
 		require.NoError(t, err)
 		require.NoError(t, lock.Save(memFS, lockPath))
 	}
 
 	// Load each independently and verify.
 	for _, name := range []string{"curl", "bash", "vim"} {
-		lockPath, err := lockfile.LockPath(testProjectDir, name)
+		lockPath, err := lockfile.LockPath(testLockDir, name)
 		require.NoError(t, err)
 		loaded, err := lockfile.Load(memFS, lockPath)
 		require.NoError(t, err)
@@ -258,7 +260,7 @@ func TestMultipleComponentsIndependentFiles(t *testing.T) {
 
 func TestImportCommitPreservedOnRewrite(t *testing.T) {
 	memFS := afero.NewMemMapFs()
-	lockPath, err := lockfile.LockPath(testProjectDir, "curl")
+	lockPath, err := lockfile.LockPath(testLockDir, "curl")
 	require.NoError(t, err)
 
 	// First write: set import-commit and upstream-commit to same value (initial import).
@@ -288,7 +290,7 @@ func TestImportCommitPreservedOnRewrite(t *testing.T) {
 
 func TestResolutionInputHashRoundTrip(t *testing.T) {
 	memFS := afero.NewMemMapFs()
-	lockPath, err := lockfile.LockPath(testProjectDir, "curl")
+	lockPath, err := lockfile.LockPath(testLockDir, "curl")
 	require.NoError(t, err)
 
 	// v2 field: currently stubbed but should survive round-trip.
@@ -305,7 +307,7 @@ func TestResolutionInputHashRoundTrip(t *testing.T) {
 
 func TestOmitEmptyFields(t *testing.T) {
 	memFS := afero.NewMemMapFs()
-	lockPath, err := lockfile.LockPath(testProjectDir, "local-pkg")
+	lockPath, err := lockfile.LockPath(testLockDir, "local-pkg")
 	require.NoError(t, err)
 
 	// Local component: only version and fingerprint set.
@@ -329,7 +331,7 @@ func TestOmitEmptyFields(t *testing.T) {
 
 func TestStoreGetOrNew_NewComponent(t *testing.T) {
 	memFS := afero.NewMemMapFs()
-	store := lockfile.NewStore(memFS, testProjectDir)
+	store := lockfile.NewStore(memFS, testLockDir)
 
 	lock, err := store.GetOrNew("newpkg")
 	require.NoError(t, err)
@@ -339,7 +341,7 @@ func TestStoreGetOrNew_NewComponent(t *testing.T) {
 
 func TestStoreGetOrNew_ExistingComponent(t *testing.T) {
 	memFS := afero.NewMemMapFs()
-	store := lockfile.NewStore(memFS, testProjectDir)
+	store := lockfile.NewStore(memFS, testLockDir)
 
 	// Save a lock with data.
 	original := lockfile.New()
@@ -359,10 +361,10 @@ func TestStoreGetOrNew_ExistingComponent(t *testing.T) {
 
 func TestStoreGetOrNew_CorruptLock_ReturnsError(t *testing.T) {
 	memFS := afero.NewMemMapFs()
-	store := lockfile.NewStore(memFS, testProjectDir)
+	store := lockfile.NewStore(memFS, testLockDir)
 
 	// Write corrupt content to the lock file path.
-	lockPath, err := lockfile.LockPath(testProjectDir, "corrupt")
+	lockPath, err := lockfile.LockPath(testLockDir, "corrupt")
 	require.NoError(t, err)
 
 	require.NoError(t, fileutils.MkdirAll(memFS, filepath.Dir(lockPath)))
@@ -376,7 +378,7 @@ func TestStoreGetOrNew_CorruptLock_ReturnsError(t *testing.T) {
 
 func TestStoreGet_Caching(t *testing.T) {
 	memFS := afero.NewMemMapFs()
-	store := lockfile.NewStore(memFS, testProjectDir)
+	store := lockfile.NewStore(memFS, testLockDir)
 
 	lock := lockfile.New()
 	lock.UpstreamCommit = testCommitHash

--- a/internal/lockfile/lockfile_test.go
+++ b/internal/lockfile/lockfile_test.go
@@ -283,3 +283,71 @@ func TestOmitEmptyFields(t *testing.T) {
 	assert.NotContains(t, content, "resolution-input-hash", "empty resolution-input-hash should be omitted")
 	assert.Contains(t, content, "input-fingerprint")
 }
+
+// Store tests
+
+func TestStoreGetOrNew_NewComponent(t *testing.T) {
+	memFS := afero.NewMemMapFs()
+	store := lockfile.NewStore(memFS, testProjectDir)
+
+	lock, err := store.GetOrNew("newpkg")
+	require.NoError(t, err)
+	assert.Equal(t, 1, lock.Version)
+	assert.Empty(t, lock.UpstreamCommit)
+}
+
+func TestStoreGetOrNew_ExistingComponent(t *testing.T) {
+	memFS := afero.NewMemMapFs()
+	store := lockfile.NewStore(memFS, testProjectDir)
+
+	// Save a lock with data.
+	original := lockfile.New()
+	original.UpstreamCommit = testCommitHash
+	original.ImportCommit = "import-hash"
+	original.ManualBump = 3
+
+	require.NoError(t, store.Save("curl", original))
+
+	// GetOrNew should return the existing lock, preserving all fields.
+	lock, err := store.GetOrNew("curl")
+	require.NoError(t, err)
+	assert.Equal(t, testCommitHash, lock.UpstreamCommit)
+	assert.Equal(t, "import-hash", lock.ImportCommit)
+	assert.Equal(t, 3, lock.ManualBump)
+}
+
+func TestStoreGetOrNew_CorruptLock_ReturnsError(t *testing.T) {
+	memFS := afero.NewMemMapFs()
+	store := lockfile.NewStore(memFS, testProjectDir)
+
+	// Write corrupt content to the lock file path.
+	lockPath := lockfile.LockPath(testProjectDir, "corrupt")
+
+	require.NoError(t, fileutils.MkdirAll(memFS, filepath.Dir(lockPath)))
+	require.NoError(t, fileutils.WriteFile(memFS, lockPath, []byte("not valid toml {{{"), fileperms.PublicFile))
+
+	// GetOrNew should error, NOT silently create a new lock.
+	_, err := store.GetOrNew("corrupt")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "loading existing lock")
+}
+
+func TestStoreGet_Caching(t *testing.T) {
+	memFS := afero.NewMemMapFs()
+	store := lockfile.NewStore(memFS, testProjectDir)
+
+	lock := lockfile.New()
+	lock.UpstreamCommit = testCommitHash
+
+	require.NoError(t, store.Save("curl", lock))
+
+	// First get loads from disk.
+	first, err := store.Get("curl")
+	require.NoError(t, err)
+	assert.Equal(t, testCommitHash, first.UpstreamCommit)
+
+	// Second get should return cached (same pointer).
+	second, err := store.Get("curl")
+	require.NoError(t, err)
+	assert.Same(t, first, second, "second Get should return cached instance")
+}

--- a/internal/lockfile/store.go
+++ b/internal/lockfile/store.go
@@ -4,6 +4,7 @@
 package lockfile
 
 import (
+	"fmt"
 	"sync"
 
 	"github.com/microsoft/azure-linux-dev-tools/internal/global/opctx"
@@ -60,15 +61,27 @@ func (s *Store) Get(componentName string) (*ComponentLock, error) {
 }
 
 // GetOrNew returns the lock for a component, creating a new empty lock if
-// none exists on disk. Useful for update flows that create locks for new
-// components.
-func (s *Store) GetOrNew(componentName string) *ComponentLock {
+// the lock file does not exist on disk. Returns an error if the lock file
+// exists but cannot be loaded (e.g., corrupt TOML, unsupported version).
+func (s *Store) GetOrNew(componentName string) (*ComponentLock, error) {
 	lock, err := s.Get(componentName)
 	if err != nil {
-		lock = New()
+		// Distinguish "not found" from other errors. Only create a new lock
+		// if the file doesn't exist; corrupt/unreadable files should be
+		// surfaced as errors to avoid silently losing data.
+		exists, existsErr := s.Exists(componentName)
+		if existsErr != nil {
+			return nil, fmt.Errorf("checking lock for %#q:\n%w", componentName, existsErr)
+		}
+
+		if exists {
+			return nil, fmt.Errorf("loading existing lock for %#q:\n%w", componentName, err)
+		}
+
+		return New(), nil
 	}
 
-	return lock
+	return lock, nil
 }
 
 // Save writes the lock for a component to disk and updates the cache.

--- a/internal/lockfile/store.go
+++ b/internal/lockfile/store.go
@@ -51,17 +51,22 @@ var (
 // key may result in a redundant disk read, but the result is identical and
 // harmless.
 type Store struct {
-	fs         opctx.FS
-	projectDir string
-	cache      sync.Map // map[string]*ComponentLock
+	fs      opctx.FS
+	lockDir string
+	cache   sync.Map // map[string]*ComponentLock
 }
 
-// NewStore creates a new lock store for the given project.
-func NewStore(fs opctx.FS, projectDir string) *Store {
+// NewStore creates a new lock store that reads/writes lock files in lockDir.
+func NewStore(fs opctx.FS, lockDir string) *Store {
 	return &Store{
-		fs:         fs,
-		projectDir: projectDir,
+		fs:      fs,
+		lockDir: lockDir,
 	}
+}
+
+// lockPath returns the path for a component's lock file within this store.
+func (s *Store) lockPath(componentName string) (string, error) {
+	return LockPath(s.lockDir, componentName)
 }
 
 // Get returns the lock for a component, loading it from disk on first access.
@@ -81,7 +86,7 @@ func (s *Store) Get(componentName string) (*ComponentLock, error) {
 	}
 
 	// Not cached — load from disk.
-	lockPath, err := LockPath(s.projectDir, componentName)
+	lockPath, err := s.lockPath(componentName)
 	if err != nil {
 		return nil, fmt.Errorf("getting lock path for component %#q:\n%w", componentName, err)
 	}
@@ -126,7 +131,7 @@ func (s *Store) GetOrNew(componentName string) (*ComponentLock, error) {
 
 // Save writes the lock for a component to disk and updates the cache.
 func (s *Store) Save(componentName string, lock *ComponentLock) error {
-	lockPath, err := LockPath(s.projectDir, componentName)
+	lockPath, err := s.lockPath(componentName)
 	if err != nil {
 		return fmt.Errorf("getting lock path for component %#q:\n%w", componentName, err)
 	}
@@ -146,7 +151,7 @@ func (s *Store) Exists(componentName string) (bool, error) {
 		return true, nil
 	}
 
-	lockPath, err := LockPath(s.projectDir, componentName)
+	lockPath, err := s.lockPath(componentName)
 	if err != nil {
 		return false, fmt.Errorf("getting lock path for component %#q:\n%w", componentName, err)
 	}
@@ -156,7 +161,7 @@ func (s *Store) Exists(componentName string) (bool, error) {
 
 // Remove deletes a component's lock file from disk and evicts it from cache.
 func (s *Store) Remove(componentName string) error {
-	lockPath, err := LockPath(s.projectDir, componentName)
+	lockPath, err := s.lockPath(componentName)
 	if err != nil {
 		return fmt.Errorf("getting lock path for component %#q:\n%w", componentName, err)
 	}

--- a/internal/lockfile/store.go
+++ b/internal/lockfile/store.go
@@ -46,7 +46,10 @@ func (s *Store) Get(componentName string) (*ComponentLock, error) {
 	s.mu.RUnlock()
 
 	// Not cached — load from disk.
-	lockPath := LockPath(s.projectDir, componentName)
+	lockPath, err := LockPath(s.projectDir, componentName)
+	if err != nil {
+		return nil, fmt.Errorf("getting lock path for component %#q:\n%w", componentName, err)
+	}
 
 	lock, err := Load(s.fs, lockPath)
 	if err != nil {
@@ -86,7 +89,10 @@ func (s *Store) GetOrNew(componentName string) (*ComponentLock, error) {
 
 // Save writes the lock for a component to disk and updates the cache.
 func (s *Store) Save(componentName string, lock *ComponentLock) error {
-	lockPath := LockPath(s.projectDir, componentName)
+	lockPath, err := LockPath(s.projectDir, componentName)
+	if err != nil {
+		return fmt.Errorf("getting lock path for component %#q:\n%w", componentName, err)
+	}
 
 	if err := lock.Save(s.fs, lockPath); err != nil {
 		return err
@@ -111,12 +117,20 @@ func (s *Store) Exists(componentName string) (bool, error) {
 
 	s.mu.RUnlock()
 
-	return Exists(s.fs, LockPath(s.projectDir, componentName))
+	lockPath, err := LockPath(s.projectDir, componentName)
+	if err != nil {
+		return false, fmt.Errorf("getting lock path for component %#q:\n%w", componentName, err)
+	}
+
+	return Exists(s.fs, lockPath)
 }
 
 // Remove deletes a component's lock file from disk and evicts it from cache.
 func (s *Store) Remove(componentName string) error {
-	lockPath := LockPath(s.projectDir, componentName)
+	lockPath, err := LockPath(s.projectDir, componentName)
+	if err != nil {
+		return fmt.Errorf("getting lock path for component %#q:\n%w", componentName, err)
+	}
 
 	if err := Remove(s.fs, lockPath); err != nil {
 		return err

--- a/internal/lockfile/store.go
+++ b/internal/lockfile/store.go
@@ -10,17 +10,50 @@ import (
 	"github.com/microsoft/azure-linux-dev-tools/internal/global/opctx"
 )
 
+// LockReader provides read-only access to per-component lock files. Use this
+// interface for commands that consume lock state but should not modify it
+// (e.g., render, build).
+type LockReader interface {
+	// Get returns the lock for a component. Returns an error if the lock file
+	// does not exist or cannot be parsed.
+	Get(componentName string) (*ComponentLock, error)
+	// Exists checks whether a lock file exists for the given component.
+	Exists(componentName string) (bool, error)
+}
+
+// LockWriter extends [LockReader] with write operations. Use this interface
+// for commands that create or update lock files (e.g., component update).
+type LockWriter interface {
+	LockReader
+	// GetOrNew returns the lock for a component, creating a new empty lock if
+	// none exists on disk. Returns an error if the lock file exists but is
+	// corrupt/unreadable.
+	GetOrNew(componentName string) (*ComponentLock, error)
+	// Save writes the lock for a component to disk.
+	Save(componentName string, lock *ComponentLock) error
+	// Remove deletes a component's lock file from disk.
+	Remove(componentName string) error
+}
+
+// Compile-time check that Store satisfies both interfaces.
+var (
+	_ LockReader = (*Store)(nil)
+	_ LockWriter = (*Store)(nil)
+)
+
 // Store provides cached access to per-component lock files. It wraps the
-// low-level Load/Save/Exists functions with a lazy-loading cache.
+// low-level Load/Save/Exists functions with a lazy-loading cache, avoiding
+// repeated disk reads when commands touch the same component multiple times
+// or when parallel goroutines resolve different components concurrently.
 //
-// Store is safe for concurrent read access (Get/Exists). Write operations
-// (Save/Remove) should be serialized by the caller.
+// All methods are safe for concurrent use. The cache uses [sync.Map] for
+// lock-free reads on different keys. Concurrent first-time loads of the same
+// key may result in a redundant disk read, but the result is identical and
+// harmless.
 type Store struct {
 	fs         opctx.FS
 	projectDir string
-
-	mu    sync.RWMutex
-	cache map[string]*ComponentLock
+	cache      sync.Map // map[string]*ComponentLock
 }
 
 // NewStore creates a new lock store for the given project.
@@ -28,22 +61,24 @@ func NewStore(fs opctx.FS, projectDir string) *Store {
 	return &Store{
 		fs:         fs,
 		projectDir: projectDir,
-		cache:      make(map[string]*ComponentLock),
 	}
 }
 
 // Get returns the lock for a component, loading it from disk on first access.
-// Returns nil and an error if the lock file does not exist or cannot be parsed.
+// Returns a copy — callers may mutate the returned value without affecting
+// cached state. Returns an error if the lock file does not exist or cannot
+// be parsed.
 func (s *Store) Get(componentName string) (*ComponentLock, error) {
-	s.mu.RLock()
+	if cached, ok := s.cache.Load(componentName); ok {
+		lock, typeOK := cached.(*ComponentLock)
+		if !typeOK {
+			return nil, fmt.Errorf("cache corruption for %#q: unexpected type", componentName)
+		}
 
-	if lock, ok := s.cache[componentName]; ok {
-		s.mu.RUnlock()
+		cp := *lock
 
-		return lock, nil
+		return &cp, nil
 	}
-
-	s.mu.RUnlock()
 
 	// Not cached — load from disk.
 	lockPath, err := LockPath(s.projectDir, componentName)
@@ -56,11 +91,13 @@ func (s *Store) Get(componentName string) (*ComponentLock, error) {
 		return nil, err
 	}
 
-	s.mu.Lock()
-	s.cache[componentName] = lock
-	s.mu.Unlock()
+	// Store in cache. If another goroutine raced us, the duplicate is harmless
+	// (same file contents).
+	s.cache.Store(componentName, lock)
 
-	return lock, nil
+	cp := *lock
+
+	return &cp, nil
 }
 
 // GetOrNew returns the lock for a component, creating a new empty lock if
@@ -98,24 +135,16 @@ func (s *Store) Save(componentName string, lock *ComponentLock) error {
 		return err
 	}
 
-	s.mu.Lock()
-	s.cache[componentName] = lock
-	s.mu.Unlock()
+	s.cache.Store(componentName, lock)
 
 	return nil
 }
 
 // Exists checks whether a lock file exists for the given component.
 func (s *Store) Exists(componentName string) (bool, error) {
-	s.mu.RLock()
-
-	if _, ok := s.cache[componentName]; ok {
-		s.mu.RUnlock()
-
+	if _, ok := s.cache.Load(componentName); ok {
 		return true, nil
 	}
-
-	s.mu.RUnlock()
 
 	lockPath, err := LockPath(s.projectDir, componentName)
 	if err != nil {
@@ -136,19 +165,7 @@ func (s *Store) Remove(componentName string) error {
 		return err
 	}
 
-	s.mu.Lock()
-	delete(s.cache, componentName)
-	s.mu.Unlock()
+	s.cache.Delete(componentName)
 
 	return nil
-}
-
-// ProjectDir returns the project directory this store operates on.
-func (s *Store) ProjectDir() string {
-	return s.projectDir
-}
-
-// FS returns the filesystem this store operates on.
-func (s *Store) FS() opctx.FS {
-	return s.fs
 }

--- a/internal/lockfile/store.go
+++ b/internal/lockfile/store.go
@@ -1,0 +1,127 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+package lockfile
+
+import (
+	"sync"
+
+	"github.com/microsoft/azure-linux-dev-tools/internal/global/opctx"
+)
+
+// Store provides cached access to per-component lock files. It wraps the
+// low-level Load/Save/Exists functions with a lazy-loading cache.
+//
+// Store is safe for concurrent read access (Get/Exists). Write operations
+// (Save/Remove) should be serialized by the caller.
+type Store struct {
+	fs         opctx.FS
+	projectDir string
+
+	mu    sync.RWMutex
+	cache map[string]*ComponentLock
+}
+
+// NewStore creates a new lock store for the given project.
+func NewStore(fs opctx.FS, projectDir string) *Store {
+	return &Store{
+		fs:         fs,
+		projectDir: projectDir,
+		cache:      make(map[string]*ComponentLock),
+	}
+}
+
+// Get returns the lock for a component, loading it from disk on first access.
+// Returns nil and an error if the lock file does not exist or cannot be parsed.
+func (s *Store) Get(componentName string) (*ComponentLock, error) {
+	s.mu.RLock()
+
+	if lock, ok := s.cache[componentName]; ok {
+		s.mu.RUnlock()
+
+		return lock, nil
+	}
+
+	s.mu.RUnlock()
+
+	// Not cached — load from disk.
+	lockPath := LockPath(s.projectDir, componentName)
+
+	lock, err := Load(s.fs, lockPath)
+	if err != nil {
+		return nil, err
+	}
+
+	s.mu.Lock()
+	s.cache[componentName] = lock
+	s.mu.Unlock()
+
+	return lock, nil
+}
+
+// GetOrNew returns the lock for a component, creating a new empty lock if
+// none exists on disk. Useful for update flows that create locks for new
+// components.
+func (s *Store) GetOrNew(componentName string) *ComponentLock {
+	lock, err := s.Get(componentName)
+	if err != nil {
+		lock = New()
+	}
+
+	return lock
+}
+
+// Save writes the lock for a component to disk and updates the cache.
+func (s *Store) Save(componentName string, lock *ComponentLock) error {
+	lockPath := LockPath(s.projectDir, componentName)
+
+	if err := lock.Save(s.fs, lockPath); err != nil {
+		return err
+	}
+
+	s.mu.Lock()
+	s.cache[componentName] = lock
+	s.mu.Unlock()
+
+	return nil
+}
+
+// Exists checks whether a lock file exists for the given component.
+func (s *Store) Exists(componentName string) (bool, error) {
+	s.mu.RLock()
+
+	if _, ok := s.cache[componentName]; ok {
+		s.mu.RUnlock()
+
+		return true, nil
+	}
+
+	s.mu.RUnlock()
+
+	return Exists(s.fs, LockPath(s.projectDir, componentName))
+}
+
+// Remove deletes a component's lock file from disk and evicts it from cache.
+func (s *Store) Remove(componentName string) error {
+	lockPath := LockPath(s.projectDir, componentName)
+
+	if err := Remove(s.fs, lockPath); err != nil {
+		return err
+	}
+
+	s.mu.Lock()
+	delete(s.cache, componentName)
+	s.mu.Unlock()
+
+	return nil
+}
+
+// ProjectDir returns the project directory this store operates on.
+func (s *Store) ProjectDir() string {
+	return s.projectDir
+}
+
+// FS returns the filesystem this store operates on.
+func (s *Store) FS() opctx.FS {
+	return s.fs
+}

--- a/internal/lockfile/store.go
+++ b/internal/lockfile/store.go
@@ -130,7 +130,13 @@ func (s *Store) GetOrNew(componentName string) (*ComponentLock, error) {
 }
 
 // Save writes the lock for a component to disk and updates the cache.
+// Caches a defensive copy so caller mutations after Save don't affect
+// cached state.
 func (s *Store) Save(componentName string, lock *ComponentLock) error {
+	if lock == nil {
+		return fmt.Errorf("cannot save nil lock for component %#q", componentName)
+	}
+
 	lockPath, err := s.lockPath(componentName)
 	if err != nil {
 		return fmt.Errorf("getting lock path for component %#q:\n%w", componentName, err)
@@ -140,7 +146,9 @@ func (s *Store) Save(componentName string, lock *ComponentLock) error {
 		return err
 	}
 
-	s.cache.Store(componentName, lock)
+	// Cache a copy so caller can't mutate cached state after Save.
+	cp := *lock
+	s.cache.Store(componentName, &cp)
 
 	return nil
 }

--- a/internal/projectconfig/project.go
+++ b/internal/projectconfig/project.go
@@ -131,6 +131,9 @@ type ProjectInfo struct {
 	// Path to the output directory for rendered specs (component render).
 	RenderedSpecsDir string `toml:"rendered-specs-dir,omitempty" json:"renderedSpecsDir,omitempty" jsonschema:"title=Rendered Specs Directory,description=Output directory for rendered specs,example=SPECS"`
 
+	// Path to the directory for per-component lock files.
+	LockDir string `toml:"lock-dir,omitempty" json:"lockDir,omitempty" jsonschema:"title=Lock Directory,description=Directory for per-component lock files,default=locks"`
+
 	// Default-selected distro. May be overridden at runtime.
 	DefaultDistro DistroReference `toml:"default-distro,omitempty" json:"defaultDistro,omitempty" jsonschema:"title=Default Distro,description=Default selected distro reference"`
 
@@ -163,6 +166,7 @@ func (p *ProjectInfo) WithAbsolutePaths(referenceDir string) *ProjectInfo {
 	result.WorkDir = makeAbsolute(referenceDir, result.WorkDir)
 	result.OutputDir = makeAbsolute(referenceDir, result.OutputDir)
 	result.RenderedSpecsDir = makeAbsolute(referenceDir, result.RenderedSpecsDir)
+	result.LockDir = makeAbsolute(referenceDir, result.LockDir)
 
 	return result
 }

--- a/scenario/__snapshots__/TestSnapshotsContainer_config_generate-schema_stdout_1.snap
+++ b/scenario/__snapshots__/TestSnapshotsContainer_config_generate-schema_stdout_1.snap
@@ -719,6 +719,12 @@
             "SPECS"
           ]
         },
+        "lock-dir": {
+          "type": "string",
+          "title": "Lock Directory",
+          "description": "Directory for per-component lock files",
+          "default": "locks"
+        },
         "default-distro": {
           "$ref": "#/$defs/DistroReference",
           "title": "Default Distro",

--- a/scenario/__snapshots__/TestSnapshots_config_generate-schema_stdout_1.snap
+++ b/scenario/__snapshots__/TestSnapshots_config_generate-schema_stdout_1.snap
@@ -719,6 +719,12 @@
             "SPECS"
           ]
         },
+        "lock-dir": {
+          "type": "string",
+          "title": "Lock Directory",
+          "description": "Directory for per-component lock files",
+          "default": "locks"
+        },
         "default-distro": {
           "$ref": "#/$defs/DistroReference",
           "title": "Default Distro",

--- a/schemas/azldev.schema.json
+++ b/schemas/azldev.schema.json
@@ -719,6 +719,12 @@
             "SPECS"
           ]
         },
+        "lock-dir": {
+          "type": "string",
+          "title": "Lock Directory",
+          "description": "Directory for per-component lock files",
+          "default": "locks"
+        },
         "default-distro": {
           "$ref": "#/$defs/DistroReference",
           "title": "Default Distro",


### PR DESCRIPTION
Replace single azldev.lock (map[string]ComponentLock) with per-component files under locks/<name>.lock. Each component gets its own lock file with:
- import-commit: permanent fork point (write-once)
- upstream-commit: current resolved commit
- manual-bump: mass-rebuild counter
- input-fingerprint: render input change detection
- resolution-input-hash: offline staleness (reserved for v2)

Update component update command to read/write individual lock files. Drop shared lock mutex, padding logic, and monolithic file handling.

<!--
PR Title must follow Conventional Commits format. Available types:

- feat: A new feature
- fix: A bug fix
- docs: Documentation only changes
- style: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
- refactor: A code change that neither fixes a bug nor adds a feature
- perf: A code change that improves performance
- test: Adding missing tests or correcting existing tests
- build: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
- ci: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
- chore: Other changes that don't modify src or test files
- revert: Reverts a previous commit

Reference: https://www.conventionalcommits.org/en/v1.0.0/
-->
