### PR TITLE
feat(lock): add lock file validation and orphan detection primitives

### DIFF
--- a/internal/lockfile/lockfile.go
+++ b/internal/lockfile/lockfile.go
@@ -9,9 +9,13 @@ package lockfile
 
 import (
 	"fmt"
+	"log/slog"
 	"path/filepath"
+	"sort"
+	"strings"
 
 	"github.com/microsoft/azure-linux-dev-tools/internal/global/opctx"
+	"github.com/microsoft/azure-linux-dev-tools/internal/projectconfig"
 	"github.com/microsoft/azure-linux-dev-tools/internal/utils/fileperms"
 	"github.com/microsoft/azure-linux-dev-tools/internal/utils/fileutils"
 	toml "github.com/pelletier/go-toml/v2"
@@ -145,4 +149,148 @@ func Remove(fs opctx.FS, path string) error {
 	}
 
 	return nil
+}
+
+// ValidateUpstreamCommit checks that a lock file is consistent with the
+// component's config. Returns the locked commit and an error if:
+//   - The lock file does not exist or cannot be loaded
+//   - The component has an explicit 'upstream-commit' in config that doesn't match
+//     the lock file (lock is stale, run 'component update')
+func ValidateUpstreamCommit(
+	fs opctx.FS, lockDir, componentName, configUpstreamCommit string,
+) (string, error) {
+	lockPath, pathErr := LockPath(lockDir, componentName)
+	if pathErr != nil {
+		return "", fmt.Errorf("getting lock path for %#q:\n%w", componentName, pathErr)
+	}
+
+	exists, err := Exists(fs, lockPath)
+	if err != nil {
+		return "", fmt.Errorf("checking lock for %#q:\n%w", componentName, err)
+	}
+
+	if !exists {
+		return "", fmt.Errorf(
+			"no lock file for upstream component %#q",
+			componentName)
+	}
+
+	lock, err := Load(fs, lockPath)
+	if err != nil {
+		return "", fmt.Errorf("loading lock for %#q:\n%w", componentName, err)
+	}
+
+	if lock.UpstreamCommit == "" {
+		return "", fmt.Errorf(
+			"lock file for %#q has no upstream-commit",
+			componentName)
+	}
+
+	if configUpstreamCommit != "" && lock.UpstreamCommit != configUpstreamCommit {
+		return "", fmt.Errorf(
+			"lock is stale for %#q: config pins %#q but lock has %#q",
+			componentName, configUpstreamCommit, lock.UpstreamCommit)
+	}
+
+	return lock.UpstreamCommit, nil
+}
+
+// ValidateConsistency checks lock files against resolved component configs.
+// For each upstream component, verifies a lock file exists and any explicit
+// upstream-commit pin matches. When checkOrphans is true, also detects orphan
+// lock files (components removed from config). Orphan detection should only
+// be used when validating the full project — on filtered commands it would
+// misfire against the subset.
+//
+// Returns sorted lists of components with missing/stale locks and orphan
+// component names. Returns an error if any issues are found.
+func ValidateConsistency(
+	fs opctx.FS,
+	lockDir string,
+	components map[string]projectconfig.ComponentConfig,
+	checkOrphans bool,
+) (missingOrStale, orphans []string, err error) {
+	// Check each component that may need a lock file. Only skip components
+	// that are explicitly local — unspecified source type inherits upstream
+	// from distro defaults, so those need validation too.
+	for name, comp := range components {
+		if comp.Spec.SourceType == projectconfig.SpecSourceTypeLocal {
+			continue
+		}
+
+		if _, validateErr := ValidateUpstreamCommit(
+			fs, lockDir, name, comp.Spec.UpstreamCommit,
+		); validateErr != nil {
+			slog.Debug("Lock validation failed", "component", name, "error", validateErr)
+
+			missingOrStale = append(missingOrStale, name)
+		}
+	}
+
+	if checkOrphans {
+		var orphanErr error
+
+		orphans, orphanErr = FindOrphanLockFiles(fs, lockDir, components)
+		if orphanErr != nil {
+			return missingOrStale, nil, fmt.Errorf("checking for orphan lock files:\n%w", orphanErr)
+		}
+	}
+
+	if len(missingOrStale) > 0 || len(orphans) > 0 {
+		sort.Strings(missingOrStale)
+		sort.Strings(orphans)
+
+		return missingOrStale, orphans, fmt.Errorf(
+			"lock file consistency check failed: %d missing/stale, %d orphans",
+			len(missingOrStale), len(orphans))
+	}
+
+	return nil, nil, nil
+}
+
+// FindOrphanLockFiles returns component names that have lock files but no
+// corresponding component in config (i.e., the component was removed).
+// Returns an error if the locks directory exists but cannot be read.
+func FindOrphanLockFiles(
+	fs opctx.FS,
+	lockDir string,
+	components map[string]projectconfig.ComponentConfig,
+) ([]string, error) {
+	entries, readErr := fileutils.ReadDir(fs, lockDir)
+	if readErr != nil {
+		// No locks directory is fine — nothing to detect.
+		exists, existsErr := fileutils.DirExists(fs, lockDir)
+		if existsErr != nil {
+			return nil, fmt.Errorf("checking locks directory %#q:\n%w", lockDir, existsErr)
+		}
+
+		if !exists {
+			return nil, nil
+		}
+
+		return nil, fmt.Errorf("reading locks directory %#q:\n%w", lockDir, readErr)
+	}
+
+	var orphans []string
+
+	for _, entry := range entries {
+		if entry.IsDir() {
+			continue
+		}
+
+		entryName := entry.Name()
+		if !strings.HasSuffix(entryName, lockFileExtension) || strings.HasPrefix(entryName, ".") {
+			continue
+		}
+
+		componentName := strings.TrimSuffix(entryName, lockFileExtension)
+
+		if _, exists := components[componentName]; !exists {
+			orphans = append(orphans, componentName)
+		}
+	}
+
+	sort.Strings(orphans)
+
+	return orphans, nil
 }

--- a/internal/lockfile/lockfile_test.go
+++ b/internal/lockfile/lockfile_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/microsoft/azure-linux-dev-tools/internal/lockfile"
+	"github.com/microsoft/azure-linux-dev-tools/internal/projectconfig"
 	"github.com/microsoft/azure-linux-dev-tools/internal/utils/fileperms"
 	"github.com/microsoft/azure-linux-dev-tools/internal/utils/fileutils"
 	"github.com/spf13/afero"
@@ -20,6 +21,16 @@ const (
 	testLockDir    = testProjectDir + "/" + lockfile.LockDir
 	testCommitHash = "aaaa"
 )
+
+// mustLockPath is a test helper that calls LockPath and fails the test on error.
+func mustLockPath(t *testing.T, componentName string) string {
+	t.Helper()
+
+	path, err := lockfile.LockPath(testLockDir, componentName)
+	require.NoError(t, err)
+
+	return path
+}
 
 func TestNew(t *testing.T) {
 	lock := lockfile.New()
@@ -399,4 +410,434 @@ func TestStoreGet_Caching(t *testing.T) {
 	first.UpstreamCommit = "mutated"
 	assert.NotEqual(t, first.UpstreamCommit, second.UpstreamCommit,
 		"Get should return copies, not shared pointers")
+}
+
+func TestValidateUpstreamCommit(t *testing.T) {
+	memFS := afero.NewMemMapFs()
+
+	// Create a lock file for curl.
+	lock := lockfile.New()
+	lock.UpstreamCommit = testCommitHash
+
+	require.NoError(t, lock.Save(memFS, mustLockPath(t, "curl")))
+
+	t.Run("valid entry no config pin", func(t *testing.T) {
+		commit, err := lockfile.ValidateUpstreamCommit(memFS, testLockDir, "curl", "")
+		require.NoError(t, err)
+		assert.Equal(t, testCommitHash, commit)
+	})
+
+	t.Run("valid entry matching config pin", func(t *testing.T) {
+		commit, err := lockfile.ValidateUpstreamCommit(memFS, testLockDir, "curl", testCommitHash)
+		require.NoError(t, err)
+		assert.Equal(t, testCommitHash, commit)
+	})
+
+	t.Run("missing lock file", func(t *testing.T) {
+		_, err := lockfile.ValidateUpstreamCommit(memFS, testLockDir, "nonexistent", "")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "no lock file")
+	})
+
+	t.Run("stale config pin", func(t *testing.T) {
+		_, err := lockfile.ValidateUpstreamCommit(memFS, testLockDir, "curl", "bbbb")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "stale")
+	})
+
+	t.Run("empty upstream commit in lock", func(t *testing.T) {
+		emptyLock := lockfile.New()
+		require.NoError(t, emptyLock.Save(memFS, mustLockPath(t, "empty-pkg")))
+
+		_, err := lockfile.ValidateUpstreamCommit(memFS, testLockDir, "empty-pkg", "")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "no upstream-commit")
+	})
+}
+
+func TestValidateConsistency(t *testing.T) {
+	t.Run("all valid", func(t *testing.T) {
+		memFS := afero.NewMemMapFs()
+
+		lock := lockfile.New()
+		lock.UpstreamCommit = testCommitHash
+
+		require.NoError(t, lock.Save(memFS, mustLockPath(t, "curl")))
+
+		components := map[string]projectconfig.ComponentConfig{
+			"curl": {Spec: projectconfig.SpecSource{SourceType: projectconfig.SpecSourceTypeUpstream}},
+		}
+
+		stale, orphans, err := lockfile.ValidateConsistency(memFS, testLockDir, components, true)
+		require.NoError(t, err)
+		assert.Empty(t, stale)
+		assert.Empty(t, orphans)
+	})
+
+	t.Run("missing lock", func(t *testing.T) {
+		memFS := afero.NewMemMapFs()
+
+		components := map[string]projectconfig.ComponentConfig{
+			"curl": {Spec: projectconfig.SpecSource{SourceType: projectconfig.SpecSourceTypeUpstream}},
+		}
+
+		stale, _, err := lockfile.ValidateConsistency(memFS, testLockDir, components, true)
+		require.Error(t, err)
+		assert.Contains(t, stale, "curl")
+	})
+
+	t.Run("orphan lock file", func(t *testing.T) {
+		memFS := afero.NewMemMapFs()
+
+		lock := lockfile.New()
+		lock.UpstreamCommit = testCommitHash
+
+		require.NoError(t, lock.Save(memFS, mustLockPath(t, "removed-pkg")))
+
+		components := map[string]projectconfig.ComponentConfig{}
+
+		_, orphans, err := lockfile.ValidateConsistency(memFS, testLockDir, components, true)
+		require.Error(t, err)
+		assert.Contains(t, orphans, "removed-pkg")
+	})
+
+	t.Run("local component with lock is not orphan", func(t *testing.T) {
+		memFS := afero.NewMemMapFs()
+
+		lock := lockfile.New()
+		lock.InputFingerprint = "sha256:local-fp"
+
+		require.NoError(t, lock.Save(memFS, mustLockPath(t, "curl")))
+
+		// Component exists but is local — lock is still valid (used for fingerprinting).
+		components := map[string]projectconfig.ComponentConfig{
+			"curl": {Spec: projectconfig.SpecSource{SourceType: projectconfig.SpecSourceTypeLocal}},
+		}
+
+		_, orphans, err := lockfile.ValidateConsistency(memFS, testLockDir, components, true)
+		require.NoError(t, err)
+		assert.Empty(t, orphans)
+	})
+
+	t.Run("local components skipped", func(t *testing.T) {
+		memFS := afero.NewMemMapFs()
+
+		components := map[string]projectconfig.ComponentConfig{
+			"local-pkg": {Spec: projectconfig.SpecSource{SourceType: projectconfig.SpecSourceTypeLocal}},
+		}
+
+		stale, orphans, err := lockfile.ValidateConsistency(memFS, testLockDir, components, true)
+		require.NoError(t, err)
+		assert.Empty(t, stale)
+		assert.Empty(t, orphans)
+	})
+
+	t.Run("unspecified source type validated like upstream", func(t *testing.T) {
+		memFS := afero.NewMemMapFs()
+
+		// Component with unspecified source type (inherits upstream from defaults)
+		// but no lock file — should be flagged as missing.
+		components := map[string]projectconfig.ComponentConfig{
+			"curl": {},
+		}
+
+		stale, _, err := lockfile.ValidateConsistency(memFS, testLockDir, components, true)
+		require.Error(t, err)
+		assert.Contains(t, stale, "curl")
+	})
+
+	t.Run("unspecified source type with valid lock passes", func(t *testing.T) {
+		memFS := afero.NewMemMapFs()
+
+		lock := lockfile.New()
+		lock.UpstreamCommit = testCommitHash
+
+		require.NoError(t, lock.Save(memFS, mustLockPath(t, "curl")))
+
+		components := map[string]projectconfig.ComponentConfig{
+			"curl": {},
+		}
+
+		stale, orphans, err := lockfile.ValidateConsistency(memFS, testLockDir, components, true)
+		require.NoError(t, err)
+		assert.Empty(t, stale)
+		assert.Empty(t, orphans)
+	})
+
+	t.Run("mixed stale and orphan", func(t *testing.T) {
+		memFS := afero.NewMemMapFs()
+
+		// Create orphan lock.
+		orphanLock := lockfile.New()
+		orphanLock.UpstreamCommit = "orphan-commit"
+
+		require.NoError(t, orphanLock.Save(memFS, mustLockPath(t, "orphan")))
+
+		// Config has upstream component with no lock.
+		components := map[string]projectconfig.ComponentConfig{
+			"missing": {Spec: projectconfig.SpecSource{SourceType: projectconfig.SpecSourceTypeUpstream}},
+		}
+
+		stale, orphans, err := lockfile.ValidateConsistency(memFS, testLockDir, components, true)
+		require.Error(t, err)
+		assert.Contains(t, stale, "missing")
+		assert.Contains(t, orphans, "orphan")
+	})
+}
+
+func TestPruneOrphans(t *testing.T) {
+	t.Run("prunes removed components", func(t *testing.T) {
+		memFS := afero.NewMemMapFs()
+
+		lock := lockfile.New()
+		lock.UpstreamCommit = testCommitHash
+
+		require.NoError(t, lock.Save(memFS, mustLockPath(t, "removed")))
+
+		components := map[string]projectconfig.ComponentConfig{}
+
+		store := lockfile.NewStore(memFS, testLockDir)
+
+		pruned, err := store.PruneOrphans(components)
+		require.NoError(t, err)
+		assert.Equal(t, 1, pruned)
+
+		exists, existsErr := lockfile.Exists(memFS, mustLockPath(t, "removed"))
+		require.NoError(t, existsErr)
+		assert.False(t, exists)
+	})
+
+	t.Run("local component lock preserved", func(t *testing.T) {
+		memFS := afero.NewMemMapFs()
+
+		lock := lockfile.New()
+		lock.InputFingerprint = "sha256:local-fp"
+
+		require.NoError(t, lock.Save(memFS, mustLockPath(t, "curl")))
+
+		// Local component — lock still valid for fingerprinting.
+		components := map[string]projectconfig.ComponentConfig{
+			"curl": {Spec: projectconfig.SpecSource{SourceType: projectconfig.SpecSourceTypeLocal}},
+		}
+
+		store := lockfile.NewStore(memFS, testLockDir)
+
+		pruned, err := store.PruneOrphans(components)
+		require.NoError(t, err)
+		assert.Equal(t, 0, pruned, "local component locks should not be pruned")
+	})
+
+	t.Run("preserves valid locks", func(t *testing.T) {
+		memFS := afero.NewMemMapFs()
+
+		lock := lockfile.New()
+		lock.UpstreamCommit = testCommitHash
+
+		require.NoError(t, lock.Save(memFS, mustLockPath(t, "curl")))
+
+		components := map[string]projectconfig.ComponentConfig{
+			"curl": {Spec: projectconfig.SpecSource{SourceType: projectconfig.SpecSourceTypeUpstream}},
+		}
+
+		store := lockfile.NewStore(memFS, testLockDir)
+
+		pruned, err := store.PruneOrphans(components)
+		require.NoError(t, err)
+		assert.Equal(t, 0, pruned)
+
+		exists, existsErr := lockfile.Exists(memFS, mustLockPath(t, "curl"))
+		require.NoError(t, existsErr)
+		assert.True(t, exists)
+	})
+
+	t.Run("unspecified source type is not orphan", func(t *testing.T) {
+		memFS := afero.NewMemMapFs()
+
+		lock := lockfile.New()
+		lock.UpstreamCommit = testCommitHash
+
+		require.NoError(t, lock.Save(memFS, mustLockPath(t, "curl")))
+
+		// Unspecified source type (empty) = inherits upstream from defaults.
+		components := map[string]projectconfig.ComponentConfig{
+			"curl": {},
+		}
+
+		_, orphans, err := lockfile.ValidateConsistency(memFS, testLockDir, components, true)
+		require.NoError(t, err)
+		assert.Empty(t, orphans)
+	})
+}
+
+// Regression: orphan detection must be scoped by checkOrphans flag.
+// Without this, a filtered command like "build curl" on a project with 200
+// components would report 199 locks as orphans and fail.
+func TestValidateConsistency_FilteredSetSkipsOrphans(t *testing.T) {
+	memFS := afero.NewMemMapFs()
+
+	// Create locks for curl and bash.
+	for _, name := range []string{"curl", "bash"} {
+		lock := lockfile.New()
+		lock.UpstreamCommit = testCommitHash
+
+		require.NoError(t, lock.Save(memFS, mustLockPath(t, name)))
+	}
+
+	// Validate only curl (filtered). bash's lock should NOT be an orphan.
+	filteredComponents := map[string]projectconfig.ComponentConfig{
+		"curl": {Spec: projectconfig.SpecSource{SourceType: projectconfig.SpecSourceTypeUpstream}},
+	}
+
+	stale, orphans, err := lockfile.ValidateConsistency(memFS, testLockDir, filteredComponents, false)
+	require.NoError(t, err)
+	assert.Empty(t, stale)
+	assert.Empty(t, orphans, "orphan detection should be skipped on filtered commands")
+
+	// Same call with checkOrphans=true WOULD report bash as orphan.
+	_, orphansAll, errAll := lockfile.ValidateConsistency(memFS, testLockDir, filteredComponents, true)
+	require.Error(t, errAll)
+	assert.Contains(t, orphansAll, "bash")
+}
+
+// Regression: PruneOrphans with an empty component map must not delete locks
+// that belong to real components. Protects against "update -a" on a
+// misconfigured project wiping the entire locks/ directory.
+func TestStorePruneOrphans_EmptyMapDeletesAll(t *testing.T) {
+	memFS := afero.NewMemMapFs()
+	store := lockfile.NewStore(memFS, testLockDir)
+
+	// Create a lock for curl.
+	lock := lockfile.New()
+	lock.UpstreamCommit = testCommitHash
+
+	require.NoError(t, lock.Save(memFS, mustLockPath(t, "curl")))
+
+	// Pruning with an empty map classifies everything as orphan.
+	// Callers (update.go) must guard against this; the store itself
+	// does what it's told. This test documents the behavior.
+	pruned, err := store.PruneOrphans(map[string]projectconfig.ComponentConfig{})
+	require.NoError(t, err)
+	assert.Equal(t, 1, pruned, "empty map causes all locks to be pruned — caller must guard")
+}
+
+// Regression: FindOrphanLockFiles must propagate real I/O errors instead of
+// silently returning no orphans.
+func TestFindOrphanLockFiles_MissingDirIsNotError(t *testing.T) {
+	memFS := afero.NewMemMapFs()
+
+	// No locks directory exists at all.
+	orphans, err := lockfile.FindOrphanLockFiles(memFS, "/nonexistent/locks", nil)
+	require.NoError(t, err)
+	assert.Empty(t, orphans)
+}
+
+// Regression: FindOrphanLockFiles should propagate errors when the directory
+// exists but cannot be read. We approximate this by verifying the error path
+// is exercised — afero.MemMapFs doesn't support permission errors, so we
+// verify the "dir exists" path works correctly.
+func TestFindOrphanLockFiles_EmptyDirNoOrphans(t *testing.T) {
+	memFS := afero.NewMemMapFs()
+	require.NoError(t, fileutils.MkdirAll(memFS, testLockDir))
+
+	orphans, err := lockfile.FindOrphanLockFiles(memFS, testLockDir, nil)
+	require.NoError(t, err)
+	assert.Empty(t, orphans)
+}
+
+// Regression: corrupt lock files (bad TOML) must surface errors from Get and
+// GetOrNew so callers (e.g., update) treat them as failures — we never silently
+// overwrite because import-commit data would be lost. Save can still overwrite
+// if the user manually fixes the situation.
+func TestStoreGet_CorruptLockReturnsError(t *testing.T) {
+	memFS := afero.NewMemMapFs()
+	store := lockfile.NewStore(memFS, testLockDir)
+
+	// Write garbage to a lock file.
+	lockPath := filepath.Join(testLockDir, "corrupt.lock")
+	require.NoError(t, fileutils.MkdirAll(memFS, testLockDir))
+	require.NoError(t, fileutils.WriteFile(memFS, lockPath, []byte("not valid toml {{{{"), fileperms.PublicFile))
+
+	// Get should fail.
+	_, err := store.Get("corrupt")
+	require.Error(t, err, "corrupt lock should return an error from Get")
+
+	// GetOrNew should also fail (exists but unreadable = error, not new).
+	_, err = store.GetOrNew("corrupt")
+	require.Error(t, err, "corrupt lock should return an error from GetOrNew")
+
+	// But Save should overwrite it successfully.
+	newLock := lockfile.New()
+	newLock.UpstreamCommit = "fixed"
+
+	require.NoError(t, store.Save("corrupt", newLock))
+
+	// Now Get should work.
+	loaded, err := store.Get("corrupt")
+	require.NoError(t, err)
+	assert.Equal(t, "fixed", loaded.UpstreamCommit)
+}
+
+func TestValidateAndSuggestFixes(t *testing.T) {
+	t.Run("no issues no suggestion", func(t *testing.T) {
+		memFS := afero.NewMemMapFs()
+		store := lockfile.NewStore(memFS, testLockDir)
+
+		lock := lockfile.New()
+		lock.UpstreamCommit = testCommitHash
+
+		require.NoError(t, store.Save("curl", lock))
+
+		components := map[string]projectconfig.ComponentConfig{
+			"curl": {Spec: projectconfig.SpecSource{SourceType: projectconfig.SpecSourceTypeUpstream}},
+		}
+
+		var suggestions []string
+
+		err := store.ValidateAndSuggestFixes(components, false, func(s string) {
+			suggestions = append(suggestions, s)
+		})
+		require.NoError(t, err)
+		assert.Empty(t, suggestions)
+	})
+
+	t.Run("few stale suggests specific update", func(t *testing.T) {
+		memFS := afero.NewMemMapFs()
+		store := lockfile.NewStore(memFS, testLockDir)
+
+		components := map[string]projectconfig.ComponentConfig{
+			"curl": {Spec: projectconfig.SpecSource{SourceType: projectconfig.SpecSourceTypeUpstream}},
+			"bash": {Spec: projectconfig.SpecSource{SourceType: projectconfig.SpecSourceTypeUpstream}},
+		}
+
+		var suggestions []string
+
+		err := store.ValidateAndSuggestFixes(components, false, func(s string) {
+			suggestions = append(suggestions, s)
+		})
+		require.Error(t, err)
+		require.Len(t, suggestions, 1)
+		assert.Contains(t, suggestions[0], "azldev component update")
+		assert.NotContains(t, suggestions[0], "-a")
+	})
+
+	t.Run("orphans suggest update all", func(t *testing.T) {
+		memFS := afero.NewMemMapFs()
+		store := lockfile.NewStore(memFS, testLockDir)
+
+		orphanLock := lockfile.New()
+		orphanLock.UpstreamCommit = "orphan"
+
+		require.NoError(t, store.Save("removed", orphanLock))
+
+		components := map[string]projectconfig.ComponentConfig{}
+
+		var suggestions []string
+
+		err := store.ValidateAndSuggestFixes(components, true, func(s string) {
+			suggestions = append(suggestions, s)
+		})
+		require.Error(t, err)
+		require.Len(t, suggestions, 1)
+		assert.Contains(t, suggestions[0], "update -a")
+	})
 }

--- a/internal/lockfile/store.go
+++ b/internal/lockfile/store.go
@@ -4,10 +4,14 @@
 package lockfile
 
 import (
+	"errors"
 	"fmt"
+	"log/slog"
+	"strings"
 	"sync"
 
 	"github.com/microsoft/azure-linux-dev-tools/internal/global/opctx"
+	"github.com/microsoft/azure-linux-dev-tools/internal/projectconfig"
 )
 
 // LockReader provides read-only access to per-component lock files. Use this
@@ -181,4 +185,92 @@ func (s *Store) Remove(componentName string) error {
 	s.cache.Delete(componentName)
 
 	return nil
+}
+
+// ValidateConsistency checks lock files against the resolved component configs.
+// For each non-local component, verifies a lock file exists and any explicit
+// upstream-commit pin matches. When checkOrphans is true, also detects orphan
+// lock files (only appropriate when validating the full project).
+//
+// Returns sorted lists of components with missing/stale locks and orphan
+// component names. Returns an error if any issues are found.
+func (s *Store) ValidateConsistency(
+	components map[string]projectconfig.ComponentConfig,
+	checkOrphans bool,
+) (missingOrStale, orphans []string, err error) {
+	return ValidateConsistency(s.fs, s.lockDir, components, checkOrphans)
+}
+
+// FindOrphanLockFiles returns component names that have lock files but no
+// corresponding component in the given config map.
+func (s *Store) FindOrphanLockFiles(
+	components map[string]projectconfig.ComponentConfig,
+) ([]string, error) {
+	return FindOrphanLockFiles(s.fs, s.lockDir, components)
+}
+
+// PruneOrphans removes lock files for components that no longer exist in
+// config. Returns the number of files removed and an error if any removals
+// failed. Also evicts pruned entries from the cache.
+func (s *Store) PruneOrphans(
+	components map[string]projectconfig.ComponentConfig,
+) (int, error) {
+	orphans, findErr := s.FindOrphanLockFiles(components)
+	if findErr != nil {
+		return 0, fmt.Errorf("finding orphan lock files:\n%w", findErr)
+	}
+
+	if len(orphans) == 0 {
+		return 0, nil
+	}
+
+	var (
+		pruned int
+		errs   []error
+	)
+
+	for _, componentName := range orphans {
+		slog.Info("Removing orphan lock file", "component", componentName)
+
+		if removeErr := s.Remove(componentName); removeErr != nil {
+			errs = append(errs, fmt.Errorf("removing lock for %#q:\n%w", componentName, removeErr))
+
+			continue
+		}
+
+		pruned++
+	}
+
+	if len(errs) > 0 {
+		return pruned, fmt.Errorf("failed to remove %d orphan lock file(s):\n  %w",
+			len(errs), errors.Join(errs...))
+	}
+
+	return pruned, nil
+}
+
+// ValidateAndSuggestFixes checks consistency and formats fix suggestions.
+// Returns an error if validation fails, with human-readable fix suggestions
+// appended via the addSuggestion callback.
+func (s *Store) ValidateAndSuggestFixes(
+	components map[string]projectconfig.ComponentConfig,
+	checkOrphans bool,
+	addSuggestion func(string),
+) error {
+	const maxIssuesForDetailedSuggestion = 10
+
+	stale, orphans, validateErr := s.ValidateConsistency(components, checkOrphans)
+	if validateErr == nil {
+		return nil
+	}
+
+	if len(orphans) > 0 || len(stale) > maxIssuesForDetailedSuggestion {
+		addSuggestion("run 'azldev component update -a' to fix all lock file issues")
+	} else if len(stale) > 0 {
+		addSuggestion(fmt.Sprintf(
+			"run 'azldev component update %s'",
+			strings.Join(stale, " ")))
+	}
+
+	return validateErr
 }


### PR DESCRIPTION
Add package-level and Store-bound functions for lock file consistency checking:

- ValidateUpstreamCommit: checks a single component's lock against config
- ValidateConsistency: batch validation with optional orphan detection
- FindOrphanLockFiles: detects lock files for removed components
- Store.PruneOrphans: removes orphan lock files with cache eviction
- Store.ValidateAndSuggestFixes: formats actionable fix suggestions

Orphan detection is gated by a checkOrphans parameter so filtered commands (e.g., build curl) don't misfire against unrelated lock files. FindOrphanLockFiles propagates real I/O errors and skips directories and dotfiles.

Comprehensive tests covering valid/missing/stale/orphan/corrupt paths, filtered vs full validation, empty-map prune behavior, and suggestion formatting.

<!--
PR Title must follow Conventional Commits format. Available types:

- feat: A new feature
- fix: A bug fix
- docs: Documentation only changes
- style: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
- refactor: A code change that neither fixes a bug nor adds a feature
- perf: A code change that improves performance
- test: Adding missing tests or correcting existing tests
- build: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
- ci: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
- chore: Other changes that don't modify src or test files
- revert: Reverts a previous commit

Reference: https://www.conventionalcommits.org/en/v1.0.0/
-->
