### PR TITLE
feat(dist-git): Construct dist-git with lock file history

### DIFF
--- a/internal/app/azldev/cmds/component/build.go
+++ b/internal/app/azldev/cmds/component/build.go
@@ -253,7 +253,7 @@ func BuildComponent(
 
 	var preparerOpts []sources.PreparerOption
 	if options.WithGitRepo {
-		preparerOpts = append(preparerOpts, sources.WithGitRepo(env.Config().Project.DefaultAuthorEmail))
+		preparerOpts = append(preparerOpts, sources.WithGitRepo(env))
 	}
 
 	sourcePreparer, err := sources.NewPreparer(sourceManager, env.FS(), env, env, preparerOpts...)

--- a/internal/app/azldev/cmds/component/build.go
+++ b/internal/app/azldev/cmds/component/build.go
@@ -253,7 +253,7 @@ func BuildComponent(
 
 	var preparerOpts []sources.PreparerOption
 	if options.WithGitRepo {
-		preparerOpts = append(preparerOpts, sources.WithGitRepo(env))
+		preparerOpts = append(preparerOpts, sources.WithGitRepo(env, relativeLockDir(env)))
 	}
 
 	sourcePreparer, err := sources.NewPreparer(sourceManager, env.FS(), env, env, preparerOpts...)

--- a/internal/app/azldev/cmds/component/build.go
+++ b/internal/app/azldev/cmds/component/build.go
@@ -253,7 +253,7 @@ func BuildComponent(
 
 	var preparerOpts []sources.PreparerOption
 	if options.WithGitRepo {
-		preparerOpts = append(preparerOpts, sources.WithGitRepo(env, relativeLockDir(env)))
+		preparerOpts = append(preparerOpts, sources.WithGitRepo(env, env.LockReader()))
 	}
 
 	sourcePreparer, err := sources.NewPreparer(sourceManager, env.FS(), env, env, preparerOpts...)

--- a/internal/app/azldev/cmds/component/component.go
+++ b/internal/app/azldev/cmds/component/component.go
@@ -4,10 +4,7 @@
 package component
 
 import (
-	"path/filepath"
-
 	"github.com/microsoft/azure-linux-dev-tools/internal/app/azldev"
-	"github.com/microsoft/azure-linux-dev-tools/internal/lockfile"
 	"github.com/spf13/cobra"
 )
 
@@ -34,17 +31,4 @@ components defined in the project configuration.`,
 	queryOnAppInit(app, cmd)
 	renderOnAppInit(app, cmd)
 	updateOnAppInit(app, cmd)
-}
-
-// relativeLockDir returns the lock file directory relative to the project
-// repository root. Uses the configured 'lock-dir' from the project config
-// if set, falling back to the default [lockfile.LockDir].
-func relativeLockDir(env *azldev.Env) string {
-	if cfg := env.Config(); cfg != nil && cfg.Project.LockDir != "" {
-		if rel, err := filepath.Rel(env.ProjectDir(), cfg.Project.LockDir); err == nil {
-			return rel
-		}
-	}
-
-	return lockfile.LockDir
 }

--- a/internal/app/azldev/cmds/component/component.go
+++ b/internal/app/azldev/cmds/component/component.go
@@ -4,7 +4,10 @@
 package component
 
 import (
+	"path/filepath"
+
 	"github.com/microsoft/azure-linux-dev-tools/internal/app/azldev"
+	"github.com/microsoft/azure-linux-dev-tools/internal/lockfile"
 	"github.com/spf13/cobra"
 )
 
@@ -31,4 +34,17 @@ components defined in the project configuration.`,
 	queryOnAppInit(app, cmd)
 	renderOnAppInit(app, cmd)
 	updateOnAppInit(app, cmd)
+}
+
+// relativeLockDir returns the lock file directory relative to the project
+// repository root. Uses the configured 'lock-dir' from the project config
+// if set, falling back to the default [lockfile.LockDir].
+func relativeLockDir(env *azldev.Env) string {
+	if cfg := env.Config(); cfg != nil && cfg.Project.LockDir != "" {
+		if rel, err := filepath.Rel(env.ProjectDir(), cfg.Project.LockDir); err == nil {
+			return rel
+		}
+	}
+
+	return lockfile.LockDir
 }

--- a/internal/app/azldev/cmds/component/preparesources.go
+++ b/internal/app/azldev/cmds/component/preparesources.go
@@ -128,7 +128,7 @@ func PrepareComponentSources(env *azldev.Env, options *PrepareSourcesOptions) er
 
 	var preparerOpts []sources.PreparerOption
 	if options.WithGitRepo {
-		preparerOpts = append(preparerOpts, sources.WithGitRepo(env, relativeLockDir(env)))
+		preparerOpts = append(preparerOpts, sources.WithGitRepo(env, env.LockReader()))
 	}
 
 	if options.AllowNoHashes {

--- a/internal/app/azldev/cmds/component/preparesources.go
+++ b/internal/app/azldev/cmds/component/preparesources.go
@@ -128,7 +128,7 @@ func PrepareComponentSources(env *azldev.Env, options *PrepareSourcesOptions) er
 
 	var preparerOpts []sources.PreparerOption
 	if options.WithGitRepo {
-		preparerOpts = append(preparerOpts, sources.WithGitRepo(env.Config().Project.DefaultAuthorEmail))
+		preparerOpts = append(preparerOpts, sources.WithGitRepo(env))
 	}
 
 	if options.AllowNoHashes {

--- a/internal/app/azldev/cmds/component/preparesources.go
+++ b/internal/app/azldev/cmds/component/preparesources.go
@@ -128,7 +128,7 @@ func PrepareComponentSources(env *azldev.Env, options *PrepareSourcesOptions) er
 
 	var preparerOpts []sources.PreparerOption
 	if options.WithGitRepo {
-		preparerOpts = append(preparerOpts, sources.WithGitRepo(env))
+		preparerOpts = append(preparerOpts, sources.WithGitRepo(env, relativeLockDir(env)))
 	}
 
 	if options.AllowNoHashes {

--- a/internal/app/azldev/cmds/component/render.go
+++ b/internal/app/azldev/cmds/component/render.go
@@ -427,7 +427,7 @@ func prepareComponentSources(
 	// WithSkipLookaside avoids expensive tarball downloads — only spec +
 	// sidecar files are needed for rendering.
 	preparerOpts := []sources.PreparerOption{
-		sources.WithGitRepo(env.Config().Project.DefaultAuthorEmail),
+		sources.WithGitRepo(env),
 		sources.WithSkipLookaside(),
 	}
 

--- a/internal/app/azldev/cmds/component/render.go
+++ b/internal/app/azldev/cmds/component/render.go
@@ -427,7 +427,7 @@ func prepareComponentSources(
 	// WithSkipLookaside avoids expensive tarball downloads — only spec +
 	// sidecar files are needed for rendering.
 	preparerOpts := []sources.PreparerOption{
-		sources.WithGitRepo(env),
+		sources.WithGitRepo(env, relativeLockDir(env)),
 		sources.WithSkipLookaside(),
 	}
 

--- a/internal/app/azldev/cmds/component/render.go
+++ b/internal/app/azldev/cmds/component/render.go
@@ -427,7 +427,7 @@ func prepareComponentSources(
 	// WithSkipLookaside avoids expensive tarball downloads — only spec +
 	// sidecar files are needed for rendering.
 	preparerOpts := []sources.PreparerOption{
-		sources.WithGitRepo(env, relativeLockDir(env)),
+		sources.WithGitRepo(env, env.LockReader()),
 		sources.WithSkipLookaside(),
 	}
 

--- a/internal/app/azldev/core/sources/sourceprep.go
+++ b/internal/app/azldev/core/sources/sourceprep.go
@@ -19,6 +19,7 @@ import (
 	"github.com/go-git/go-git/v5/plumbing/object"
 	"github.com/microsoft/azure-linux-dev-tools/internal/app/azldev/core/components"
 	"github.com/microsoft/azure-linux-dev-tools/internal/global/opctx"
+	"github.com/microsoft/azure-linux-dev-tools/internal/lockfile"
 	"github.com/microsoft/azure-linux-dev-tools/internal/projectconfig"
 	"github.com/microsoft/azure-linux-dev-tools/internal/providers/sourceproviders"
 	"github.com/microsoft/azure-linux-dev-tools/internal/providers/sourceproviders/fedorasource"
@@ -64,12 +65,16 @@ type PreparerOption func(*sourcePreparerImpl)
 // Without this option, no dist-git is created and synthetic history is skipped.
 //
 // The cmdFactory is used to shell out to git for fingerprint change detection.
+// The lockDir is the lock file directory relative to the project repository
+// root (e.g. "locks").
 func WithGitRepo(
 	cmdFactory opctx.CmdFactory,
+	lockDir string,
 ) PreparerOption {
 	return func(p *sourcePreparerImpl) {
 		p.withGitRepo = true
 		p.cmdFactory = cmdFactory
+		p.lockDir = lockDir
 	}
 }
 
@@ -122,6 +127,11 @@ type sourcePreparerImpl struct {
 	// cmdFactory is used to shell out to git for fingerprint change detection
 	// in the project repository. Set via [WithGitRepo].
 	cmdFactory opctx.CmdFactory
+
+	// lockDir is the lock file directory relative to the project repository
+	// root. Used to locate lock files for fingerprint change detection in
+	// synthetic history generation. Set via [WithGitRepo].
+	lockDir string
 
 	// allowNoHashes, when true, allows source file references without hash
 	// values. Missing hashes are computed from the downloaded files.
@@ -319,7 +329,7 @@ func (p *sourcePreparerImpl) collectOverlays(
 
 // initSourcesRepo initializes a new git repository in sourcesDirPath, stages all files,
 // and creates an initial commit. This is used for components that don't have an upstream
-// dist-git so that Affects commits can still be layered on top.
+// dist-git so that synthetic commits can still be layered on top.
 func initSourcesRepo(sourcesDirPath string) (*gogit.Repository, error) {
 	slog.Info("Initializing git repository for sources", "path", sourcesDirPath)
 
@@ -365,9 +375,9 @@ func (p *sourcePreparerImpl) trySyntheticHistory(
 	config := component.GetConfig()
 	componentName := component.GetName()
 
-	lockRelPath, err := LockFilePath(componentName)
+	lockRelPath, err := lockfile.LockPath(p.lockDir, componentName)
 	if err != nil {
-		return err
+		return fmt.Errorf("resolving lock file path for %#q:\n%w", componentName, err)
 	}
 
 	// Build commit metadata from lock file fingerprint changes.

--- a/internal/app/azldev/core/sources/sourceprep.go
+++ b/internal/app/azldev/core/sources/sourceprep.go
@@ -63,12 +63,13 @@ type PreparerOption func(*sourcePreparerImpl)
 // requires the project configuration to reside inside a git repository.
 // Without this option, no dist-git is created and synthetic history is skipped.
 //
-// The defaultAuthorEmail is used for synthetic changelog entries and commits
-// when no author email is available from git history.
-func WithGitRepo(defaultAuthorEmail string) PreparerOption {
+// The cmdFactory is used to shell out to git for fingerprint change detection.
+func WithGitRepo(
+	cmdFactory opctx.CmdFactory,
+) PreparerOption {
 	return func(p *sourcePreparerImpl) {
 		p.withGitRepo = true
-		p.defaultAuthorEmail = defaultAuthorEmail
+		p.cmdFactory = cmdFactory
 	}
 }
 
@@ -118,9 +119,9 @@ type sourcePreparerImpl struct {
 	// source preparation. Git-tracked files are still fetched.
 	skipLookaside bool
 
-	// defaultAuthorEmail is the email address used for synthetic changelog
-	// entries and commits when no author email is available from git history.
-	defaultAuthorEmail string
+	// cmdFactory is used to shell out to git for fingerprint change detection
+	// in the project repository. Set via [WithGitRepo].
+	cmdFactory opctx.CmdFactory
 
 	// allowNoHashes, when true, allows source file references without hash
 	// values. Missing hashes are computed from the downloaded files.
@@ -220,7 +221,7 @@ func (p *sourcePreparerImpl) PrepareSources(
 
 	// Record the changes as synthetic git history when dist-git creation is enabled.
 	if p.withGitRepo {
-		if err := p.trySyntheticHistory(component, outputDir); err != nil {
+		if err := p.trySyntheticHistory(ctx, component, outputDir); err != nil {
 			return fmt.Errorf("failed to generate synthetic history for component %#q:\n%w",
 				component.GetName(), err)
 		}
@@ -350,37 +351,46 @@ func initSourcesRepo(sourcesDirPath string) (*gogit.Repository, error) {
 }
 
 // trySyntheticHistory attempts to create synthetic git commits on top of the
-// component's sources directory. If no .git directory exists, one is initialized
-// with an initial commit so Affects commits can be layered on uniformly for all
-// component types.
+// component's sources directory. Synthetic commits are derived from lock file
+// fingerprint changes in the project repository and interleaved into the
+// upstream dist-git history. If no .git directory exists, one is initialized
+// with an initial commit so synthetic commits can be layered on uniformly.
 //
 // Returns a non-nil error if history generation fails.
 func (p *sourcePreparerImpl) trySyntheticHistory(
+	ctx context.Context,
 	component components.Component,
 	sourcesDirPath string,
 ) error {
 	config := component.GetConfig()
+	componentName := component.GetName()
 
-	// Build commit metadata from Affects commits.
-	commits, err := buildSyntheticCommits(config, component.GetName(), p.defaultAuthorEmail)
+	lockRelPath, err := LockFilePath(componentName)
+	if err != nil {
+		return err
+	}
+
+	// Build commit metadata from lock file fingerprint changes.
+	changes, importCommit, err := buildSyntheticCommits(
+		ctx, p.cmdFactory, config, lockRelPath,
+	)
 	if err != nil {
 		return fmt.Errorf("failed to build synthetic commits:\n%w", err)
 	}
 
-	if len(commits) == 0 {
+	if len(changes) == 0 {
 		slog.Debug("No synthetic commits to create; skipping history generation",
-			"component", component.GetName())
+			"component", componentName)
 
 		return nil
 	}
 
 	// Adjust the Release tag before staging changes. See [tryBumpStaticRelease]
 	// for the handling of %autorelease, static integers, and non-standard values.
-	if err := p.tryBumpStaticRelease(component, sourcesDirPath, len(commits)); err != nil {
+	if err := p.tryBumpStaticRelease(component, sourcesDirPath, len(changes)); err != nil {
 		return fmt.Errorf("failed to apply release bump:\n%w", err)
 	}
 
-	// Use os.Stat (not p.fs) because go-git always operates on the real filesystem.
 	gitDirPath := filepath.Join(sourcesDirPath, ".git")
 
 	_, statErr := os.Stat(gitDirPath)
@@ -391,7 +401,7 @@ func (p *sourcePreparerImpl) trySyntheticHistory(
 
 	if os.IsNotExist(statErr) {
 		slog.Info("No .git directory in sources; initializing repository",
-			"component", component.GetName())
+			"component", componentName)
 
 		if _, err := initSourcesRepo(sourcesDirPath); err != nil {
 			return fmt.Errorf("failed to initialize sources repository:\n%w", err)
@@ -404,7 +414,7 @@ func (p *sourcePreparerImpl) trySyntheticHistory(
 		return fmt.Errorf("failed to open sources repository at %#q:\n%w", sourcesDirPath, err)
 	}
 
-	if err := CommitSyntheticHistory(sourcesRepo, commits); err != nil {
+	if err := CommitInterleavedHistory(sourcesRepo, changes, importCommit); err != nil {
 		return fmt.Errorf("failed to commit synthetic history:\n%w", err)
 	}
 

--- a/internal/app/azldev/core/sources/sourceprep.go
+++ b/internal/app/azldev/core/sources/sourceprep.go
@@ -65,16 +65,15 @@ type PreparerOption func(*sourcePreparerImpl)
 // Without this option, no dist-git is created and synthetic history is skipped.
 //
 // The cmdFactory is used to shell out to git for fingerprint change detection.
-// The lockDir is the lock file directory relative to the project repository
-// root (e.g. "locks").
+// The lockReader provides access to per-component lock files and their directory.
 func WithGitRepo(
 	cmdFactory opctx.CmdFactory,
-	lockDir string,
+	lockReader lockfile.LockReader,
 ) PreparerOption {
 	return func(p *sourcePreparerImpl) {
 		p.withGitRepo = true
 		p.cmdFactory = cmdFactory
-		p.lockDir = lockDir
+		p.lockReader = lockReader
 	}
 }
 
@@ -128,10 +127,9 @@ type sourcePreparerImpl struct {
 	// in the project repository. Set via [WithGitRepo].
 	cmdFactory opctx.CmdFactory
 
-	// lockDir is the lock file directory relative to the project repository
-	// root. Used to locate lock files for fingerprint change detection in
-	// synthetic history generation. Set via [WithGitRepo].
-	lockDir string
+	// lockReader provides access to per-component lock files and their
+	// directory path. Set via [WithGitRepo].
+	lockReader lockfile.LockReader
 
 	// allowNoHashes, when true, allows source file references without hash
 	// values. Missing hashes are computed from the downloaded files.
@@ -375,14 +373,9 @@ func (p *sourcePreparerImpl) trySyntheticHistory(
 	config := component.GetConfig()
 	componentName := component.GetName()
 
-	lockRelPath, err := lockfile.LockPath(p.lockDir, componentName)
-	if err != nil {
-		return fmt.Errorf("resolving lock file path for %#q:\n%w", componentName, err)
-	}
-
 	// Build commit metadata from lock file fingerprint changes.
 	changes, importCommit, err := buildSyntheticCommits(
-		ctx, p.cmdFactory, config, lockRelPath,
+		ctx, p.cmdFactory, config, componentName, p.lockReader.LockDir(),
 	)
 	if err != nil {
 		return fmt.Errorf("failed to build synthetic commits:\n%w", err)

--- a/internal/app/azldev/core/sources/synthistory.go
+++ b/internal/app/azldev/core/sources/synthistory.go
@@ -8,6 +8,7 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"os"
 	"path/filepath"
 	"slices"
 	"strings"
@@ -18,10 +19,9 @@ import (
 	"github.com/go-git/go-git/v5/plumbing/object"
 	"github.com/go-git/go-git/v5/plumbing/storer"
 	"github.com/microsoft/azure-linux-dev-tools/internal/global/opctx"
+	"github.com/microsoft/azure-linux-dev-tools/internal/lockfile"
 	"github.com/microsoft/azure-linux-dev-tools/internal/projectconfig"
-	"github.com/microsoft/azure-linux-dev-tools/internal/utils/fileutils"
 	"github.com/microsoft/azure-linux-dev-tools/internal/utils/git"
-	toml "github.com/pelletier/go-toml/v2"
 )
 
 // CommitMetadata holds full metadata for a commit in the project repository.
@@ -51,30 +51,6 @@ type interleavedEntry struct {
 	syntheticChange *FingerprintChange
 }
 
-// LockFilePath returns the relative path to a component's lock file within the
-// project repository. The path follows the same letter-prefix convention used by
-// [components.RenderedSpecDir]: specs/<letter>/<name>/<name>.lock.
-// Returns an error if componentName is unsafe (absolute, contains path separators
-// or traversal sequences).
-func LockFilePath(componentName string) (string, error) {
-	if err := fileutils.ValidateFilename(componentName); err != nil {
-		return "", fmt.Errorf("invalid component name for lock file path:\n%w", err)
-	}
-
-	prefix := strings.ToLower(componentName[:1])
-
-	return filepath.Join("specs", prefix, componentName, componentName+".lock"), nil
-}
-
-// lockFileFields holds the subset of lock file fields needed for fingerprint
-// change detection. This avoids importing the full [lockfile.ComponentLock]
-// struct and decouples the synthetic history logic from lock file versioning.
-type lockFileFields struct {
-	ImportCommit     string `toml:"import-commit"`
-	UpstreamCommit   string `toml:"upstream-commit"`
-	InputFingerprint string `toml:"input-fingerprint"`
-}
-
 // FindFingerprintChanges walks the git log of the project repository for commits
 // that changed the given lock file and returns metadata for each commit where the
 // 'input-fingerprint' field changed. Results are sorted chronologically (oldest
@@ -82,6 +58,7 @@ type lockFileFields struct {
 func FindFingerprintChanges(
 	ctx context.Context,
 	cmdFactory opctx.CmdFactory,
+	projectRepo *gogit.Repository,
 	projectRepoDir string,
 	lockFileRelPath string,
 ) ([]FingerprintChange, error) {
@@ -95,24 +72,21 @@ func FindFingerprintChanges(
 		return nil, nil
 	}
 
-	// Pair each commit's metadata with its lock file fields.
+	// Pair each commit's metadata with its lock file contents.
 	type entry struct {
-		fields lockFileFields
-		meta   CommitMetadata
+		lock lockfile.ComponentLock
+		meta CommitMetadata
 	}
 
 	var entries []entry //nolint:prealloc // size not known ahead of time.
 
 	for _, meta := range metas {
-		fields, err := gitShowLockFile(ctx, cmdFactory, projectRepoDir, meta.Hash, lockFileRelPath)
+		lock, err := showLockFileAtCommit(projectRepo, meta.Hash, lockFileRelPath)
 		if err != nil {
-			slog.Warn("Failed to read lock file at commit; skipping",
-				"commit", meta.Hash, "error", err)
-
-			continue
+			return nil, fmt.Errorf("failed to read lock file at commit %#q:\n%w", meta.Hash, err)
 		}
 
-		entries = append(entries, entry{fields: fields, meta: meta})
+		entries = append(entries, entry{lock: lock, meta: meta})
 	}
 
 	if len(entries) == 0 {
@@ -128,14 +102,14 @@ func FindFingerprintChanges(
 	prevFingerprint := ""
 
 	for _, change := range entries {
-		if change.fields.InputFingerprint != prevFingerprint {
+		if change.lock.InputFingerprint != prevFingerprint {
 			changes = append(changes, FingerprintChange{
 				CommitMetadata: change.meta,
-				UpstreamCommit: change.fields.UpstreamCommit,
+				UpstreamCommit: change.lock.UpstreamCommit,
 			})
 		}
 
-		prevFingerprint = change.fields.InputFingerprint
+		prevFingerprint = change.lock.InputFingerprint
 	}
 
 	return changes, nil
@@ -215,8 +189,10 @@ func stageAndCaptureOverlayTree(repo *gogit.Repository) (plumbing.Hash, error) {
 // buildInterleavedSequence produces the full commit sequence for the rebuilt
 // history. Upstream commits appear in chronological order; synthetic commits
 // that reference an older upstream are inserted directly after it. Synthetic
-// commits referencing the latest upstream are appended at the end. Orphaned
-// commits whose upstream is not found in the dist-git history are dropped.
+// commits referencing the latest upstream are appended at the end.
+// Changes with no upstream commit (local components) are always placed on top.
+// Orphaned commits whose non-empty upstream is not found in the dist-git
+// history are dropped with a warning.
 func buildInterleavedSequence(
 	upstreamCommits []*object.Commit,
 	changes []FingerprintChange,
@@ -225,11 +201,16 @@ func buildInterleavedSequence(
 
 	var interleaved, top []FingerprintChange
 
-	for i := range changes {
-		if changes[i].UpstreamCommit == latestUpstream {
-			top = append(top, changes[i])
-		} else {
-			interleaved = append(interleaved, changes[i])
+	for idx := range changes {
+		switch changes[idx].UpstreamCommit {
+		case "":
+			// Local component changes have no upstream commit reference.
+			// Always place them on top of the history.
+			top = append(top, changes[idx])
+		case latestUpstream:
+			top = append(top, changes[idx])
+		default:
+			interleaved = append(interleaved, changes[idx])
 		}
 	}
 
@@ -258,8 +239,8 @@ func buildInterleavedSequence(
 		}
 	}
 
-	// Orphaned changes whose upstream-commit wasn't found are dropped —
-	// they reference an upstream commit outside the known dist-git history.
+	// Remaining interleaved changes reference upstream commits not found in
+	// the dist-git history — drop them with a warning. Will be useful for when we switch branches.
 	for hash, orphaned := range interleavedByUpstream {
 		slog.Warn("Upstream commit referenced by fingerprint change not found in dist-git history; "+
 			"dropping",
@@ -483,31 +464,61 @@ func buildSyntheticCommits(
 
 	configFilePath := config.SourceConfigFile.SourcePath()
 
-	projectRepoDir, err := git.RunInDir(ctx, cmdFactory, filepath.Dir(configFilePath), "rev-parse", "--show-toplevel")
+	// Open the project repository by walking up from the config file directory.
+	projectRepo, err := gogit.PlainOpenWithOptions(
+		filepath.Dir(configFilePath),
+		&gogit.PlainOpenOptions{DetectDotGit: true},
+	)
 	if err != nil {
 		return nil, "", fmt.Errorf("failed to find project repository for config file %#q:\n%w",
 			configFilePath, err)
 	}
 
 	// Read the current lock file at HEAD to get the import-commit boundary.
-	headHash, err := gitHeadHash(ctx, cmdFactory, projectRepoDir)
+	head, err := projectRepo.Head()
 	if err != nil {
-		return nil, "", fmt.Errorf("failed to get HEAD hash:\n%w", err)
+		return nil, "", fmt.Errorf("failed to get HEAD:\n%w", err)
 	}
 
-	// If no lock file exists, the component has no overlays — the dist-git
-	// is just the upstream as-is, so no synthetic commits are needed.
-	headFields, lockFileErr := gitShowLockFile(ctx, cmdFactory, projectRepoDir, headHash, lockFileRelPath)
+	// Read the lock file at HEAD. Distinguish "path does not exist in the
+	// commit tree" (file-not-found) from real failures such as TOML parse
+	// errors or unexpected git object errors — only the former is tolerated.
+	headLock, lockFileErr := showLockFileAtCommit(projectRepo, head.Hash().String(), lockFileRelPath)
 	if lockFileErr != nil {
+		// Real errors (parse failures, git object errors, etc.) are always fatal.
+		if !errors.Is(lockFileErr, object.ErrFileNotFound) {
+			return nil, "", fmt.Errorf("failed to read lock file %#q at HEAD:\n%w",
+				lockFileRelPath, lockFileErr)
+		}
+
+		// File genuinely missing — the component has no overlays, so the
+		// dist-git is just the upstream as-is and no synthetic commits
+		// are needed.
+		//nolint:godox // tracked by TODO(lockfiles) tag.
+		// TODO(lockfiles): remove env var gate and make this a hard error unconditionally.
+		if os.Getenv("AZLDEV_ENABLE_LOCK_VALIDATION") == "1" {
+			return nil, "", fmt.Errorf("lock file %#q not found at HEAD:\n%w",
+				lockFileRelPath, lockFileErr)
+		}
+
 		slog.Debug("No lock file found at HEAD; skipping synthetic history",
 			"lockFile", lockFileRelPath, "error", lockFileErr)
 
 		return nil, "", nil
 	}
 
-	importCommit = headFields.ImportCommit
+	importCommit = headLock.ImportCommit
 
-	fpChanges, err := FindFingerprintChanges(ctx, cmdFactory, projectRepoDir, lockFileRelPath)
+	// Resolve the worktree root for git CLI operations that still need a
+	// directory path (gitLogFileMetadata uses git log with path filtering).
+	worktree, err := projectRepo.Worktree()
+	if err != nil {
+		return nil, "", fmt.Errorf("failed to get project worktree:\n%w", err)
+	}
+
+	projectRepoDir := worktree.Filesystem.Root()
+
+	fpChanges, err := FindFingerprintChanges(ctx, cmdFactory, projectRepo, projectRepoDir, lockFileRelPath)
 	if err != nil {
 		return nil, "", fmt.Errorf("failed to find fingerprint changes for lock file %#q:\n%w",
 			lockFileRelPath, err)
@@ -590,8 +601,10 @@ func collectUpstreamCommits(
 	}
 
 	if importCommit != "" && !foundImport {
-		slog.Warn("Import-commit not found in dist-git history; using all collected commits",
-			"importCommit", importCommit)
+		return nil, fmt.Errorf(
+			"import-commit %#q not found in dist-git history; "+
+				"the repository may be a shallow clone or the commit may have been rebased away",
+			importCommit)
 	}
 
 	// Walk was newest-first; reverse to chronological.
@@ -608,13 +621,13 @@ func unixToTime(unix int64) time.Time {
 // --- git CLI helpers ---
 
 // gitLogFileMetadata returns commit metadata (newest-first) for all commits
-// that touched the given file path in the repository at repoDir. Each commit's
-// metadata is separated by a NUL byte in the git log output.
+// that touched the given file path in the repository at repoDir. Fields within
+// each record are separated by NUL (\x00); records are separated by SOH (\x01).
 func gitLogFileMetadata(
 	ctx context.Context, cmdFactory opctx.CmdFactory, repoDir, filePath string,
 ) ([]CommitMetadata, error) {
 	output, err := git.RunInDir(ctx, cmdFactory, repoDir,
-		"log", "--format=%H%n%an%n%ae%n%at%n%s%x00", "--", filePath)
+		"log", "--format=%H%x00%an%x00%ae%x00%at%x00%s%x01", "--", filePath)
 	if err != nil {
 		return nil, fmt.Errorf("failed to list commits for %#q:\n%w", filePath, err)
 	}
@@ -623,7 +636,7 @@ func gitLogFileMetadata(
 		return nil, nil
 	}
 
-	blocks := strings.Split(output, "\x00")
+	blocks := strings.Split(output, "\x01")
 
 	var metas []CommitMetadata //nolint:prealloc // trailing empty block after split.
 
@@ -644,63 +657,70 @@ func gitLogFileMetadata(
 	return metas, nil
 }
 
-// gitShowLockFile reads the lock file content at a specific commit and parses
-// the 'upstream-commit' and 'input-fingerprint' TOML fields.
-func gitShowLockFile(
-	ctx context.Context, cmdFactory opctx.CmdFactory,
-	repoDir, commitHash, lockFileRelPath string,
-) (lockFileFields, error) {
-	ref := commitHash + ":" + lockFileRelPath
+// showLockFileAtCommit reads the lock file content at a specific commit hash
+// using go-git and parses it into a [lockfile.ComponentLock].
+func showLockFileAtCommit(
+	repo *gogit.Repository,
+	commitHash, lockFileRelPath string,
+) (lockfile.ComponentLock, error) {
+	hash := plumbing.NewHash(commitHash)
 
-	output, err := git.RunInDir(ctx, cmdFactory, repoDir, "show", ref)
+	commitObj, err := repo.CommitObject(hash)
 	if err != nil {
-		return lockFileFields{}, fmt.Errorf("failed to read lock file at %#q:\n%w", ref, err)
+		return lockfile.ComponentLock{}, fmt.Errorf("failed to resolve commit %#q:\n%w", commitHash, err)
 	}
 
-	var fields lockFileFields
-	if err := toml.Unmarshal([]byte(output), &fields); err != nil {
-		return lockFileFields{}, fmt.Errorf("failed to parse lock file at %#q:\n%w", ref, err)
+	tree, err := commitObj.Tree()
+	if err != nil {
+		return lockfile.ComponentLock{}, fmt.Errorf("failed to get tree for commit %#q:\n%w", commitHash, err)
 	}
 
-	return fields, nil
+	file, err := tree.File(lockFileRelPath)
+	if err != nil {
+		return lockfile.ComponentLock{}, fmt.Errorf("failed to read %#q at commit %#q:\n%w",
+			lockFileRelPath, commitHash, err)
+	}
+
+	content, err := file.Contents()
+	if err != nil {
+		return lockfile.ComponentLock{}, fmt.Errorf("failed to read contents of %#q at commit %#q:\n%w",
+			lockFileRelPath, commitHash, err)
+	}
+
+	lock, err := lockfile.Parse([]byte(content))
+	if err != nil {
+		return lockfile.ComponentLock{}, fmt.Errorf("failed to parse lock file %#q at commit %#q:\n%w",
+			lockFileRelPath, commitHash, err)
+	}
+
+	return *lock, nil
 }
 
-// commitMetadataFieldCount is the number of fields expected in the output of
-// 'git log -1 --format=%H%n%an%n%ae%n%at%n%s'.
+// commitMetadataFieldCount is the number of NUL-separated fields expected in
+// a single commit record produced by 'git log --format=%H%x00%an%x00%ae%x00%at%x00%s'.
 const commitMetadataFieldCount = 5
 
-// ParseCommitMetadata parses the output of 'git log -1 --format=%H%n%an%n%ae%n%at%n%s'.
+// ParseCommitMetadata parses a single NUL-delimited commit record produced by
+// 'git log --format=%H%x00%an%x00%ae%x00%at%x00%s'.
 func ParseCommitMetadata(output string) (CommitMetadata, error) {
-	lines := strings.SplitN(strings.TrimSpace(output), "\n", commitMetadataFieldCount)
+	fields := strings.SplitN(output, "\x00", commitMetadataFieldCount)
 
-	if len(lines) < commitMetadataFieldCount {
+	if len(fields) < commitMetadataFieldCount {
 		return CommitMetadata{}, fmt.Errorf(
-			"unexpected git log output (expected %d lines, got %d):\n%v",
-			commitMetadataFieldCount, len(lines), output)
+			"unexpected git log output (expected %d fields, got %d):\n%v",
+			commitMetadataFieldCount, len(fields), output)
 	}
 
 	var timestamp int64
-	if _, err := fmt.Sscanf(lines[3], "%d", &timestamp); err != nil {
-		return CommitMetadata{}, fmt.Errorf("failed to parse timestamp %#q:\n%w", lines[3], err)
+	if _, err := fmt.Sscanf(fields[3], "%d", &timestamp); err != nil {
+		return CommitMetadata{}, fmt.Errorf("failed to parse timestamp %#q:\n%w", fields[3], err)
 	}
 
 	return CommitMetadata{
-		Hash:        lines[0],
-		Author:      lines[1],
-		AuthorEmail: lines[2],
+		Hash:        fields[0],
+		Author:      fields[1],
+		AuthorEmail: fields[2],
 		Timestamp:   timestamp,
-		Message:     lines[4],
+		Message:     fields[4],
 	}, nil
-}
-
-// gitHeadHash returns the HEAD commit hash of the repository at repoDir.
-func gitHeadHash(
-	ctx context.Context, cmdFactory opctx.CmdFactory, repoDir string,
-) (string, error) {
-	hash, err := git.RunInDir(ctx, cmdFactory, repoDir, "rev-parse", "HEAD")
-	if err != nil {
-		return "", fmt.Errorf("failed to resolve HEAD in %#q:\n%w", repoDir, err)
-	}
-
-	return hash, nil
 }

--- a/internal/app/azldev/core/sources/synthistory.go
+++ b/internal/app/azldev/core/sources/synthistory.go
@@ -130,7 +130,7 @@ func CommitInterleavedHistory(
 ) error {
 	// No changes means no synthetic commits to create, so skip the whole process.
 	if len(changes) == 0 {
-		return errors.New("no fingerprint changes to commit")
+		return nil
 	}
 
 	// The latest fingerprint change's UpstreamCommit is the commit we're
@@ -449,74 +449,49 @@ func updateHead(repo *gogit.Repository, commitHash plumbing.Hash) error {
 // Returns an error if the lock file exists but has no fingerprint changes.
 // The second return value is the import-commit hash from the lock file, used
 // to scope the upstream commit walk in [CommitInterleavedHistory].
+//
+// The lockDir is the absolute path to the lock file directory. It is converted
+// to a repo-relative path internally once the git repository root is known.
 func buildSyntheticCommits(
 	ctx context.Context,
 	cmdFactory opctx.CmdFactory,
 	config *projectconfig.ComponentConfig,
-	lockFileRelPath string,
+	componentName string,
+	lockDir string,
 ) (changes []FingerprintChange, importCommit string, err error) {
-	if config.SourceConfigFile == nil || config.SourceConfigFile.SourcePath() == "" {
-		slog.Debug("Cannot resolve config file for synthetic commits; skipping",
-			"lockFile", lockFileRelPath)
+	projectRepo, projectRepoDir, err := openProjectRepo(config, componentName)
+	if err != nil {
+		return nil, "", err
+	}
 
+	if projectRepo == nil {
 		return nil, "", nil
 	}
 
-	configFilePath := config.SourceConfigFile.SourcePath()
-
-	// Open the project repository by walking up from the config file directory.
-	projectRepo, err := gogit.PlainOpenWithOptions(
-		filepath.Dir(configFilePath),
-		&gogit.PlainOpenOptions{DetectDotGit: true},
-	)
+	// Compute the lock file path relative to the git repository root.
+	lockFileAbsPath, err := lockfile.LockPath(lockDir, componentName)
 	if err != nil {
-		return nil, "", fmt.Errorf("failed to find project repository for config file %#q:\n%w",
-			configFilePath, err)
+		return nil, "", fmt.Errorf("resolving lock file path for %#q:\n%w", componentName, err)
 	}
 
-	// Read the current lock file at HEAD to get the import-commit boundary.
-	head, err := projectRepo.Head()
+	lockFileRelPath, err := filepath.Rel(projectRepoDir, lockFileAbsPath)
 	if err != nil {
-		return nil, "", fmt.Errorf("failed to get HEAD:\n%w", err)
+		return nil, "", fmt.Errorf("failed to compute repo-relative lock path for %#q:\n%w",
+			lockFileAbsPath, err)
 	}
 
-	// Read the lock file at HEAD. Distinguish "path does not exist in the
-	// commit tree" (file-not-found) from real failures such as TOML parse
-	// errors or unexpected git object errors — only the former is tolerated.
-	headLock, lockFileErr := showLockFileAtCommit(projectRepo, head.Hash().String(), lockFileRelPath)
-	if lockFileErr != nil {
-		// Real errors (parse failures, git object errors, etc.) are always fatal.
-		if !errors.Is(lockFileErr, object.ErrFileNotFound) {
-			return nil, "", fmt.Errorf("failed to read lock file %#q at HEAD:\n%w",
-				lockFileRelPath, lockFileErr)
-		}
+	// Read the lock file at HEAD. If the file is missing (not yet committed),
+	// synthetic history is skipped.
+	headLock, err := readLockFileAtHEAD(projectRepo, lockFileRelPath)
+	if err != nil {
+		return nil, "", err
+	}
 
-		// File genuinely missing — the component has no overlays, so the
-		// dist-git is just the upstream as-is and no synthetic commits
-		// are needed.
-		//nolint:godox // tracked by TODO(lockfiles) tag.
-		// TODO(lockfiles): remove env var gate and make this a hard error unconditionally.
-		if os.Getenv("AZLDEV_ENABLE_LOCK_VALIDATION") == "1" {
-			return nil, "", fmt.Errorf("lock file %#q not found at HEAD:\n%w",
-				lockFileRelPath, lockFileErr)
-		}
-
-		slog.Debug("No lock file found at HEAD; skipping synthetic history",
-			"lockFile", lockFileRelPath, "error", lockFileErr)
-
+	if headLock == nil {
 		return nil, "", nil
 	}
 
 	importCommit = headLock.ImportCommit
-
-	// Resolve the worktree root for git CLI operations that still need a
-	// directory path (gitLogFileMetadata uses git log with path filtering).
-	worktree, err := projectRepo.Worktree()
-	if err != nil {
-		return nil, "", fmt.Errorf("failed to get project worktree:\n%w", err)
-	}
-
-	projectRepoDir := worktree.Filesystem.Root()
 
 	fpChanges, err := FindFingerprintChanges(ctx, cmdFactory, projectRepo, projectRepoDir, lockFileRelPath)
 	if err != nil {
@@ -525,10 +500,19 @@ func buildSyntheticCommits(
 	}
 
 	if len(fpChanges) == 0 {
-		return nil, "", fmt.Errorf(
-			"lock file %#q exists but has no fingerprint changes; "+
-				"this indicates a corrupt or empty lock file history",
-			lockFileRelPath)
+		// In a shallow clone the commit that added the lock file may have
+		// been pruned, so check explicitly.
+		shallowCommits, _ := projectRepo.Storer.Shallow()
+		if len(shallowCommits) > 0 {
+			return nil, "", fmt.Errorf(
+				"lock file %#q has no git history; a full clone is required",
+				lockFileRelPath)
+		}
+
+		slog.Warn("Lock file has no fingerprint changes; skipping synthetic history",
+			"lockFile", lockFileRelPath)
+
+		return nil, "", nil
 	}
 
 	slog.Info("Found fingerprint changes",
@@ -536,6 +520,83 @@ func buildSyntheticCommits(
 		"changeCount", len(fpChanges))
 
 	return fpChanges, importCommit, nil
+}
+
+// openProjectRepo opens the git repository that contains the component's
+// config file and returns both the [gogit.Repository] and the worktree root
+// directory. Returns (nil, "", nil) when the config file path cannot be
+// resolved, indicating that synthetic commits should be skipped.
+func openProjectRepo(
+	config *projectconfig.ComponentConfig,
+	componentName string,
+) (*gogit.Repository, string, error) {
+	if config.SourceConfigFile == nil || config.SourceConfigFile.SourcePath() == "" {
+		slog.Debug("Cannot resolve config file for synthetic commits; skipping",
+			"component", componentName)
+
+		return nil, "", nil
+	}
+
+	configFilePath := config.SourceConfigFile.SourcePath()
+
+	repo, err := gogit.PlainOpenWithOptions(
+		filepath.Dir(configFilePath),
+		&gogit.PlainOpenOptions{DetectDotGit: true},
+	)
+	if err != nil {
+		return nil, "", fmt.Errorf("failed to find project repository for config file %#q:\n%w",
+			configFilePath, err)
+	}
+
+	worktree, err := repo.Worktree()
+	if err != nil {
+		return nil, "", fmt.Errorf("failed to get project worktree:\n%w", err)
+	}
+
+	return repo, worktree.Filesystem.Root(), nil
+}
+
+// readLockFileAtHEAD reads the lock file at the repository's HEAD commit.
+// Returns nil (without error) when the lock file or its parent directory does
+// not exist in the commit tree — this is the normal case for components that
+// have never had overlays. Returns a non-nil error for real failures (TOML
+// parse errors, unexpected git object errors, etc.).
+func readLockFileAtHEAD(
+	repo *gogit.Repository,
+	lockFileRelPath string,
+) (*lockfile.ComponentLock, error) {
+	head, err := repo.Head()
+	if err != nil {
+		return nil, fmt.Errorf("failed to get HEAD:\n%w", err)
+	}
+
+	headLock, lockFileErr := showLockFileAtCommit(repo, head.Hash().String(), lockFileRelPath)
+	if lockFileErr == nil {
+		return &headLock, nil
+	}
+
+	// Tolerate both file-not-found and directory-not-found — the latter
+	// occurs when the locks directory has never been created in the repo.
+	if !errors.Is(lockFileErr, object.ErrFileNotFound) &&
+		!errors.Is(lockFileErr, object.ErrDirectoryNotFound) {
+		return nil, fmt.Errorf("failed to read lock file %#q at HEAD:\n%w",
+			lockFileRelPath, lockFileErr)
+	}
+
+	// File genuinely missing — the component has no overlays, so the
+	// dist-git is just the upstream as-is and no synthetic commits
+	// are needed.
+	//nolint:godox // tracked by TODO(lockfiles) tag.
+	// TODO(lockfiles): remove env var gate and make this a hard error unconditionally.
+	if os.Getenv("AZLDEV_ENABLE_LOCK_VALIDATION") == "1" {
+		return nil, fmt.Errorf("lock file %#q not found at HEAD:\n%w",
+			lockFileRelPath, lockFileErr)
+	}
+
+	slog.Debug("No lock file found at HEAD; skipping synthetic history",
+		"lockFile", lockFileRelPath, "error", lockFileErr)
+
+	return nil, nil //nolint:nilnil // nil,nil signals "not found, skip" to caller.
 }
 
 // collectUpstreamCommits returns commits in the repository in chronological
@@ -623,6 +684,13 @@ func unixToTime(unix int64) time.Time {
 // gitLogFileMetadata returns commit metadata (newest-first) for all commits
 // that touched the given file path in the repository at repoDir. Fields within
 // each record are separated by NUL (\x00); records are separated by SOH (\x01).
+//
+// This shells out to 'git log' rather than using go-git's [gogit.LogOptions]
+// PathFilter because go-git's path filtering walks the entire commit graph
+// in-process, diffing trees at every commit. For large repositories with
+// thousands of commits this is prohibitively slow. The git CLI delegates the
+// work to native C code with bitmap indices and pack-file optimizations,
+// making it orders of magnitude faster for path-scoped log queries.
 func gitLogFileMetadata(
 	ctx context.Context, cmdFactory opctx.CmdFactory, repoDir, filePath string,
 ) ([]CommitMetadata, error) {
@@ -641,7 +709,7 @@ func gitLogFileMetadata(
 	var metas []CommitMetadata //nolint:prealloc // trailing empty block after split.
 
 	for _, block := range blocks {
-		block = strings.TrimSpace(block)
+		block = strings.TrimRight(block, "\r\n")
 		if block == "" {
 			continue
 		}

--- a/internal/app/azldev/core/sources/synthistory.go
+++ b/internal/app/azldev/core/sources/synthistory.go
@@ -4,23 +4,25 @@
 package sources
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"log/slog"
 	"path/filepath"
-	"regexp"
 	"slices"
 	"strings"
 	"time"
 
 	gogit "github.com/go-git/go-git/v5"
+	"github.com/go-git/go-git/v5/plumbing"
 	"github.com/go-git/go-git/v5/plumbing/object"
+	"github.com/go-git/go-git/v5/plumbing/storer"
+	"github.com/microsoft/azure-linux-dev-tools/internal/global/opctx"
 	"github.com/microsoft/azure-linux-dev-tools/internal/projectconfig"
+	"github.com/microsoft/azure-linux-dev-tools/internal/utils/fileutils"
+	"github.com/microsoft/azure-linux-dev-tools/internal/utils/git"
+	toml "github.com/pelletier/go-toml/v2"
 )
-
-// affectsRegexPattern is the regex pattern prefix used to match an "Affects:" trailer
-// line in a commit message. Each line must contain exactly one component name.
-const affectsRegexPattern = `(?m)^[ \t]*Affects:[ \t]*`
 
 // CommitMetadata holds full metadata for a commit in the project repository.
 type CommitMetadata struct {
@@ -31,53 +33,547 @@ type CommitMetadata struct {
 	Message     string
 }
 
-// MessageAffectsComponent reports whether a commit message contains an "Affects:"
-// trailer line naming the given component.
-func MessageAffectsComponent(message, componentName string) bool {
-	re := regexp.MustCompile(affectsRegexPattern + regexp.QuoteMeta(componentName) + `[ \t]*$`)
+// FingerprintChange records a project commit that changed a component's lock file
+// fingerprint. [UpstreamCommit] is the value of the 'upstream-commit' field in the
+// lock file at the point of the change.
+type FingerprintChange struct {
+	CommitMetadata
 
-	return re.MatchString(message)
+	// UpstreamCommit is the upstream dist-git commit hash recorded in the lock
+	// file at the time the fingerprint changed.
+	UpstreamCommit string
 }
 
-// FindAffectsCommits walks the git log from HEAD and returns metadata for all commits
-// whose message contains an "Affects: <componentName>" trailer line. Results are sorted
-// chronologically (oldest first).
-func FindAffectsCommits(repo *gogit.Repository, componentName string) ([]CommitMetadata, error) {
-	// Synthetic history depends on a complete project commit log so Affects
-	// trailers can be discovered reliably.
-	shallowCommits, err := repo.Storer.Shallow()
+// interleavedEntry represents a single commit in the rebuilt dist-git history.
+// Exactly one of upstreamCommit or syntheticChange is non-nil.
+type interleavedEntry struct {
+	upstreamCommit  *object.Commit
+	syntheticChange *FingerprintChange
+}
+
+// LockFilePath returns the relative path to a component's lock file within the
+// project repository. The path follows the same letter-prefix convention used by
+// [components.RenderedSpecDir]: specs/<letter>/<name>/<name>.lock.
+// Returns an error if componentName is unsafe (absolute, contains path separators
+// or traversal sequences).
+func LockFilePath(componentName string) (string, error) {
+	if err := fileutils.ValidateFilename(componentName); err != nil {
+		return "", fmt.Errorf("invalid component name for lock file path:\n%w", err)
+	}
+
+	prefix := strings.ToLower(componentName[:1])
+
+	return filepath.Join("specs", prefix, componentName, componentName+".lock"), nil
+}
+
+// lockFileFields holds the subset of lock file fields needed for fingerprint
+// change detection. This avoids importing the full [lockfile.ComponentLock]
+// struct and decouples the synthetic history logic from lock file versioning.
+type lockFileFields struct {
+	ImportCommit     string `toml:"import-commit"`
+	UpstreamCommit   string `toml:"upstream-commit"`
+	InputFingerprint string `toml:"input-fingerprint"`
+}
+
+// FindFingerprintChanges walks the git log of the project repository for commits
+// that changed the given lock file and returns metadata for each commit where the
+// 'input-fingerprint' field changed. Results are sorted chronologically (oldest
+// first).
+func FindFingerprintChanges(
+	ctx context.Context,
+	cmdFactory opctx.CmdFactory,
+	projectRepoDir string,
+	lockFileRelPath string,
+) ([]FingerprintChange, error) {
+	// Get commit metadata (newest-first) for all commits that touched the lock file.
+	metas, err := gitLogFileMetadata(ctx, cmdFactory, projectRepoDir, lockFileRelPath)
 	if err != nil {
-		return nil, fmt.Errorf("failed to inspect repository history depth:\n%w", err)
+		return nil, err
 	}
 
-	if len(shallowCommits) > 0 {
-		return nil, errors.New(
-			"repository is a shallow clone; synthetic history requires a full clone. " +
-				"Run `git fetch --unshallow` or re-clone without `--depth`",
-		)
+	if len(metas) == 0 {
+		return nil, nil
 	}
 
+	// Pair each commit's metadata with its lock file fields.
+	type entry struct {
+		fields lockFileFields
+		meta   CommitMetadata
+	}
+
+	var entries []entry //nolint:prealloc // size not known ahead of time.
+
+	for _, meta := range metas {
+		fields, err := gitShowLockFile(ctx, cmdFactory, projectRepoDir, meta.Hash, lockFileRelPath)
+		if err != nil {
+			slog.Warn("Failed to read lock file at commit; skipping",
+				"commit", meta.Hash, "error", err)
+
+			continue
+		}
+
+		entries = append(entries, entry{fields: fields, meta: meta})
+	}
+
+	if len(entries) == 0 {
+		return nil, nil
+	}
+
+	// Entries are newest-first (from git log order). Reverse to chronological.
+	slices.Reverse(entries)
+
+	// Walk chronologically and detect fingerprint changes.
+	var changes []FingerprintChange
+
+	prevFingerprint := ""
+
+	for _, change := range entries {
+		if change.fields.InputFingerprint != prevFingerprint {
+			changes = append(changes, FingerprintChange{
+				CommitMetadata: change.meta,
+				UpstreamCommit: change.fields.UpstreamCommit,
+			})
+		}
+
+		prevFingerprint = change.fields.InputFingerprint
+	}
+
+	return changes, nil
+}
+
+// CommitInterleavedHistory rebuilds the dist-git history by interleaving
+// synthetic commits with the existing upstream commits. Synthetic commits
+// referencing an older upstream commit are placed directly after that commit;
+// those referencing the latest upstream commit are appended on top. The very
+// last synthetic commit carries the overlay file changes; all others are empty.
+//
+// When importCommit is non-empty, only upstream commits from importCommit
+// onward are considered for interleaving.
+func CommitInterleavedHistory(
+	repo *gogit.Repository,
+	changes []FingerprintChange,
+	importCommit string,
+) error {
+	// No changes means no synthetic commits to create, so skip the whole process.
+	if len(changes) == 0 {
+		return errors.New("no fingerprint changes to commit")
+	}
+
+	// The latest fingerprint change's UpstreamCommit is the commit we're
+	// pinned to — use it as the upper bound for the upstream walk instead
+	// of HEAD, which may be ahead (e.g., at the branch tip).
+	upstreamCommit := changes[len(changes)-1].UpstreamCommit
+
+	// Collect upstream commits BEFORE staging, so the temporary commit
+	// created by stageAndCaptureOverlayTree is not included.
+	upstreamCommits, err := collectUpstreamCommits(repo, importCommit, upstreamCommit)
+	if err != nil {
+		return err
+	}
+
+	// Stage overlay changes and capture the resulting tree hash.
+	overlayTreeHash, err := stageAndCaptureOverlayTree(repo)
+	if err != nil {
+		return err
+	}
+
+	// Build the full interleaved sequence of upstream and synthetic commits.
+	sequence := buildInterleavedSequence(upstreamCommits, changes)
+
+	return replayInterleavedHistory(repo, sequence, overlayTreeHash)
+}
+
+// stageAndCaptureOverlayTree stages all working tree changes and creates a
+// temporary commit to capture the resulting tree hash. The tree hash is used
+// later to set the content of the final synthetic commit.
+func stageAndCaptureOverlayTree(repo *gogit.Repository) (plumbing.Hash, error) {
+	worktree, err := repo.Worktree()
+	if err != nil {
+		return plumbing.ZeroHash, fmt.Errorf("failed to get worktree:\n%w", err)
+	}
+
+	if err := worktree.AddWithOptions(&gogit.AddOptions{All: true}); err != nil {
+		return plumbing.ZeroHash, fmt.Errorf("failed to stage changes:\n%w", err)
+	}
+
+	tempHash, err := worktree.Commit("temp: capture overlay tree", &gogit.CommitOptions{
+		AllowEmptyCommits: true,
+		Author:            &object.Signature{Name: "azldev", When: time.Unix(0, 0).UTC()},
+	})
+	if err != nil {
+		return plumbing.ZeroHash, fmt.Errorf("failed to create temporary commit:\n%w", err)
+	}
+
+	tempCommit, err := repo.CommitObject(tempHash)
+	if err != nil {
+		return plumbing.ZeroHash, fmt.Errorf("failed to read temporary commit:\n%w", err)
+	}
+
+	return tempCommit.TreeHash, nil
+}
+
+// buildInterleavedSequence produces the full commit sequence for the rebuilt
+// history. Upstream commits appear in chronological order; synthetic commits
+// that reference an older upstream are inserted directly after it. Synthetic
+// commits referencing the latest upstream are appended at the end. Orphaned
+// commits whose upstream is not found in the dist-git history are dropped.
+func buildInterleavedSequence(
+	upstreamCommits []*object.Commit,
+	changes []FingerprintChange,
+) []interleavedEntry {
+	latestUpstream := changes[len(changes)-1].UpstreamCommit
+
+	var interleaved, top []FingerprintChange
+
+	for i := range changes {
+		if changes[i].UpstreamCommit == latestUpstream {
+			top = append(top, changes[i])
+		} else {
+			interleaved = append(interleaved, changes[i])
+		}
+	}
+
+	// Build a lookup from upstream-commit hash → synthetic commits.
+	interleavedByUpstream := make(map[string][]FingerprintChange)
+
+	for i := range interleaved {
+		hash := interleaved[i].UpstreamCommit
+		interleavedByUpstream[hash] = append(interleavedByUpstream[hash], interleaved[i])
+	}
+
+	// Walk upstream commits, inserting synthetics after their referenced commit.
+	sequence := make([]interleavedEntry, 0, len(upstreamCommits)+len(changes))
+
+	for i := range upstreamCommits {
+		sequence = append(sequence, interleavedEntry{upstreamCommit: upstreamCommits[i]})
+
+		hash := upstreamCommits[i].Hash.String()
+		if synthetics, ok := interleavedByUpstream[hash]; ok {
+			for j := range synthetics {
+				synth := synthetics[j]
+				sequence = append(sequence, interleavedEntry{syntheticChange: &synth})
+			}
+
+			delete(interleavedByUpstream, hash)
+		}
+	}
+
+	// Orphaned changes whose upstream-commit wasn't found are dropped —
+	// they reference an upstream commit outside the known dist-git history.
+	for hash, orphaned := range interleavedByUpstream {
+		slog.Warn("Upstream commit referenced by fingerprint change not found in dist-git history; "+
+			"dropping",
+			"upstreamCommit", hash,
+			"count", len(orphaned))
+	}
+
+	// Append "top" synthetic commits at the end.
+	for i := range top {
+		topChange := top[i]
+		sequence = append(sequence, interleavedEntry{syntheticChange: &topChange})
+	}
+
+	return sequence
+}
+
+// replayInterleavedHistory walks the interleaved sequence and creates new
+// commit objects with correct tree hashes and parent chains. The first upstream
+// commit (import-commit) is kept as-is; subsequent upstream commits are
+// recreated with updated parents. Synthetic commits are empty except for the
+// very last one, which carries the overlay tree.
+func replayInterleavedHistory(
+	repo *gogit.Repository,
+	sequence []interleavedEntry,
+	overlayTreeHash plumbing.Hash,
+) error {
+	syntheticCount := countSyntheticEntries(sequence)
+
+	var (
+		lastHash     plumbing.Hash
+		lastTreeHash plumbing.Hash
+		syntheticIdx int
+	)
+
+	for idx, entry := range sequence {
+		if idx == 0 && entry.upstreamCommit != nil {
+			lastHash = entry.upstreamCommit.Hash
+			lastTreeHash = entry.upstreamCommit.TreeHash
+
+			continue
+		}
+
+		if entry.upstreamCommit != nil {
+			hash, err := replayUpstreamCommit(repo, entry.upstreamCommit, lastHash)
+			if err != nil {
+				return err
+			}
+
+			lastHash = hash
+			lastTreeHash = entry.upstreamCommit.TreeHash
+
+			continue
+		}
+
+		syntheticIdx++
+
+		isLast := syntheticIdx == syntheticCount
+
+		treeHash := lastTreeHash
+		if isLast {
+			treeHash = overlayTreeHash
+		}
+
+		hash, err := createSyntheticCommit(repo, entry.syntheticChange, treeHash, lastHash,
+			syntheticIdx, syntheticCount)
+		if err != nil {
+			return err
+		}
+
+		lastHash = hash
+		lastTreeHash = treeHash
+	}
+
+	if err := updateHead(repo, lastHash); err != nil {
+		return err
+	}
+
+	slog.Info("Interleaved synthetic history complete",
+		"syntheticCommits", syntheticCount,
+		"totalCommits", len(sequence))
+
+	return nil
+}
+
+// replayUpstreamCommit recreates an upstream commit with a new parent, preserving
+// tree content, author, committer, and message. Returns an error if the commit
+// is a merge commit (multiple parents), since the replay assumes linear history.
+func replayUpstreamCommit(
+	repo *gogit.Repository,
+	commit *object.Commit,
+	parentHash plumbing.Hash,
+) (plumbing.Hash, error) {
+	if len(commit.ParentHashes) > 1 {
+		return plumbing.ZeroHash, fmt.Errorf("upstream commit %s is a merge commit; linear history expected",
+			commit.Hash)
+	}
+
+	hash, err := createCommitObject(repo, commit.TreeHash, parentHash,
+		commit.Author, commit.Committer, commit.Message)
+	if err != nil {
+		return plumbing.ZeroHash, fmt.Errorf("failed to replay upstream commit:\n%w", err)
+	}
+
+	return hash, nil
+}
+
+// createSyntheticCommit creates a synthetic commit from a [FingerprintChange],
+// logging progress information.
+func createSyntheticCommit(
+	repo *gogit.Repository,
+	change *FingerprintChange,
+	treeHash, parentHash plumbing.Hash,
+	syntheticIdx, syntheticCount int,
+) (plumbing.Hash, error) {
+	author := object.Signature{
+		Name:  change.Author,
+		Email: change.AuthorEmail,
+		When:  unixToTime(change.Timestamp),
+	}
+
+	message := fmt.Sprintf("%s\n\nProject commit: %s", change.Message, change.Hash)
+
+	slog.Info("Creating synthetic commit",
+		"commit", syntheticIdx,
+		"total", syntheticCount,
+		"projectHash", change.Hash,
+		"upstreamCommit", change.UpstreamCommit,
+		"isLast", syntheticIdx == syntheticCount,
+	)
+
+	hash, err := createCommitObject(repo, treeHash, parentHash, author, author, message)
+	if err != nil {
+		return plumbing.ZeroHash, fmt.Errorf("failed to create synthetic commit %d:\n%w", syntheticIdx, err)
+	}
+
+	return hash, nil
+}
+
+// countSyntheticEntries returns the number of synthetic entries in the sequence.
+func countSyntheticEntries(sequence []interleavedEntry) int {
+	count := 0
+
+	for _, entry := range sequence {
+		if entry.syntheticChange != nil {
+			count++
+		}
+	}
+
+	return count
+}
+
+// createCommitObject creates a new commit in the repository's object store with
+// the given tree, parent, author, committer, and message.
+func createCommitObject(
+	repo *gogit.Repository,
+	treeHash, parentHash plumbing.Hash,
+	author, committer object.Signature,
+	message string,
+) (plumbing.Hash, error) {
+	commit := &object.Commit{
+		Author:       author,
+		Committer:    committer,
+		Message:      message,
+		TreeHash:     treeHash,
+		ParentHashes: []plumbing.Hash{parentHash},
+	}
+
+	obj := repo.Storer.NewEncodedObject()
+	if err := commit.Encode(obj); err != nil {
+		return plumbing.ZeroHash, fmt.Errorf("failed to encode commit:\n%w", err)
+	}
+
+	hash, err := repo.Storer.SetEncodedObject(obj)
+	if err != nil {
+		return plumbing.ZeroHash, fmt.Errorf("failed to store commit:\n%w", err)
+	}
+
+	return hash, nil
+}
+
+// updateHead updates the HEAD reference (or the branch it points to) to the
+// given commit hash.
+func updateHead(repo *gogit.Repository, commitHash plumbing.Hash) error {
+	head, err := repo.Storer.Reference(plumbing.HEAD)
+	if err != nil {
+		return fmt.Errorf("failed to read HEAD reference:\n%w", err)
+	}
+
+	// Resolve symbolic ref (e.g., HEAD → refs/heads/main).
+	name := plumbing.HEAD
+	if head.Type() != plumbing.HashReference {
+		name = head.Target()
+	}
+
+	ref := plumbing.NewHashReference(name, commitHash)
+	if err := repo.Storer.SetReference(ref); err != nil {
+		return fmt.Errorf("failed to update HEAD to %s:\n%w", commitHash, err)
+	}
+
+	return nil
+}
+
+// buildSyntheticCommits resolves the project repository from the component's
+// config file, walks the lock file's git history for fingerprint changes, and
+// returns the matching [FingerprintChange] entries sorted chronologically.
+// Returns an error if the lock file exists but has no fingerprint changes.
+// The second return value is the import-commit hash from the lock file, used
+// to scope the upstream commit walk in [CommitInterleavedHistory].
+func buildSyntheticCommits(
+	ctx context.Context,
+	cmdFactory opctx.CmdFactory,
+	config *projectconfig.ComponentConfig,
+	lockFileRelPath string,
+) (changes []FingerprintChange, importCommit string, err error) {
+	if config.SourceConfigFile == nil || config.SourceConfigFile.SourcePath() == "" {
+		slog.Debug("Cannot resolve config file for synthetic commits; skipping",
+			"lockFile", lockFileRelPath)
+
+		return nil, "", nil
+	}
+
+	configFilePath := config.SourceConfigFile.SourcePath()
+
+	projectRepoDir, err := git.RunInDir(ctx, cmdFactory, filepath.Dir(configFilePath), "rev-parse", "--show-toplevel")
+	if err != nil {
+		return nil, "", fmt.Errorf("failed to find project repository for config file %#q:\n%w",
+			configFilePath, err)
+	}
+
+	// Read the current lock file at HEAD to get the import-commit boundary.
+	headHash, err := gitHeadHash(ctx, cmdFactory, projectRepoDir)
+	if err != nil {
+		return nil, "", fmt.Errorf("failed to get HEAD hash:\n%w", err)
+	}
+
+	// If no lock file exists, the component has no overlays — the dist-git
+	// is just the upstream as-is, so no synthetic commits are needed.
+	headFields, lockFileErr := gitShowLockFile(ctx, cmdFactory, projectRepoDir, headHash, lockFileRelPath)
+	if lockFileErr != nil {
+		slog.Debug("No lock file found at HEAD; skipping synthetic history",
+			"lockFile", lockFileRelPath, "error", lockFileErr)
+
+		return nil, "", nil
+	}
+
+	importCommit = headFields.ImportCommit
+
+	fpChanges, err := FindFingerprintChanges(ctx, cmdFactory, projectRepoDir, lockFileRelPath)
+	if err != nil {
+		return nil, "", fmt.Errorf("failed to find fingerprint changes for lock file %#q:\n%w",
+			lockFileRelPath, err)
+	}
+
+	if len(fpChanges) == 0 {
+		return nil, "", fmt.Errorf(
+			"lock file %#q exists but has no fingerprint changes; "+
+				"this indicates a corrupt or empty lock file history",
+			lockFileRelPath)
+	}
+
+	slog.Info("Found fingerprint changes",
+		"lockFile", lockFileRelPath,
+		"changeCount", len(fpChanges))
+
+	return fpChanges, importCommit, nil
+}
+
+// collectUpstreamCommits returns commits in the repository in chronological
+// order (oldest first), bounded by importCommit (inclusive start) and
+// upstreamCommit (inclusive end). The walk stops as soon as the import-commit
+// is reached to avoid traversing the entire history.
+func collectUpstreamCommits(
+	repo *gogit.Repository, importCommit, upstreamCommit string,
+) ([]*object.Commit, error) {
 	head, err := repo.Head()
 	if err != nil {
 		return nil, fmt.Errorf("failed to get HEAD reference:\n%w", err)
 	}
 
-	commitIter, err := repo.Log(&gogit.LogOptions{From: head.Hash()})
+	iter, err := repo.Log(&gogit.LogOptions{From: head.Hash()})
 	if err != nil {
 		return nil, fmt.Errorf("failed to iterate commit log:\n%w", err)
 	}
 
-	var matches []CommitMetadata
+	// Walk newest-first. Collect commits until we pass the upstream-commit
+	// boundary, then keep collecting until we reach the import-commit.
+	var (
+		commits       []*object.Commit
+		foundUpstream bool
+		foundImport   bool
+		collecting    = upstreamCommit == "" // if no upper bound, collect from start.
+	)
 
-	err = commitIter.ForEach(func(commit *object.Commit) error {
-		if MessageAffectsComponent(commit.Message, componentName) {
-			matches = append(matches, CommitMetadata{
-				Hash:        commit.Hash.String(),
-				Author:      commit.Author.Name,
-				AuthorEmail: commit.Author.Email,
-				Timestamp:   commit.Author.When.Unix(),
-				Message:     strings.TrimSpace(commit.Message),
-			})
+	err = iter.ForEach(func(commit *object.Commit) error {
+		hash := commit.Hash.String()
+
+		// Start collecting once we see the upstream-commit (newest boundary).
+		if !collecting && hash == upstreamCommit {
+			collecting = true
+		}
+
+		if collecting {
+			commits = append(commits, commit)
+		}
+
+		if hash == upstreamCommit {
+			foundUpstream = true
+		}
+
+		// Stop once we reach the import-commit (oldest boundary).
+		if importCommit != "" && hash == importCommit {
+			foundImport = true
+
+			return storer.ErrStop
 		}
 
 		return nil
@@ -86,165 +582,125 @@ func FindAffectsCommits(repo *gogit.Repository, componentName string) ([]CommitM
 		return nil, fmt.Errorf("failed to walk commit log:\n%w", err)
 	}
 
-	// Log iteration returns newest-first; reverse to get chronological order.
-	slices.Reverse(matches)
-
-	return matches, nil
-}
-
-// CommitSyntheticHistory stages all pending working tree changes and creates synthetic
-// commits in the provided git repository. The first commit captures all file changes;
-// subsequent commits are created as empty commits to preserve the commit count for
-// rpmautospec release numbering.
-func CommitSyntheticHistory(
-	repo *gogit.Repository,
-	commits []CommitMetadata,
-) error {
-	worktree, err := repo.Worktree()
-	if err != nil {
-		return fmt.Errorf("failed to get worktree:\n%w", err)
+	if upstreamCommit != "" && !foundUpstream {
+		return nil, fmt.Errorf(
+			"upstream-commit %#q not found in dist-git history; "+
+				"the lock file may reference a commit from a different branch",
+			upstreamCommit)
 	}
 
-	// Stage all working tree changes once — overlays have already been applied.
-	if err := worktree.AddWithOptions(&gogit.AddOptions{All: true}); err != nil {
-		return fmt.Errorf("failed to stage changes:\n%w", err)
+	if importCommit != "" && !foundImport {
+		slog.Warn("Import-commit not found in dist-git history; using all collected commits",
+			"importCommit", importCommit)
 	}
 
-	for commitIdx, commitMeta := range commits {
-		slog.Info("Creating synthetic commit",
-			"commit", commitIdx+1,
-			"total", len(commits),
-			"projectHash", commitMeta.Hash,
-		)
+	// Walk was newest-first; reverse to chronological.
+	slices.Reverse(commits)
 
-		message := fmt.Sprintf("%s\n\nProject commit: %s",
-			commitMeta.Message, commitMeta.Hash)
-
-		_, err := worktree.Commit(message, &gogit.CommitOptions{
-			AllowEmptyCommits: true,
-			Author: &object.Signature{
-				Name:  commitMeta.Author,
-				Email: commitMeta.AuthorEmail,
-				When:  unixToTime(commitMeta.Timestamp),
-			},
-		})
-		if err != nil {
-			return fmt.Errorf("failed to create synthetic commit %d:\n%w", commitIdx+1, err)
-		}
-	}
-
-	slog.Info("Synthetic history generation complete",
-		"commitsCreated", len(commits))
-
-	return nil
-}
-
-// buildSyntheticCommits resolves the project repository from the component's config file,
-// walks the git log for commits containing "Affects: <componentName>", and returns the
-// matching commit metadata sorted chronologically. If no Affects commits are found, a
-// single default overlay commit is returned instead.
-func buildSyntheticCommits(
-	config *projectconfig.ComponentConfig, componentName, defaultAuthorEmail string,
-) ([]CommitMetadata, error) {
-	configFilePath, err := resolveConfigFilePath(config, componentName)
-	if err != nil {
-		// No config file reference means this component can't have Affects commits.
-		slog.Debug("Cannot resolve config file for synthetic commits; skipping",
-			"component", componentName, "error", err)
-
-		return nil, nil
-	}
-
-	projectRepo, err := openProjectRepo(configFilePath)
-	if err != nil {
-		return nil, err
-	}
-
-	affectsCommits, err := FindAffectsCommits(projectRepo, componentName)
-	if err != nil {
-		return nil, fmt.Errorf("failed to find Affects commits for component %#q:\n%w", componentName, err)
-	}
-
-	if len(affectsCommits) == 0 {
-		slog.Info("No commits with Affects marker found; "+
-			"creating default commit",
-			"component", componentName)
-
-		commit := defaultOverlayCommit(projectRepo, componentName, defaultAuthorEmail)
-
-		return []CommitMetadata{commit}, nil
-	}
-
-	slog.Info("Found commits affecting component",
-		"component", componentName,
-		"commitCount", len(affectsCommits))
-
-	return affectsCommits, nil
-}
-
-// defaultOverlayCommit returns a single [CommitMetadata] entry that represents a generic
-// commit when no Affects commits exist in the project history. The commit hash is
-// set to the current HEAD of the project repository.
-func defaultOverlayCommit(repo *gogit.Repository, componentName,
-	defaultAuthorEmail string,
-) CommitMetadata {
-	if defaultAuthorEmail == "" {
-		slog.Warn("No default author email configured; synthetic commit will have an empty author email",
-			"hint", "set project.default-author-email in the project config")
-	}
-
-	var (
-		timestamp int64
-		hash      string
-	)
-
-	if head, err := repo.Head(); err == nil {
-		hash = head.Hash().String()
-		if commit, commitErr := repo.CommitObject(head.Hash()); commitErr == nil {
-			timestamp = commit.Author.When.Unix()
-		}
-	}
-
-	return CommitMetadata{
-		Hash:        hash,
-		Author:      "azldev",
-		AuthorEmail: defaultAuthorEmail,
-		Timestamp:   timestamp,
-		Message:     "Latest state for " + componentName,
-	}
-}
-
-// resolveConfigFilePath extracts and validates the source config file path from the component config.
-func resolveConfigFilePath(config *projectconfig.ComponentConfig, componentName string) (string, error) {
-	configFile := config.SourceConfigFile
-	if configFile == nil {
-		return "", fmt.Errorf("component %#q has no source config file reference", componentName)
-	}
-
-	configFilePath := configFile.SourcePath()
-	if configFilePath == "" {
-		return "", fmt.Errorf("component %#q source config file has no path", componentName)
-	}
-
-	return configFilePath, nil
-}
-
-// openProjectRepo finds and opens the git repository containing configFilePath by
-// walking up the directory tree.
-func openProjectRepo(configFilePath string) (*gogit.Repository, error) {
-	repo, err := gogit.PlainOpenWithOptions(filepath.Dir(configFilePath), &gogit.PlainOpenOptions{
-		DetectDotGit:          true,
-		EnableDotGitCommonDir: true,
-	})
-	if err != nil {
-		return nil, fmt.Errorf("failed to find project repository for config file %#q:\n%w",
-			configFilePath, err)
-	}
-
-	return repo, nil
+	return commits, nil
 }
 
 // unixToTime converts a Unix timestamp to a [time.Time] in UTC.
 func unixToTime(unix int64) time.Time {
 	return time.Unix(unix, 0).UTC()
+}
+
+// --- git CLI helpers ---
+
+// gitLogFileMetadata returns commit metadata (newest-first) for all commits
+// that touched the given file path in the repository at repoDir. Each commit's
+// metadata is separated by a NUL byte in the git log output.
+func gitLogFileMetadata(
+	ctx context.Context, cmdFactory opctx.CmdFactory, repoDir, filePath string,
+) ([]CommitMetadata, error) {
+	output, err := git.RunInDir(ctx, cmdFactory, repoDir,
+		"log", "--format=%H%n%an%n%ae%n%at%n%s%x00", "--", filePath)
+	if err != nil {
+		return nil, fmt.Errorf("failed to list commits for %#q:\n%w", filePath, err)
+	}
+
+	if output == "" {
+		return nil, nil
+	}
+
+	blocks := strings.Split(output, "\x00")
+
+	var metas []CommitMetadata //nolint:prealloc // trailing empty block after split.
+
+	for _, block := range blocks {
+		block = strings.TrimSpace(block)
+		if block == "" {
+			continue
+		}
+
+		meta, err := ParseCommitMetadata(block)
+		if err != nil {
+			return nil, fmt.Errorf("failed to parse commit metadata:\n%w", err)
+		}
+
+		metas = append(metas, meta)
+	}
+
+	return metas, nil
+}
+
+// gitShowLockFile reads the lock file content at a specific commit and parses
+// the 'upstream-commit' and 'input-fingerprint' TOML fields.
+func gitShowLockFile(
+	ctx context.Context, cmdFactory opctx.CmdFactory,
+	repoDir, commitHash, lockFileRelPath string,
+) (lockFileFields, error) {
+	ref := commitHash + ":" + lockFileRelPath
+
+	output, err := git.RunInDir(ctx, cmdFactory, repoDir, "show", ref)
+	if err != nil {
+		return lockFileFields{}, fmt.Errorf("failed to read lock file at %#q:\n%w", ref, err)
+	}
+
+	var fields lockFileFields
+	if err := toml.Unmarshal([]byte(output), &fields); err != nil {
+		return lockFileFields{}, fmt.Errorf("failed to parse lock file at %#q:\n%w", ref, err)
+	}
+
+	return fields, nil
+}
+
+// commitMetadataFieldCount is the number of fields expected in the output of
+// 'git log -1 --format=%H%n%an%n%ae%n%at%n%s'.
+const commitMetadataFieldCount = 5
+
+// ParseCommitMetadata parses the output of 'git log -1 --format=%H%n%an%n%ae%n%at%n%s'.
+func ParseCommitMetadata(output string) (CommitMetadata, error) {
+	lines := strings.SplitN(strings.TrimSpace(output), "\n", commitMetadataFieldCount)
+
+	if len(lines) < commitMetadataFieldCount {
+		return CommitMetadata{}, fmt.Errorf(
+			"unexpected git log output (expected %d lines, got %d):\n%v",
+			commitMetadataFieldCount, len(lines), output)
+	}
+
+	var timestamp int64
+	if _, err := fmt.Sscanf(lines[3], "%d", &timestamp); err != nil {
+		return CommitMetadata{}, fmt.Errorf("failed to parse timestamp %#q:\n%w", lines[3], err)
+	}
+
+	return CommitMetadata{
+		Hash:        lines[0],
+		Author:      lines[1],
+		AuthorEmail: lines[2],
+		Timestamp:   timestamp,
+		Message:     lines[4],
+	}, nil
+}
+
+// gitHeadHash returns the HEAD commit hash of the repository at repoDir.
+func gitHeadHash(
+	ctx context.Context, cmdFactory opctx.CmdFactory, repoDir string,
+) (string, error) {
+	hash, err := git.RunInDir(ctx, cmdFactory, repoDir, "rev-parse", "HEAD")
+	if err != nil {
+		return "", fmt.Errorf("failed to resolve HEAD in %#q:\n%w", repoDir, err)
+	}
+
+	return hash, nil
 }

--- a/internal/app/azldev/core/sources/synthistory_test.go
+++ b/internal/app/azldev/core/sources/synthistory_test.go
@@ -238,36 +238,29 @@ func TestFindAffectsCommits_CaseSensitive(t *testing.T) {
 
 func TestMessageAffectsComponent(t *testing.T) {
 	tests := []struct {
-		name      string
-		message   string
-		component string
-		want      bool
+		name          string
+		componentName string
+		want          string
 	}{
-		// Positive matches.
-		{"exact match in body", "Fix bug\n\nAffects: curl", "curl", true},
-		{"trailing whitespace", "Fix bug\n\nAffects: curl  ", "curl", true},
-		{"leading whitespace on line", "Fix bug\n\n  Affects: curl", "curl", true},
-		{"subject line only", "Affects: curl", "curl", true},
-
-		// Negative matches.
-		{"different component", "Fix bug\n\nAffects: wget", "curl", false},
-		{"no substring match", "Fix bug\n\nAffects: curl-minimal", "curl", false},
-		{"comma separated", "Fix bug\n\nAffects: curl, wget", "curl", false},
-		{"extra text after name", "Affects: curl - fix build failure", "curl", false},
-		{"case sensitive", "Fix bug\n\nAffects: Curl", "curl", false},
-		{"no match across newlines", "Fix bug\n\nAffects:\ncurl", "curl", false},
+		{"simple name", "curl", "specs/c/curl/curl.lock"},
+		{"hyphenated name", "curl-minimal", "specs/c/curl-minimal/curl-minimal.lock"},
+		{"uppercase first letter", "Kernel", "specs/k/Kernel/Kernel.lock"},
+		{"single char name", "a", "specs/a/a/a.lock"},
+		{"long name", "golang-github-example", "specs/g/golang-github-example/golang-github-example.lock"},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := sources.MessageAffectsComponent(tt.message, tt.component)
+			got, err := sources.LockFilePath(tt.componentName)
+			require.NoError(t, err)
 			assert.Equal(t, tt.want, got)
 		})
 	}
 }
 
-func TestCommitSyntheticHistory(t *testing.T) {
-	// Create an in-memory repo with an initial commit (simulating upstream).
+func TestCommitInterleavedHistory_AllOnTop(t *testing.T) {
+	// When all fingerprint changes reference the latest upstream commit,
+	// all synthetic commits should be appended on top.
 	memFS := memfs.New()
 	storer := memory.NewStorage()
 
@@ -277,7 +270,7 @@ func TestCommitSyntheticHistory(t *testing.T) {
 	worktree, err := repo.Worktree()
 	require.NoError(t, err)
 
-	// Create an initial file (upstream).
+	// Create an upstream commit.
 	file, err := memFS.Create("package.spec")
 	require.NoError(t, err)
 
@@ -288,7 +281,7 @@ func TestCommitSyntheticHistory(t *testing.T) {
 	_, err = worktree.Add("package.spec")
 	require.NoError(t, err)
 
-	_, err = worktree.Commit("upstream: initial", &gogit.CommitOptions{
+	upstreamCommit, err := worktree.Commit("upstream: initial", &gogit.CommitOptions{
 		Author: &object.Signature{
 			Name:  "Upstream",
 			Email: "upstream@fedora.org",
@@ -297,7 +290,7 @@ func TestCommitSyntheticHistory(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	// Simulate overlay application by modifying the working tree before committing.
+	// Simulate overlay modification.
 	specFile, err := memFS.Create("package.spec")
 	require.NoError(t, err)
 
@@ -305,28 +298,35 @@ func TestCommitSyntheticHistory(t *testing.T) {
 	require.NoError(t, err)
 	require.NoError(t, specFile.Close())
 
-	// Define synthetic commits.
-	commits := []sources.CommitMetadata{
+	upstreamHash := upstreamCommit.String()
+
+	changes := []sources.FingerprintChange{
 		{
-			Hash:        "abc123def456",
-			Author:      "Alice",
-			AuthorEmail: "alice@example.com",
-			Timestamp:   time.Date(2025, 1, 10, 10, 0, 0, 0, time.UTC).Unix(),
-			Message:     "Apply patch fix",
+			CommitMetadata: sources.CommitMetadata{
+				Hash:        "abc123",
+				Author:      "Alice",
+				AuthorEmail: "alice@example.com",
+				Timestamp:   time.Date(2025, 1, 10, 10, 0, 0, 0, time.UTC).Unix(),
+				Message:     "Apply patch fix",
+			},
+			UpstreamCommit: upstreamHash,
 		},
 		{
-			Hash:        "789abc012def",
-			Author:      "Bob",
-			AuthorEmail: "bob@example.com",
-			Timestamp:   time.Date(2025, 2, 20, 14, 0, 0, 0, time.UTC).Unix(),
-			Message:     "Bump release",
+			CommitMetadata: sources.CommitMetadata{
+				Hash:        "def456",
+				Author:      "Bob",
+				AuthorEmail: "bob@example.com",
+				Timestamp:   time.Date(2025, 2, 20, 14, 0, 0, 0, time.UTC).Unix(),
+				Message:     "Bump release",
+			},
+			UpstreamCommit: upstreamHash,
 		},
 	}
 
-	err = sources.CommitSyntheticHistory(repo, commits)
+	err = sources.CommitInterleavedHistory(repo, changes, "")
 	require.NoError(t, err)
 
-	// Verify the commit log has 3 commits: upstream + 2 synthetic.
+	// Verify the commit log: upstream + 2 synthetic = 3 commits.
 	head, err := repo.Head()
 	require.NoError(t, err)
 
@@ -344,12 +344,11 @@ func TestCommitSyntheticHistory(t *testing.T) {
 
 	require.Len(t, logCommits, 3, "should have upstream + 2 synthetic commits")
 
-	// Most recent commit (Bob's) — empty commit.
+	// Most recent commit (Bob's) — this is the last synthetic commit.
 	assert.Contains(t, logCommits[0].Message, "Bump release")
 	assert.Equal(t, "Bob", logCommits[0].Author.Name)
-	assert.Equal(t, "bob@example.com", logCommits[0].Author.Email)
 
-	// Second commit (Alice's) — has the actual file changes.
+	// Second commit (Alice's).
 	assert.Contains(t, logCommits[1].Message, "Apply patch fix")
 	assert.Equal(t, "Alice", logCommits[1].Author.Name)
 
@@ -357,7 +356,122 @@ func TestCommitSyntheticHistory(t *testing.T) {
 	assert.Equal(t, "upstream: initial", logCommits[2].Message)
 }
 
-func TestCommitSyntheticHistory_SingleCommit(t *testing.T) {
+func TestCommitInterleavedHistory_Interleaved(t *testing.T) {
+	// Two upstream commits, one synthetic change for the first (older) upstream
+	// commit and one for the second (latest). The interleaved commit should
+	// appear between the two upstream commits.
+	memFS := memfs.New()
+	storer := memory.NewStorage()
+
+	repo, err := gogit.Init(storer, memFS)
+	require.NoError(t, err)
+
+	worktree, err := repo.Worktree()
+	require.NoError(t, err)
+
+	// Upstream commit 1.
+	file1, err := memFS.Create("package.spec")
+	require.NoError(t, err)
+
+	_, err = file1.Write([]byte("Name: package\nVersion: 1.0\n"))
+	require.NoError(t, err)
+	require.NoError(t, file1.Close())
+
+	_, err = worktree.Add("package.spec")
+	require.NoError(t, err)
+
+	upstream1, err := worktree.Commit("upstream: v1.0", &gogit.CommitOptions{
+		Author: &object.Signature{
+			Name:  "Upstream",
+			Email: "upstream@fedora.org",
+			When:  time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC),
+		},
+	})
+	require.NoError(t, err)
+
+	// Upstream commit 2.
+	file2, err := memFS.Create("package.spec")
+	require.NoError(t, err)
+
+	_, err = file2.Write([]byte("Name: package\nVersion: 2.0\n"))
+	require.NoError(t, err)
+	require.NoError(t, file2.Close())
+
+	_, err = worktree.Add("package.spec")
+	require.NoError(t, err)
+
+	upstream2, err := worktree.Commit("upstream: v2.0", &gogit.CommitOptions{
+		Author: &object.Signature{
+			Name:  "Upstream",
+			Email: "upstream@fedora.org",
+			When:  time.Date(2024, 6, 1, 0, 0, 0, 0, time.UTC),
+		},
+	})
+	require.NoError(t, err)
+
+	// Simulate overlay modification in working tree.
+	specFile, err := memFS.Create("package.spec")
+	require.NoError(t, err)
+
+	_, err = specFile.Write([]byte("Name: package\nVersion: 2.0\n# overlays\n"))
+	require.NoError(t, err)
+	require.NoError(t, specFile.Close())
+
+	changes := []sources.FingerprintChange{
+		{
+			CommitMetadata: sources.CommitMetadata{
+				Hash:        "proj-aaa",
+				Author:      "Alice",
+				AuthorEmail: "alice@example.com",
+				Timestamp:   time.Date(2024, 3, 1, 0, 0, 0, 0, time.UTC).Unix(),
+				Message:     "Fix for v1.0",
+			},
+			UpstreamCommit: upstream1.String(), // references older upstream.
+		},
+		{
+			CommitMetadata: sources.CommitMetadata{
+				Hash:        "proj-bbb",
+				Author:      "Bob",
+				AuthorEmail: "bob@example.com",
+				Timestamp:   time.Date(2024, 7, 1, 0, 0, 0, 0, time.UTC).Unix(),
+				Message:     "Fix for v2.0",
+			},
+			UpstreamCommit: upstream2.String(), // references latest upstream.
+		},
+	}
+
+	err = sources.CommitInterleavedHistory(repo, changes, upstream1.String())
+	require.NoError(t, err)
+
+	// Expected order (newest first):
+	// 1. "Fix for v2.0" (synthetic, on top — latest upstream, with overlay)
+	// 2. "upstream: v2.0" (replayed with new parent)
+	// 3. "Fix for v1.0" (synthetic, interleaved after upstream v1.0)
+	// 4. "upstream: v1.0" (import-commit, kept as-is)
+	head, err := repo.Head()
+	require.NoError(t, err)
+
+	commitIter, err := repo.Log(&gogit.LogOptions{From: head.Hash()})
+	require.NoError(t, err)
+
+	var logCommits []*object.Commit
+
+	err = commitIter.ForEach(func(c *object.Commit) error {
+		logCommits = append(logCommits, c)
+
+		return nil
+	})
+	require.NoError(t, err)
+
+	require.Len(t, logCommits, 4, "should have 2 upstream + 2 synthetic commits")
+
+	assert.Contains(t, logCommits[0].Message, "Fix for v2.0")   // top synthetic (latest)
+	assert.Contains(t, logCommits[1].Message, "upstream: v2.0") // replayed upstream 2
+	assert.Contains(t, logCommits[2].Message, "Fix for v1.0")   // interleaved synthetic
+	assert.Contains(t, logCommits[3].Message, "upstream: v1.0") // import-commit (kept)
+}
+
+func TestCommitInterleavedHistory_SingleCommit(t *testing.T) {
 	memFS := memfs.New()
 	storer := memory.NewStorage()
 
@@ -377,7 +491,7 @@ func TestCommitSyntheticHistory_SingleCommit(t *testing.T) {
 	_, err = worktree.Add("package.spec")
 	require.NoError(t, err)
 
-	_, err = worktree.Commit("upstream: initial", &gogit.CommitOptions{
+	upstream, err := worktree.Commit("upstream: initial", &gogit.CommitOptions{
 		Author: &object.Signature{
 			Name:  "Upstream",
 			Email: "upstream@fedora.org",
@@ -394,17 +508,20 @@ func TestCommitSyntheticHistory_SingleCommit(t *testing.T) {
 	require.NoError(t, err)
 	require.NoError(t, specFile.Close())
 
-	commits := []sources.CommitMetadata{
+	changes := []sources.FingerprintChange{
 		{
-			Hash:        "abc123",
-			Author:      "Alice",
-			AuthorEmail: "alice@example.com",
-			Timestamp:   time.Date(2025, 1, 10, 10, 0, 0, 0, time.UTC).Unix(),
-			Message:     "Fix build",
+			CommitMetadata: sources.CommitMetadata{
+				Hash:        "abc123",
+				Author:      "Alice",
+				AuthorEmail: "alice@example.com",
+				Timestamp:   time.Date(2025, 1, 10, 10, 0, 0, 0, time.UTC).Unix(),
+				Message:     "Fix build",
+			},
+			UpstreamCommit: upstream.String(),
 		},
 	}
 
-	err = sources.CommitSyntheticHistory(repo, commits)
+	err = sources.CommitInterleavedHistory(repo, changes, "")
 	require.NoError(t, err)
 
 	// Verify working tree changes are in the single synthetic commit.
@@ -427,4 +544,127 @@ func TestCommitSyntheticHistory_SingleCommit(t *testing.T) {
 	content, err := entry.Contents()
 	require.NoError(t, err)
 	assert.Contains(t, content, "# modified")
+}
+
+func TestCommitInterleavedHistory_OrphanUpstreamCommit(t *testing.T) {
+	// When a fingerprint change references an upstream commit that doesn't
+	// exist in the dist-git history, it should be dropped (not appended).
+	memFS := memfs.New()
+	storer := memory.NewStorage()
+
+	repo, err := gogit.Init(storer, memFS)
+	require.NoError(t, err)
+
+	worktree, err := repo.Worktree()
+	require.NoError(t, err)
+
+	file, err := memFS.Create("package.spec")
+	require.NoError(t, err)
+
+	_, err = file.Write([]byte("Name: package\n"))
+	require.NoError(t, err)
+	require.NoError(t, file.Close())
+
+	_, err = worktree.Add("package.spec")
+	require.NoError(t, err)
+
+	upstream, err := worktree.Commit("upstream: initial", &gogit.CommitOptions{
+		Author: &object.Signature{
+			Name:  "Upstream",
+			Email: "upstream@fedora.org",
+			When:  time.Date(2024, 6, 1, 0, 0, 0, 0, time.UTC),
+		},
+	})
+	require.NoError(t, err)
+
+	changes := []sources.FingerprintChange{
+		{
+			CommitMetadata: sources.CommitMetadata{
+				Hash:        "proj-orphan",
+				Author:      "Alice",
+				AuthorEmail: "alice@example.com",
+				Timestamp:   time.Date(2024, 3, 1, 0, 0, 0, 0, time.UTC).Unix(),
+				Message:     "Fix for unknown upstream",
+			},
+			UpstreamCommit: "deadbeefdeadbeef", // not in dist-git history.
+		},
+		{
+			CommitMetadata: sources.CommitMetadata{
+				Hash:        "proj-latest",
+				Author:      "Bob",
+				AuthorEmail: "bob@example.com",
+				Timestamp:   time.Date(2024, 7, 1, 0, 0, 0, 0, time.UTC).Unix(),
+				Message:     "Latest fix",
+			},
+			UpstreamCommit: upstream.String(), // latest.
+		},
+	}
+
+	err = sources.CommitInterleavedHistory(repo, changes, "")
+	require.NoError(t, err)
+
+	head, err := repo.Head()
+	require.NoError(t, err)
+
+	commitIter, err := repo.Log(&gogit.LogOptions{From: head.Hash()})
+	require.NoError(t, err)
+
+	var logCommits []*object.Commit
+
+	err = commitIter.ForEach(func(c *object.Commit) error {
+		logCommits = append(logCommits, c)
+
+		return nil
+	})
+	require.NoError(t, err)
+
+	// Only the latest-upstream synthetic commit is included; orphan is dropped.
+	require.Len(t, logCommits, 2)
+	assert.Contains(t, logCommits[0].Message, "Latest fix")
+	assert.Equal(t, "upstream: initial", logCommits[1].Message)
+}
+
+func TestParseCommitMetadata(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   string
+		want    sources.CommitMetadata
+		wantErr bool
+	}{
+		{
+			name:  "valid output",
+			input: "abc123def456\nAlice\nalice@example.com\n1706100000\nFix CVE-2025-1234",
+			want: sources.CommitMetadata{
+				Hash:        "abc123def456",
+				Author:      "Alice",
+				AuthorEmail: "alice@example.com",
+				Timestamp:   1706100000,
+				Message:     "Fix CVE-2025-1234",
+			},
+		},
+		{
+			name:    "too few lines",
+			input:   "abc123\nAlice\nalice@example.com",
+			wantErr: true,
+		},
+		{
+			name:    "invalid timestamp",
+			input:   "abc123\nAlice\nalice@example.com\nnot-a-number\nFix bug",
+			wantErr: true,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			got, err := sources.ParseCommitMetadata(test.input)
+			if test.wantErr {
+				assert.Error(t, err)
+
+				return
+			}
+
+			require.NoError(t, err)
+			assert.Equal(t, test.want, got)
+		})
+	}
 }

--- a/internal/app/azldev/core/sources/synthistory_test.go
+++ b/internal/app/azldev/core/sources/synthistory_test.go
@@ -4,259 +4,17 @@
 package sources_test
 
 import (
-	"fmt"
 	"testing"
 	"time"
 
 	memfs "github.com/go-git/go-billy/v5/memfs"
 	gogit "github.com/go-git/go-git/v5"
-	"github.com/go-git/go-git/v5/plumbing"
 	"github.com/go-git/go-git/v5/plumbing/object"
 	"github.com/go-git/go-git/v5/storage/memory"
 	"github.com/microsoft/azure-linux-dev-tools/internal/app/azldev/core/sources"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
-
-// createInMemoryRepo creates an empty in-memory git repository.
-func createInMemoryRepo(t *testing.T) *gogit.Repository {
-	t.Helper()
-
-	repo, err := gogit.Init(memory.NewStorage(), memfs.New())
-	require.NoError(t, err)
-
-	return repo
-}
-
-// addCommit creates a commit in the in-memory repository with the given message, author name,
-// email, and timestamp. A dummy file change is added to ensure the commit is non-empty.
-func addCommit(
-	t *testing.T, repo *gogit.Repository, message, authorName, authorEmail string, when time.Time,
-) {
-	t.Helper()
-
-	worktree, err := repo.Worktree()
-	require.NoError(t, err)
-
-	fs := worktree.Filesystem
-
-	// Write a unique file per commit to guarantee a non-empty diff.
-	fileName := fmt.Sprintf("file-%d.txt", when.UnixNano())
-
-	f, err := fs.Create(fileName)
-	require.NoError(t, err)
-
-	_, err = f.Write([]byte(message))
-	require.NoError(t, err)
-	require.NoError(t, f.Close())
-
-	_, err = worktree.Add(fileName)
-	require.NoError(t, err)
-
-	_, err = worktree.Commit(message, &gogit.CommitOptions{
-		Author: &object.Signature{
-			Name:  authorName,
-			Email: authorEmail,
-			When:  when,
-		},
-	})
-	require.NoError(t, err)
-}
-
-func TestFindAffectsCommits(t *testing.T) {
-	repo := createInMemoryRepo(t)
-
-	// Three commits: two mention curl, one does not.
-	addCommit(t, repo,
-		"Initial setup",
-		"Alice", "alice@example.com",
-		time.Date(2025, 1, 1, 10, 0, 0, 0, time.UTC))
-
-	addCommit(t, repo,
-		"Fix CVE-2025-1234\n\nAffects: curl",
-		"Bob", "bob@example.com",
-		time.Date(2025, 2, 1, 10, 0, 0, 0, time.UTC))
-
-	addCommit(t, repo,
-		"Bump release\n\nAffects: curl",
-		"Charlie", "charlie@example.com",
-		time.Date(2025, 3, 1, 10, 0, 0, 0, time.UTC))
-
-	results, err := sources.FindAffectsCommits(repo, "curl")
-	require.NoError(t, err)
-
-	// Expect 2 matching commits, oldest first.
-	require.Len(t, results, 2)
-
-	assert.Equal(t, "Bob", results[0].Author)
-	assert.Equal(t, "bob@example.com", results[0].AuthorEmail)
-	assert.Contains(t, results[0].Message, "Fix CVE-2025-1234")
-
-	assert.Equal(t, "Charlie", results[1].Author)
-	assert.Equal(t, "charlie@example.com", results[1].AuthorEmail)
-	assert.Contains(t, results[1].Message, "Bump release")
-
-	// Chronological order: Bob's timestamp < Charlie's timestamp.
-	assert.Less(t, results[0].Timestamp, results[1].Timestamp)
-}
-
-func TestFindAffectsCommits_NoMatches(t *testing.T) {
-	repo := createInMemoryRepo(t)
-
-	addCommit(t, repo,
-		"Unrelated change",
-		"Alice", "alice@example.com",
-		time.Date(2025, 1, 1, 10, 0, 0, 0, time.UTC))
-
-	results, err := sources.FindAffectsCommits(repo, "curl")
-	require.NoError(t, err)
-	assert.Empty(t, results)
-}
-
-func TestFindAffectsCommits_ShallowRepo(t *testing.T) {
-	repo := createInMemoryRepo(t)
-
-	addCommit(t, repo,
-		"Fix CVE-2025-1234\n\nAffects: curl",
-		"Alice", "alice@example.com",
-		time.Date(2025, 1, 1, 10, 0, 0, 0, time.UTC))
-
-	head, err := repo.Head()
-	require.NoError(t, err)
-	require.NoError(t, repo.Storer.SetShallow([]plumbing.Hash{head.Hash()}))
-
-	results, err := sources.FindAffectsCommits(repo, "curl")
-	require.Error(t, err)
-	assert.Nil(t, results)
-	assert.Contains(t, err.Error(), "shallow clone")
-	assert.Contains(t, err.Error(), "git fetch --unshallow")
-}
-
-func TestFindAffectsCommits_MultipleComponents(t *testing.T) {
-	repo := createInMemoryRepo(t)
-
-	addCommit(t, repo,
-		"Fix curl issue\n\nAffects: curl",
-		"Alice", "alice@example.com",
-		time.Date(2025, 1, 1, 10, 0, 0, 0, time.UTC))
-
-	addCommit(t, repo,
-		"Fix wget issue\n\nAffects: wget",
-		"Bob", "bob@example.com",
-		time.Date(2025, 2, 1, 10, 0, 0, 0, time.UTC))
-
-	addCommit(t, repo,
-		"Fix both\n\nAffects: curl\nAffects: wget",
-		"Charlie", "charlie@example.com",
-		time.Date(2025, 3, 1, 10, 0, 0, 0, time.UTC))
-
-	curlResults, err := sources.FindAffectsCommits(repo, "curl")
-	require.NoError(t, err)
-	require.Len(t, curlResults, 2, "curl should match 2 commits")
-	assert.Equal(t, "Alice", curlResults[0].Author)
-	assert.Equal(t, "Charlie", curlResults[1].Author)
-
-	wgetResults, err := sources.FindAffectsCommits(repo, "wget")
-	require.NoError(t, err)
-	require.Len(t, wgetResults, 2, "wget should match 2 commits")
-	assert.Equal(t, "Bob", wgetResults[0].Author)
-	assert.Equal(t, "Charlie", wgetResults[1].Author)
-}
-
-func TestFindAffectsCommits_NoSubstringMatch(t *testing.T) {
-	repo := createInMemoryRepo(t)
-
-	// "Affects: curl-minimal" should NOT match when searching for "curl".
-	addCommit(t, repo,
-		"Update curl-minimal\n\nAffects: curl-minimal",
-		"Alice", "alice@example.com",
-		time.Date(2025, 1, 1, 10, 0, 0, 0, time.UTC))
-
-	addCommit(t, repo,
-		"Update curl itself\n\nAffects: curl",
-		"Bob", "bob@example.com",
-		time.Date(2025, 2, 1, 10, 0, 0, 0, time.UTC))
-
-	// Searching for "curl" matches only Bob's commit (exact component name).
-	curlResults, err := sources.FindAffectsCommits(repo, "curl")
-	require.NoError(t, err)
-	require.Len(t, curlResults, 1, "exact match should not include curl-minimal commit")
-	assert.Equal(t, "Bob", curlResults[0].Author)
-
-	// Searching for "curl-minimal" matches only Alice's commit.
-	minimalResults, err := sources.FindAffectsCommits(repo, "curl-minimal")
-	require.NoError(t, err)
-	require.Len(t, minimalResults, 1)
-	assert.Equal(t, "Alice", minimalResults[0].Author)
-}
-
-func TestFindAffectsCommits_AffectsInSubject(t *testing.T) {
-	repo := createInMemoryRepo(t)
-
-	// Affects marker in the subject line (not just the body).
-	addCommit(t, repo,
-		"Affects: curl",
-		"Alice", "alice@example.com",
-		time.Date(2025, 1, 1, 10, 0, 0, 0, time.UTC))
-
-	results, err := sources.FindAffectsCommits(repo, "curl")
-	require.NoError(t, err)
-	require.Len(t, results, 1)
-	assert.Equal(t, "Alice", results[0].Author)
-}
-
-func TestFindAffectsCommits_CaseSensitive(t *testing.T) {
-	repo := createInMemoryRepo(t)
-
-	addCommit(t, repo,
-		"Bump release\n\nAffects: Kernel",
-		"Alice", "alice@example.com",
-		time.Date(2025, 1, 1, 10, 0, 0, 0, time.UTC))
-
-	addCommit(t, repo,
-		"Fix CVE\n\nAFFECTS: KERNEL",
-		"Bob", "bob@example.com",
-		time.Date(2025, 2, 1, 10, 0, 0, 0, time.UTC))
-
-	addCommit(t, repo,
-		"Upstream fix\n\nAffects: kernel",
-		"Charlie", "charlie@example.com",
-		time.Date(2025, 3, 1, 10, 0, 0, 0, time.UTC))
-
-	// Matching is case-sensitive: searching for "kernel" only matches the exact-case commit.
-	results, err := sources.FindAffectsCommits(repo, "kernel")
-	require.NoError(t, err)
-	require.Len(t, results, 1)
-	assert.Equal(t, "Charlie", results[0].Author)
-
-	// Searching for "Kernel" matches only Alice's commit (exact case on component name).
-	results, err = sources.FindAffectsCommits(repo, "Kernel")
-	require.NoError(t, err)
-	require.Len(t, results, 1)
-	assert.Equal(t, "Alice", results[0].Author)
-}
-
-func TestMessageAffectsComponent(t *testing.T) {
-	tests := []struct {
-		name          string
-		componentName string
-		want          string
-	}{
-		{"simple name", "curl", "specs/c/curl/curl.lock"},
-		{"hyphenated name", "curl-minimal", "specs/c/curl-minimal/curl-minimal.lock"},
-		{"uppercase first letter", "Kernel", "specs/k/Kernel/Kernel.lock"},
-		{"single char name", "a", "specs/a/a/a.lock"},
-		{"long name", "golang-github-example", "specs/g/golang-github-example/golang-github-example.lock"},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			got, err := sources.LockFilePath(tt.componentName)
-			require.NoError(t, err)
-			assert.Equal(t, tt.want, got)
-		})
-	}
-}
 
 func TestCommitInterleavedHistory_AllOnTop(t *testing.T) {
 	// When all fingerprint changes reference the latest upstream commit,
@@ -624,6 +382,115 @@ func TestCommitInterleavedHistory_OrphanUpstreamCommit(t *testing.T) {
 	assert.Equal(t, "upstream: initial", logCommits[1].Message)
 }
 
+func TestCommitInterleavedHistory_LocalComponent(t *testing.T) {
+	// Local components have no upstream commits — all fingerprint changes
+	// have empty UpstreamCommit. The initial commit acts as the root and
+	// all synthetic commits are appended on top.
+	memFS := memfs.New()
+	storer := memory.NewStorage()
+
+	repo, err := gogit.Init(storer, memFS)
+	require.NoError(t, err)
+
+	worktree, err := repo.Worktree()
+	require.NoError(t, err)
+
+	// Create an initial commit (simulates initSourcesRepo).
+	file, err := memFS.Create("package.spec")
+	require.NoError(t, err)
+
+	_, err = file.Write([]byte("Name: local-package\nVersion: 1.0\n"))
+	require.NoError(t, err)
+	require.NoError(t, file.Close())
+
+	_, err = worktree.Add("package.spec")
+	require.NoError(t, err)
+
+	_, err = worktree.Commit("Initial sources", &gogit.CommitOptions{
+		Author: &object.Signature{
+			Name:  "azldev",
+			Email: "azldev@localhost",
+			When:  time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC),
+		},
+	})
+	require.NoError(t, err)
+
+	// Simulate overlay modification in working tree.
+	specFile, err := memFS.Create("package.spec")
+	require.NoError(t, err)
+
+	_, err = specFile.Write([]byte("Name: local-package\nVersion: 1.0\n# overlays applied\n"))
+	require.NoError(t, err)
+	require.NoError(t, specFile.Close())
+
+	// All changes have empty UpstreamCommit (local component).
+	changes := []sources.FingerprintChange{
+		{
+			CommitMetadata: sources.CommitMetadata{
+				Hash:        "local-aaa",
+				Author:      "Alice",
+				AuthorEmail: "alice@example.com",
+				Timestamp:   time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC).Unix(),
+				Message:     "Add overlay config",
+			},
+			UpstreamCommit: "", // local — no upstream.
+		},
+		{
+			CommitMetadata: sources.CommitMetadata{
+				Hash:        "local-bbb",
+				Author:      "Bob",
+				AuthorEmail: "bob@example.com",
+				Timestamp:   time.Date(2025, 2, 1, 0, 0, 0, 0, time.UTC).Unix(),
+				Message:     "Bump release",
+			},
+			UpstreamCommit: "", // local — no upstream.
+		},
+	}
+
+	err = sources.CommitInterleavedHistory(repo, changes, "")
+	require.NoError(t, err)
+
+	// Verify: initial commit + 2 synthetic = 3 commits.
+	head, err := repo.Head()
+	require.NoError(t, err)
+
+	commitIter, err := repo.Log(&gogit.LogOptions{From: head.Hash()})
+	require.NoError(t, err)
+
+	var logCommits []*object.Commit
+
+	err = commitIter.ForEach(func(c *object.Commit) error {
+		logCommits = append(logCommits, c)
+
+		return nil
+	})
+	require.NoError(t, err)
+
+	require.Len(t, logCommits, 3, "should have initial + 2 synthetic commits")
+
+	// Most recent (Bob's synthetic commit with overlay content).
+	assert.Contains(t, logCommits[0].Message, "Bump release")
+	assert.Equal(t, "Bob", logCommits[0].Author.Name)
+
+	// Alice's synthetic commit (empty — only the last carries overlay tree).
+	assert.Contains(t, logCommits[1].Message, "Add overlay config")
+	assert.Equal(t, "Alice", logCommits[1].Author.Name)
+
+	// Initial sources commit.
+	assert.Equal(t, "Initial sources", logCommits[2].Message)
+
+	// Verify the last synthetic commit has the overlay content.
+	tree, err := logCommits[0].Tree()
+	require.NoError(t, err)
+
+	entry, err := tree.File("package.spec")
+	require.NoError(t, err)
+
+	content, err := entry.Contents()
+	require.NoError(t, err)
+	assert.Contains(t, content, "# overlays applied")
+}
+
 func TestParseCommitMetadata(t *testing.T) {
 	tests := []struct {
 		name    string
@@ -633,7 +500,7 @@ func TestParseCommitMetadata(t *testing.T) {
 	}{
 		{
 			name:  "valid output",
-			input: "abc123def456\nAlice\nalice@example.com\n1706100000\nFix CVE-2025-1234",
+			input: "abc123def456\x00Alice\x00alice@example.com\x001706100000\x00Fix CVE-2025-1234",
 			want: sources.CommitMetadata{
 				Hash:        "abc123def456",
 				Author:      "Alice",
@@ -643,13 +510,13 @@ func TestParseCommitMetadata(t *testing.T) {
 			},
 		},
 		{
-			name:    "too few lines",
-			input:   "abc123\nAlice\nalice@example.com",
+			name:    "too few fields",
+			input:   "abc123\x00Alice\x00alice@example.com",
 			wantErr: true,
 		},
 		{
 			name:    "invalid timestamp",
-			input:   "abc123\nAlice\nalice@example.com\nnot-a-number\nFix bug",
+			input:   "abc123\x00Alice\x00alice@example.com\x00not-a-number\x00Fix bug",
 			wantErr: true,
 		},
 	}

--- a/internal/fingerprint/fingerprint_test.go
+++ b/internal/fingerprint/fingerprint_test.go
@@ -45,12 +45,12 @@ func computeFingerprint(
 	ctx *testctx.TestCtx,
 	comp projectconfig.ComponentConfig,
 	releaseVer string,
-	affects int,
+	manualBump int,
 ) string {
 	t.Helper()
 
 	identity, err := fingerprint.ComputeIdentity(ctx.FS(), comp, releaseVer, fingerprint.IdentityOptions{
-		ManualBump:     affects,
+		ManualBump:     manualBump,
 		SourceIdentity: "test-source-identity",
 	})
 	require.NoError(t, err)
@@ -292,7 +292,7 @@ func TestComputeIdentity_DistroChange(t *testing.T) {
 	assert.NotEqual(t, fp1, fp2, "different release version must produce different fingerprints")
 }
 
-func TestComputeIdentity_AffectsCountChange(t *testing.T) {
+func TestComputeIdentity_ManualBumpChange(t *testing.T) {
 	ctx := newTestFS(t, map[string]string{
 		"/specs/test.spec": "Name: testpkg\nVersion: 1.0",
 	})
@@ -303,7 +303,7 @@ func TestComputeIdentity_AffectsCountChange(t *testing.T) {
 	fp1 := computeFingerprint(t, ctx, comp, releaseVer, 0)
 	fp2 := computeFingerprint(t, ctx, comp, releaseVer, 1)
 
-	assert.NotEqual(t, fp1, fp2, "different affects commit count must produce different fingerprints")
+	assert.NotEqual(t, fp1, fp2, "different manual bump count must produce different fingerprints")
 }
 
 func TestComputeIdentity_UpstreamCommitChange(t *testing.T) {

--- a/internal/lockfile/lockfile.go
+++ b/internal/lockfile/lockfile.go
@@ -98,15 +98,27 @@ func Load(fs opctx.FS, path string) (*ComponentLock, error) {
 		return nil, fmt.Errorf("reading lock file %#q:\n%w", path, err)
 	}
 
+	lock, err := Parse(data)
+	if err != nil {
+		return nil, fmt.Errorf("loading lock file %#q:\n%w", path, err)
+	}
+
+	return lock, nil
+}
+
+// Parse unmarshals a [ComponentLock] from raw TOML bytes and validates the
+// format version. Use this when the lock file content has already been read
+// (e.g. from git show); use [Load] to read from the filesystem.
+func Parse(data []byte) (*ComponentLock, error) {
 	var lock ComponentLock
 	if err := toml.Unmarshal(data, &lock); err != nil {
-		return nil, fmt.Errorf("parsing lock file %#q:\n%w", path, err)
+		return nil, fmt.Errorf("parsing lock file:\n%w", err)
 	}
 
 	if lock.Version != currentVersion {
 		return nil, fmt.Errorf(
-			"unsupported lock file version %d in %#q (expected %d)",
-			lock.Version, path, currentVersion)
+			"unsupported lock file version %d (expected %d)",
+			lock.Version, currentVersion)
 	}
 
 	return &lock, nil

--- a/internal/lockfile/store.go
+++ b/internal/lockfile/store.go
@@ -22,6 +22,8 @@ type LockReader interface {
 	Get(componentName string) (*ComponentLock, error)
 	// Exists checks whether a lock file exists for the given component.
 	Exists(componentName string) (bool, error)
+	// LockDir returns the absolute path to the lock file directory.
+	LockDir() string
 	// ValidateConsistency checks lock files against the resolved component
 	// configs. Returns sorted lists of components with missing/stale locks
 	// and orphan component names.
@@ -72,6 +74,11 @@ func NewStore(fs opctx.FS, lockDir string) *Store {
 		fs:      fs,
 		lockDir: lockDir,
 	}
+}
+
+// LockDir returns the absolute path to the lock file directory.
+func (s *Store) LockDir() string {
+	return s.lockDir
 }
 
 // lockPath returns the path for a component's lock file within this store.

--- a/internal/projectconfig/project.go
+++ b/internal/projectconfig/project.go
@@ -143,7 +143,7 @@ type ProjectInfo struct {
 	DefaultDistro DistroReference `toml:"default-distro,omitempty" json:"defaultDistro,omitempty" jsonschema:"title=Default Distro,description=Default selected distro reference"`
 
 	// Default email address used for synthetic changelog entries and commits
-	// when no author email is available (e.g. when no Affects commits exist).
+	// when no author email is available (e.g. when no synthetic commits exist).
 	DefaultAuthorEmail string `toml:"default-author-email,omitempty" json:"defaultAuthorEmail,omitempty" jsonschema:"title=Default Author Email,description=Default email for synthetic changelog entries and commits"`
 }
 

--- a/internal/utils/git/git.go
+++ b/internal/utils/git/git.go
@@ -245,7 +245,8 @@ func RunInDir(
 
 	output, err := cmd.RunAndGetOutput(ctx)
 	if err != nil {
-		return "", fmt.Errorf("git %s failed:\n%v\n%w", args, stderr.String(), err)
+		return "", fmt.Errorf("failed to run command 'git %s':\n%s\n%w",
+			strings.Join(fullArgs, " "), stderr.String(), err)
 	}
 
 	return strings.TrimSpace(output), nil

--- a/internal/utils/git/git.go
+++ b/internal/utils/git/git.go
@@ -6,6 +6,7 @@
 package git
 
 import (
+	"bytes"
 	"context"
 	"errors"
 	"fmt"
@@ -221,4 +222,31 @@ func WithMetadataOnly() GitOptions {
 		opts.args = append(opts.args, "--filter=blob:none")
 		opts.args = append(opts.args, "--no-checkout")
 	}
+}
+
+// RunInDir executes a git command in the given directory and returns its
+// trimmed stdout output. The dir argument is passed via 'git -C dir'.
+func RunInDir(
+	ctx context.Context, cmdFactory opctx.CmdFactory, dir string, args ...string,
+) (string, error) {
+	var stderr bytes.Buffer
+
+	fullArgs := make([]string, 0, len(args)+2) //nolint:mnd // 2 accounts for "-C" and dir.
+	fullArgs = append(fullArgs, "-C", dir)
+	fullArgs = append(fullArgs, args...)
+
+	rawCmd := exec.CommandContext(ctx, "git", fullArgs...)
+	rawCmd.Stderr = &stderr
+
+	cmd, err := cmdFactory.Command(rawCmd)
+	if err != nil {
+		return "", fmt.Errorf("failed to create git command:\n%w", err)
+	}
+
+	output, err := cmd.RunAndGetOutput(ctx)
+	if err != nil {
+		return "", fmt.Errorf("git %s failed:\n%v\n%w", args, stderr.String(), err)
+	}
+
+	return strings.TrimSpace(output), nil
 }


### PR DESCRIPTION
Replaces the Affects: commit trailer approach for synthetic dist-git history with lock file fingerprint change detection. Instead of scanning commit messages for `Affects: <component>` lines, synthetic commits are now derived from changes to a component's `input-fingerprint` field in its lock file (specs/<letter>/<name>/<name>.lock).