### PR TITLE
refactor(config): extract ResolveComponentConfig for config inheritance

### DIFF
--- a/internal/app/azldev/core/components/resolver.go
+++ b/internal/app/azldev/core/components/resolver.go
@@ -9,12 +9,9 @@ import (
 	"log/slog"
 	"path"
 	"path/filepath"
-	"slices"
-	"sort"
 	"strings"
 
 	"github.com/bmatcuk/doublestar/v4"
-	"github.com/brunoga/deep"
 	"github.com/microsoft/azure-linux-dev-tools/internal/app/azldev"
 	"github.com/microsoft/azure-linux-dev-tools/internal/projectconfig"
 	"github.com/microsoft/azure-linux-dev-tools/internal/utils/fileutils"
@@ -477,48 +474,22 @@ func (r *Resolver) createComponentFromConfig(componentConfig *projectconfig.Comp
 func applyInheritedDefaultsToComponent(
 	env *azldev.Env, component projectconfig.ComponentConfig,
 ) (result *projectconfig.ComponentConfig, err error) {
-	var distroVer projectconfig.DistroVersionDefinition
-
-	// Find the distro.
-	_, distroVer, err = env.Distro()
+	_, distroVer, err := env.Distro()
 	if err != nil {
-		return result, fmt.Errorf("failed to resolve current distro:\n%w", err)
+		return nil, fmt.Errorf("failed to resolve current distro:\n%w", err)
 	}
 
-	// Start by deep-cloning the distro defaults, using them as a template.
-	result = &projectconfig.ComponentConfig{}
-	*result = deep.MustCopy(distroVer.DefaultComponentConfig)
+	groupNames := env.Config().GroupsByComponent[component.Name]
 
-	// Find all component groups that this component belongs to and apply their defaults.
-	if groupNames, ok := env.Config().GroupsByComponent[component.Name]; ok {
-		// Sort the group names for deterministic layering of defaults.
-		sortedGroupNames := slices.Clone(groupNames)
-		sort.Strings(sortedGroupNames)
-
-		for _, groupName := range sortedGroupNames {
-			// Find the group.
-			groupConfig, ok := env.Config().ComponentGroups[groupName]
-			if !ok {
-				return result, fmt.Errorf("component group not found: %s", groupName)
-			}
-
-			// Apply its defaults.
-			err = result.MergeUpdatesFrom(&groupConfig.DefaultComponentConfig)
-			if err != nil {
-				return result, fmt.Errorf(
-					"failed to apply defaults from component group '%s' to config for component '%s':\n%w",
-					groupName, component.Name, err,
-				)
-			}
-		}
-	}
-
-	// Layer in the component's explicit config.
-	err = result.MergeUpdatesFrom(&component)
+	resolved, err := projectconfig.ResolveComponentConfig(
+		component,
+		distroVer.DefaultComponentConfig,
+		env.Config().ComponentGroups,
+		groupNames,
+	)
 	if err != nil {
-		return result,
-			fmt.Errorf("failed to apply distro defaults to config for component '%s':\n%w", component.Name, err)
+		return nil, fmt.Errorf("resolving config for component '%s':\n%w", component.Name, err)
 	}
 
-	return result, nil
+	return &resolved, nil
 }

--- a/internal/projectconfig/component.go
+++ b/internal/projectconfig/component.go
@@ -5,6 +5,8 @@ package projectconfig
 
 import (
 	"fmt"
+	"slices"
+	"sort"
 
 	"dario.cat/mergo"
 	"github.com/brunoga/deep"
@@ -184,6 +186,42 @@ func (c *ComponentConfig) MergeUpdatesFrom(other *ComponentConfig) error {
 	}
 
 	return nil
+}
+
+// ResolveComponentConfig applies the full config inheritance chain for a single
+// component: distro defaults → group defaults (sorted) → component explicit config.
+// Returns a fully resolved copy; the inputs are not modified.
+// On error the returned config is undefined and must not be used.
+func ResolveComponentConfig(
+	comp ComponentConfig,
+	distroDefaults ComponentConfig,
+	groups map[string]ComponentGroupConfig,
+	groupMembership []string,
+) (ComponentConfig, error) {
+	merged := deep.MustCopy(distroDefaults)
+
+	// Apply group defaults in sorted order for determinism.
+	sortedGroups := slices.Clone(groupMembership)
+	sort.Strings(sortedGroups)
+
+	for _, groupName := range sortedGroups {
+		groupConfig, ok := groups[groupName]
+		if !ok {
+			return ComponentConfig{}, fmt.Errorf("component group not found: %#q", groupName)
+		}
+
+		if err := merged.MergeUpdatesFrom(&groupConfig.DefaultComponentConfig); err != nil {
+			return ComponentConfig{}, fmt.Errorf(
+				"failed to apply defaults from component group %#q:\n%w",
+				groupName, err)
+		}
+	}
+
+	if err := merged.MergeUpdatesFrom(&comp); err != nil {
+		return ComponentConfig{}, fmt.Errorf("failed to apply component config:\n%w", err)
+	}
+
+	return merged, nil
 }
 
 // Returns a copy of the component config with relative file paths converted to absolute

--- a/internal/projectconfig/component_test.go
+++ b/internal/projectconfig/component_test.go
@@ -233,3 +233,114 @@ func TestReleaseCalculationValidation(t *testing.T) {
 		Calculation: "manaul",
 	}))
 }
+
+func TestResolveComponentConfig(t *testing.T) {
+	distroDefaults := projectconfig.ComponentConfig{
+		Spec: projectconfig.SpecSource{
+			SourceType: projectconfig.SpecSourceTypeUpstream,
+		},
+	}
+
+	t.Run("no groups", func(t *testing.T) {
+		comp := projectconfig.ComponentConfig{Name: "curl"}
+
+		resolved, err := projectconfig.ResolveComponentConfig(
+			comp, distroDefaults, nil, nil,
+		)
+		require.NoError(t, err)
+		assert.Equal(t, "curl", resolved.Name)
+		assert.Equal(t, projectconfig.SpecSourceTypeUpstream, resolved.Spec.SourceType)
+	})
+
+	t.Run("single group", func(t *testing.T) {
+		groups := map[string]projectconfig.ComponentGroupConfig{
+			"core": {
+				DefaultComponentConfig: projectconfig.ComponentConfig{
+					Spec: projectconfig.SpecSource{
+						UpstreamCommit: "group-commit",
+					},
+				},
+			},
+		}
+		comp := projectconfig.ComponentConfig{Name: "curl"}
+
+		resolved, err := projectconfig.ResolveComponentConfig(
+			comp, distroDefaults, groups, []string{"core"},
+		)
+		require.NoError(t, err)
+		assert.Equal(t, "group-commit", resolved.Spec.UpstreamCommit)
+		assert.Equal(t, projectconfig.SpecSourceTypeUpstream, resolved.Spec.SourceType)
+	})
+
+	t.Run("multi group sorted order", func(t *testing.T) {
+		groups := map[string]projectconfig.ComponentGroupConfig{
+			"alpha": {
+				DefaultComponentConfig: projectconfig.ComponentConfig{
+					Spec: projectconfig.SpecSource{UpstreamCommit: "alpha-commit"},
+				},
+			},
+			"beta": {
+				DefaultComponentConfig: projectconfig.ComponentConfig{
+					Spec: projectconfig.SpecSource{UpstreamCommit: "beta-commit"},
+				},
+			},
+		}
+		comp := projectconfig.ComponentConfig{Name: "curl"}
+
+		// Groups applied in sorted order: alpha then beta. beta wins.
+		resolved, err := projectconfig.ResolveComponentConfig(
+			comp, distroDefaults, groups, []string{"beta", "alpha"},
+		)
+		require.NoError(t, err)
+		assert.Equal(t, "beta-commit", resolved.Spec.UpstreamCommit)
+	})
+
+	t.Run("component overrides group", func(t *testing.T) {
+		groups := map[string]projectconfig.ComponentGroupConfig{
+			"core": {
+				DefaultComponentConfig: projectconfig.ComponentConfig{
+					Spec: projectconfig.SpecSource{UpstreamCommit: "group-commit"},
+				},
+			},
+		}
+		comp := projectconfig.ComponentConfig{
+			Name: "curl",
+			Spec: projectconfig.SpecSource{UpstreamCommit: "comp-commit"},
+		}
+
+		resolved, err := projectconfig.ResolveComponentConfig(
+			comp, distroDefaults, groups, []string{"core"},
+		)
+		require.NoError(t, err)
+		assert.Equal(t, "comp-commit", resolved.Spec.UpstreamCommit)
+	})
+
+	t.Run("missing group errors", func(t *testing.T) {
+		comp := projectconfig.ComponentConfig{Name: "curl"}
+
+		_, err := projectconfig.ResolveComponentConfig(
+			comp, distroDefaults, nil, []string{"nonexistent"},
+		)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "component group not found")
+	})
+
+	t.Run("does not mutate inputs", func(t *testing.T) {
+		groups := map[string]projectconfig.ComponentGroupConfig{
+			"core": {
+				DefaultComponentConfig: projectconfig.ComponentConfig{
+					Spec: projectconfig.SpecSource{UpstreamCommit: "group-commit"},
+				},
+			},
+		}
+		comp := projectconfig.ComponentConfig{Name: "curl"}
+		originalDefaults := distroDefaults
+
+		_, err := projectconfig.ResolveComponentConfig(
+			comp, distroDefaults, groups, []string{"core"},
+		)
+		require.NoError(t, err)
+		assert.Equal(t, originalDefaults, distroDefaults, "distro defaults should not be mutated")
+		assert.Empty(t, comp.Spec.UpstreamCommit, "component config should not be mutated")
+	})
+}


### PR DESCRIPTION
Extract the distro → group → component config merge logic from applyInheritedDefaultsToComponent into projectconfig.ResolveComponentConfig.

This creates a single source of truth for the inheritance chain that can be reused by lock validation and other consumers without depending on the resolver package.

Pure refactor — no behavior change. Merge order (distro defaults → sorted group defaults → component explicit config) is preserved.

<!--
PR Title must follow Conventional Commits format. Available types:

- feat: A new feature
- fix: A bug fix
- docs: Documentation only changes
- style: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
- refactor: A code change that neither fixes a bug nor adds a feature
- perf: A code change that improves performance
- test: Adding missing tests or correcting existing tests
- build: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
- ci: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
- chore: Other changes that don't modify src or test files
- revert: Reverts a previous commit

Reference: https://www.conventionalcommits.org/en/v1.0.0/
-->
