### PR TITLE
feat(lock): compute and store input fingerprints during component update

### DIFF
--- a/internal/app/azldev/cmds/component/update.go
+++ b/internal/app/azldev/cmds/component/update.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/microsoft/azure-linux-dev-tools/internal/app/azldev"
 	"github.com/microsoft/azure-linux-dev-tools/internal/app/azldev/core/components"
+	"github.com/microsoft/azure-linux-dev-tools/internal/fingerprint"
 	"github.com/microsoft/azure-linux-dev-tools/internal/lockfile"
 	"github.com/microsoft/azure-linux-dev-tools/internal/projectconfig"
 	"github.com/microsoft/azure-linux-dev-tools/internal/providers/sourceproviders"
@@ -78,10 +79,15 @@ type UpdateResult struct {
 	Component      string `json:"component"                table:",sortkey"`
 	UpstreamCommit string `json:"upstreamCommit,omitempty"`
 	PreviousCommit string `json:"previousCommit,omitempty" table:"-"`
-	Changed        bool   `json:"changed"`
-	Skipped        bool   `json:"skipped,omitempty"`
-	SkipReason     string `json:"skipReason,omitempty"     table:",omitempty"`
-	Error          string `json:"error,omitempty"          table:",omitempty"`
+	// Changed is set by checkLockChanged (commit diff) or saveComponentLocks (fingerprint diff).
+	Changed    bool   `json:"changed"`
+	Skipped    bool   `json:"skipped,omitempty"`
+	SkipReason string `json:"skipReason,omitempty" table:",omitempty"`
+	Error      string `json:"error,omitempty"      table:",omitempty"`
+
+	// config is the resolved component config, used for fingerprint computation.
+	// Not serialized — only needed during the update pipeline.
+	config *projectconfig.ComponentConfig `json:"-" table:"-"`
 }
 
 // UpdateComponents resolves upstream commits for all selected components and
@@ -113,14 +119,18 @@ func UpdateComponents(env *azldev.Env, options *UpdateComponentOptions) ([]Updat
 	}
 
 	// Check results and bail on errors before saving.
-	if err := checkUpdateResults(results); err != nil {
+	if err := checkUpdateErrors(results); err != nil {
 		return results, err
 	}
 
 	// Write per-component lock files only on full success.
-	if err := saveComponentLocks(store, results); err != nil {
+	// saveComponentLocks may flip Changed for fingerprint-only diffs.
+	if err := saveComponentLocks(env, store, results); err != nil {
 		return results, err
 	}
+
+	// Log summary after save so Changed counts include fingerprint-only diffs.
+	logUpdateSummary(results)
 
 	// Prune orphan lock files when updating all components.
 	// Use the resolved component set (not raw config) to include
@@ -151,28 +161,86 @@ func UpdateComponents(env *azldev.Env, options *UpdateComponentOptions) ([]Updat
 	return filterDisplayResults(results), nil
 }
 
-// saveComponentLocks writes a lock file for each changed component.
-func saveComponentLocks(store *lockfile.Store, results []UpdateResult) error {
+// saveComponentLocks recomputes fingerprints and writes lock files for all
+// resolved components. A lock file is saved when either the upstream commit
+// or the input fingerprint has changed. The fingerprint is recomputed on every
+// update, so config/overlay changes are detected even when the upstream commit
+// stays the same.
+func saveComponentLocks(env *azldev.Env, store *lockfile.Store, results []UpdateResult) error {
 	saved := make([]string, 0, len(results))
 
+	// Log partially-saved components on any error so the user knows which
+	// lock files were written before the failure.
+	var retErr error
+
+	defer func() {
+		if retErr != nil && len(saved) > 0 {
+			slog.Info("Lock files saved before failure", "components", saved)
+		}
+	}()
+
 	for idx := range results {
-		if !results[idx].Changed || results[idx].Error != "" || results[idx].Skipped {
+		if results[idx].Error != "" || results[idx].Skipped {
 			continue
 		}
 
 		lock, lockErr := store.GetOrNew(results[idx].Component)
 		if lockErr != nil {
-			return fmt.Errorf("loading lock for %#q:\n%w", results[idx].Component, lockErr)
+			retErr = fmt.Errorf("loading lock for %#q:\n%w", results[idx].Component, lockErr)
+
+			return retErr
 		}
 
 		lock.UpstreamCommit = results[idx].UpstreamCommit
 
-		if saveErr := store.Save(results[idx].Component, lock); saveErr != nil {
-			if len(saved) > 0 {
-				slog.Info("Lock files saved before failure", "components", saved)
-			}
+		// Recompute fingerprint from resolved config + lock state.
+		if results[idx].config == nil {
+			retErr = fmt.Errorf("no resolved config for %#q; cannot compute fingerprint", results[idx].Component)
 
-			return fmt.Errorf("saving lock file for %#q:\n%w", results[idx].Component, saveErr)
+			return retErr
+		}
+
+		// Resolve per-component distro for ReleaseVer, matching the
+		// per-component resolution used by render/build/prepare-sources.
+		releaseVer, distroErr := resolveReleaseVer(env, results[idx].config)
+		if distroErr != nil {
+			retErr = fmt.Errorf("resolving distro for %#q:\n%w", results[idx].Component, distroErr)
+
+			return retErr
+		}
+
+		identity, fpErr := fingerprint.ComputeIdentity(
+			env.FS(),
+			*results[idx].config,
+			releaseVer,
+			fingerprint.IdentityOptions{
+				ManualBump:     lock.ManualBump,
+				SourceIdentity: lock.UpstreamCommit,
+			},
+		)
+		if fpErr != nil {
+			retErr = fmt.Errorf("computing fingerprint for %#q:\n%w", results[idx].Component, fpErr)
+
+			return retErr
+		}
+
+		// Mark as changed if fingerprint differs (catches config/overlay edits
+		// even when the upstream commit is unchanged).
+		if lock.InputFingerprint != identity.Fingerprint {
+			results[idx].Changed = true
+		}
+
+		lock.InputFingerprint = identity.Fingerprint
+
+		// Only write if something actually changed.
+		if !results[idx].Changed {
+			continue
+		}
+
+		if saveErr := store.Save(results[idx].Component, lock); saveErr != nil {
+			retErr = fmt.Errorf("saving lock file for %#q:\n%w", results[idx].Component, saveErr)
+
+			return retErr
 		}
 
 		saved = append(saved, results[idx].Component)
@@ -181,21 +249,15 @@ func saveComponentLocks(store *lockfile.Store, results []UpdateResult) error {
 	return nil
 }
 
-// checkUpdateResults counts results, logs a summary, and returns an error if any
-// component failed.
-func checkUpdateResults(results []UpdateResult) error {
-	var changed, skipped int
-
+// checkUpdateErrors returns an error if any component failed to resolve.
+// Does NOT log a summary — call [logUpdateSummary] after saves are complete
+// so that Changed counts include fingerprint-only diffs.
+func checkUpdateErrors(results []UpdateResult) error {
 	var failedNames []string
 
 	for idx := range results {
-		switch {
-		case results[idx].Error != "":
+		if results[idx].Error != "" {
 			failedNames = append(failedNames, results[idx].Component)
-		case results[idx].Skipped:
-			skipped++
-		case results[idx].Changed:
-			changed++
 		}
 	}
 
@@ -209,12 +271,27 @@ func checkUpdateResults(results []UpdateResult) error {
 			len(failedNames), strings.Join(failedNames, "\n  "))
 	}
 
+	return nil
+}
+
+// logUpdateSummary logs the final update summary. Called after saveComponentLocks
+// so that Changed counts reflect fingerprint-only diffs.
+func logUpdateSummary(results []UpdateResult) {
+	var changed, skipped int
+
+	for idx := range results {
+		switch {
+		case results[idx].Skipped:
+			skipped++
+		case results[idx].Changed:
+			changed++
+		}
+	}
+
 	slog.Info("Update complete",
 		"total", len(results),
 		"changed", changed,
 		"skipped", skipped)
-
-	return nil
 }
 
 // filterDisplayResults returns changed and skipped results for table display.
@@ -284,6 +361,7 @@ func resolveUpstreamCommitsParallel(
 			}
 
 			results[idx].UpstreamCommit = commitHash
+			results[idx].config = comp.GetConfig()
 
 			// Check existing lock to determine if the commit changed.
 			checkLockChanged(store, comp.GetName(), &results[idx])
@@ -347,4 +425,22 @@ func resolveOneUpstreamCommit(
 	slog.Info("Resolved upstream commit", "component", componentName, "commit", identity)
 
 	return identity, nil
+}
+
+// resolveReleaseVer resolves the distro release version for a component,
+// respecting per-component distro overrides. Falls back to the project's
+// default distro when the component doesn't specify one — matching the
+// resolution logic in sourceproviders.ResolveDistro.
+func resolveReleaseVer(env *azldev.Env, config *projectconfig.ComponentConfig) (string, error) {
+	ref := config.Spec.UpstreamDistro
+	if ref.Name == "" {
+		ref = env.Config().Project.DefaultDistro
+	}
+
+	_, distroVer, err := env.ResolveDistroRef(ref)
+	if err != nil {
+		return "", fmt.Errorf("resolving distro ref %#q:\n%w", ref.Name, err)
+	}
+
+	return distroVer.ReleaseVer, nil
 }

--- a/internal/app/azldev/cmds/component/update_internal_test.go
+++ b/internal/app/azldev/cmds/component/update_internal_test.go
@@ -1,0 +1,227 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+package component
+
+import (
+	"testing"
+
+	"github.com/microsoft/azure-linux-dev-tools/internal/app/azldev/core/testutils"
+	"github.com/microsoft/azure-linux-dev-tools/internal/lockfile"
+	"github.com/microsoft/azure-linux-dev-tools/internal/projectconfig"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// testLockDir is the lock directory used by TestEnv's project layout.
+const testLockDir = "/project/locks"
+
+// newTestStore creates a lockfile.Store backed by the TestEnv's in-memory filesystem.
+func newTestStore(t *testing.T, env *testutils.TestEnv) *lockfile.Store {
+	t.Helper()
+
+	return lockfile.NewStore(env.TestFS, testLockDir)
+}
+
+// makeResult builds an UpdateResult for testing saveComponentLocks.
+//
+//nolint:unparam // Helper is generic; tests happen to use "curl" consistently.
+func makeResult(name, commit string, config *projectconfig.ComponentConfig) UpdateResult {
+	return UpdateResult{
+		Component:      name,
+		UpstreamCommit: commit,
+		Changed:        true,
+		config:         config,
+	}
+}
+
+// readLock loads a lock file from the store and returns it. Fails the test on error.
+//
+//nolint:unparam // Helper is generic; tests happen to use "curl" consistently.
+func readLock(t *testing.T, store *lockfile.Store, name string) *lockfile.ComponentLock {
+	t.Helper()
+
+	lock, err := store.Get(name)
+	require.NoError(t, err, "reading lock for %q", name)
+
+	return lock
+}
+
+// baseConfig returns a minimal upstream component config suitable for fingerprinting.
+// The config has source type "upstream" which tells ComputeIdentity to expect a
+// SourceIdentity (provided via the lock's UpstreamCommit).
+func baseConfig(name string) *projectconfig.ComponentConfig {
+	return &projectconfig.ComponentConfig{
+		Name: name,
+		Spec: projectconfig.SpecSource{
+			SourceType: projectconfig.SpecSourceTypeUpstream,
+		},
+	}
+}
+
+func TestSaveComponentLocks_ComputesFingerprint(t *testing.T) {
+	env := testutils.NewTestEnv(t)
+	store := newTestStore(t, env)
+
+	results := []UpdateResult{
+		makeResult("curl", "abc123", baseConfig("curl")),
+	}
+
+	err := saveComponentLocks(env.Env, store, results)
+	require.NoError(t, err)
+
+	lock := readLock(t, store, "curl")
+	assert.Equal(t, "abc123", lock.UpstreamCommit)
+	assert.NotEmpty(t, lock.InputFingerprint, "fingerprint should be computed and stored")
+	assert.Contains(t, lock.InputFingerprint, "sha256:", "fingerprint should have sha256 prefix")
+}
+
+func TestSaveComponentLocks_DetectsFingerprintChange(t *testing.T) {
+	env := testutils.NewTestEnv(t)
+	store := newTestStore(t, env)
+
+	// First save — establishes baseline fingerprint.
+	config1 := baseConfig("curl")
+	results1 := []UpdateResult{makeResult("curl", "abc123", config1)}
+
+	require.NoError(t, saveComponentLocks(env.Env, store, results1))
+
+	fp1 := readLock(t, store, "curl").InputFingerprint
+	require.NotEmpty(t, fp1)
+
+	// Second save — same commit, but config changed (added build option).
+	config2 := baseConfig("curl")
+	config2.Build.With = []string{"feature_x"}
+
+	results2 := []UpdateResult{
+		{
+			Component:      "curl",
+			UpstreamCommit: "abc123",
+			Changed:        false, // commit didn't change
+			config:         config2,
+		},
+	}
+
+	require.NoError(t, saveComponentLocks(env.Env, store, results2))
+
+	fp2 := readLock(t, store, "curl").InputFingerprint
+	assert.NotEqual(t, fp1, fp2, "fingerprint should change when config changes")
+	assert.True(t, results2[0].Changed, "Changed should be set to true by fingerprint diff")
+}
+
+func TestSaveComponentLocks_SkipsUnchanged(t *testing.T) {
+	env := testutils.NewTestEnv(t)
+	store := newTestStore(t, env)
+
+	config := baseConfig("curl")
+
+	// First save.
+	results1 := []UpdateResult{makeResult("curl", "abc123", config)}
+	require.NoError(t, saveComponentLocks(env.Env, store, results1))
+
+	fp1 := readLock(t, store, "curl").InputFingerprint
+
+	// Second save — identical commit and config. Changed starts as false.
+	results2 := []UpdateResult{
+		{
+			Component:      "curl",
+			UpstreamCommit: "abc123",
+			Changed:        false,
+			config:         config,
+		},
+	}
+
+	require.NoError(t, saveComponentLocks(env.Env, store, results2))
+
+	assert.False(t, results2[0].Changed, "should remain unchanged when fingerprint matches")
+
+	// Fingerprint should still be the same.
+	fp2 := readLock(t, store, "curl").InputFingerprint
+	assert.Equal(t, fp1, fp2)
+}
+
+func TestSaveComponentLocks_SkipsErrorAndSkipped(t *testing.T) {
+	env := testutils.NewTestEnv(t)
+	store := newTestStore(t, env)
+
+	results := []UpdateResult{
+		{Component: "errored", Error: "resolution failed", config: baseConfig("errored")},
+		{Component: "skipped", Skipped: true, SkipReason: "local", config: baseConfig("skipped")},
+	}
+
+	err := saveComponentLocks(env.Env, store, results)
+	require.NoError(t, err)
+
+	// Neither should have lock files.
+	exists1, _ := store.Exists("errored")
+	assert.False(t, exists1)
+
+	exists2, _ := store.Exists("skipped")
+	assert.False(t, exists2)
+}
+
+func TestSaveComponentLocks_ErrorOnNilConfig(t *testing.T) {
+	env := testutils.NewTestEnv(t)
+	store := newTestStore(t, env)
+
+	results := []UpdateResult{
+		{Component: "bad", UpstreamCommit: "abc", Changed: true, config: nil},
+	}
+
+	err := saveComponentLocks(env.Env, store, results)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "no resolved config")
+}
+
+func TestSaveComponentLocks_PreservesManualBump(t *testing.T) {
+	env := testutils.NewTestEnv(t)
+	store := newTestStore(t, env)
+
+	// Pre-populate lock with ManualBump = 3.
+	existingLock := lockfile.New()
+	existingLock.UpstreamCommit = "old-commit"
+	existingLock.ManualBump = 3
+
+	require.NoError(t, store.Save("curl", existingLock))
+
+	// Update with new commit.
+	results := []UpdateResult{makeResult("curl", "new-commit", baseConfig("curl"))}
+
+	require.NoError(t, saveComponentLocks(env.Env, store, results))
+
+	lock := readLock(t, store, "curl")
+	assert.Equal(t, "new-commit", lock.UpstreamCommit)
+	assert.Equal(t, 3, lock.ManualBump, "ManualBump should be preserved from existing lock")
+	assert.NotEmpty(t, lock.InputFingerprint)
+}
+
+func TestSaveComponentLocks_ManualBumpAffectsFingerprint(t *testing.T) {
+	env := testutils.NewTestEnv(t)
+	store := newTestStore(t, env)
+	config := baseConfig("curl")
+
+	// Save with ManualBump = 0.
+	results1 := []UpdateResult{makeResult("curl", "abc123", config)}
+	require.NoError(t, saveComponentLocks(env.Env, store, results1))
+
+	fp1 := readLock(t, store, "curl").InputFingerprint
+
+	// Manually bump.
+	lock, getLockErr := store.Get("curl")
+	require.NoError(t, getLockErr)
+
+	lock.ManualBump = 1
+
+	require.NoError(t, store.Save("curl", lock))
+
+	// Re-run save with same commit and config.
+	results2 := []UpdateResult{
+		{Component: "curl", UpstreamCommit: "abc123", Changed: false, config: config},
+	}
+
+	require.NoError(t, saveComponentLocks(env.Env, store, results2))
+
+	fp2 := readLock(t, store, "curl").InputFingerprint
+	assert.NotEqual(t, fp1, fp2, "ManualBump change should produce different fingerprint")
+	assert.True(t, results2[0].Changed, "should be marked changed due to fingerprint diff")
+}

--- a/internal/app/azldev/cmds/component/update_test.go
+++ b/internal/app/azldev/cmds/component/update_test.go
@@ -4,13 +4,22 @@
 package component_test
 
 import (
+	"os/exec"
+	"strings"
 	"testing"
 
 	componentcmds "github.com/microsoft/azure-linux-dev-tools/internal/app/azldev/cmds/component"
+	"github.com/microsoft/azure-linux-dev-tools/internal/app/azldev/core/components"
 	"github.com/microsoft/azure-linux-dev-tools/internal/app/azldev/core/testutils"
+	"github.com/microsoft/azure-linux-dev-tools/internal/lockfile"
+	"github.com/microsoft/azure-linux-dev-tools/internal/projectconfig"
+	"github.com/microsoft/azure-linux-dev-tools/internal/utils/fileperms"
+	"github.com/microsoft/azure-linux-dev-tools/internal/utils/fileutils"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+const testLockDir = "/project/locks"
 
 func TestNewUpdateCmd(t *testing.T) {
 	cmd := componentcmds.NewUpdateCmd()
@@ -39,4 +48,233 @@ func TestUpdateCmd_NoComponents(t *testing.T) {
 
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "component not found")
+}
+
+// setupMockGit configures the test environment's CmdFactory to simulate git operations.
+// git clone: creates a destination directory.
+// git rev-parse / git rev-list: returns the provided commit hash.
+// All other git commands succeed silently.
+func setupMockGit(env *testutils.TestEnv, commitHash string) {
+	env.CmdFactory.RegisterCommandInSearchPath("git")
+
+	env.CmdFactory.RunHandler = func(cmd *exec.Cmd) error {
+		args := cmd.Args
+
+		// git clone: create a minimal repo structure in the destination dir.
+		for idx, arg := range args {
+			if arg == "clone" {
+				// Last arg is the destination directory.
+				destDir := args[len(args)-1]
+
+				return fileutils.MkdirAll(env.TestFS, destDir)
+			}
+
+			// git checkout: no-op.
+			if arg == "checkout" {
+				return nil
+			}
+
+			// git -C <dir> rev-list: return the commit hash (for snapshot resolution).
+			if arg == "rev-list" || (idx > 0 && args[idx-1] == "-C" && strings.Contains(strings.Join(args, " "), "rev-list")) {
+				return nil
+			}
+		}
+
+		return nil
+	}
+
+	env.CmdFactory.RunAndGetOutputHandler = func(cmd *exec.Cmd) (string, error) {
+		// git rev-parse HEAD: return the configured commit hash.
+		if strings.Contains(strings.Join(cmd.Args, " "), "rev-parse") {
+			return commitHash, nil
+		}
+
+		// git log / git rev-list --before: return the commit hash.
+		if strings.Contains(strings.Join(cmd.Args, " "), "rev-list") {
+			return commitHash, nil
+		}
+
+		return "", nil
+	}
+}
+
+// addUpstreamComponent registers an upstream component in the test config.
+func addUpstreamComponent(env *testutils.TestEnv, name string) {
+	env.Config.Components[name] = projectconfig.ComponentConfig{
+		Name: name,
+		Spec: projectconfig.SpecSource{
+			SourceType: projectconfig.SpecSourceTypeUpstream,
+		},
+	}
+}
+
+// TestUpdateComponents_WritesFingerprint exercises the full UpdateComponents pipeline
+// with mocked git, verifying that lock files are created with fingerprints.
+func TestUpdateComponents_WritesFingerprint(t *testing.T) {
+	env := testutils.NewTestEnv(t)
+
+	const commit = "abc123def456"
+
+	setupMockGit(env, commit)
+	addUpstreamComponent(env, "curl")
+
+	// Pre-create a lock file so the spec file is writable on memfs.
+	require.NoError(t, fileutils.MkdirAll(env.TestFS, testLockDir))
+
+	results, err := componentcmds.UpdateComponents(env.Env, &componentcmds.UpdateComponentOptions{
+		ComponentFilter: components.ComponentFilter{IncludeAllComponents: true},
+	})
+	require.NoError(t, err)
+	require.Len(t, results, 1)
+	assert.True(t, results[0].Changed)
+	assert.Equal(t, commit, results[0].UpstreamCommit)
+
+	// Verify lock file was written with fingerprint.
+	store := lockfile.NewStore(env.TestFS, testLockDir)
+
+	lock, loadErr := store.Get("curl")
+	require.NoError(t, loadErr)
+	assert.Equal(t, commit, lock.UpstreamCommit)
+	assert.NotEmpty(t, lock.InputFingerprint, "lock should have a computed fingerprint")
+	assert.Contains(t, lock.InputFingerprint, "sha256:")
+}
+
+// TestUpdateComponents_FingerprintLifecycle exercises the full update → modify → re-update
+// flow through the public UpdateComponents API.
+func TestUpdateComponents_FingerprintLifecycle(t *testing.T) {
+	env := testutils.NewTestEnv(t)
+
+	const commit = "abc123def456"
+
+	setupMockGit(env, commit)
+	addUpstreamComponent(env, "curl")
+
+	require.NoError(t, fileutils.MkdirAll(env.TestFS, testLockDir))
+
+	options := &componentcmds.UpdateComponentOptions{
+		ComponentFilter: components.ComponentFilter{IncludeAllComponents: true},
+	}
+
+	// Phase 1: Initial update.
+	results, err := componentcmds.UpdateComponents(env.Env, options)
+	require.NoError(t, err)
+	require.Len(t, results, 1)
+	assert.True(t, results[0].Changed)
+
+	store := lockfile.NewStore(env.TestFS, testLockDir)
+	fp1 := mustGetFingerprint(t, store, "curl")
+
+	// Phase 2: Re-run with same commit — idempotent.
+	results2, err := componentcmds.UpdateComponents(env.Env, options)
+	require.NoError(t, err)
+	assert.Empty(t, results2, "idempotent re-run should produce no display results")
+
+	// Recreate store to bypass read cache.
+	store = lockfile.NewStore(env.TestFS, testLockDir)
+	fp2 := mustGetFingerprint(t, store, "curl")
+	assert.Equal(t, fp1, fp2, "fingerprint should be stable on re-run")
+
+	// Phase 3: Modify config — fingerprint should change.
+	// Build.With survives inheritance (mergo preserves non-empty fields from
+	// later layers), so adding a build option changes the config hash.
+	modifiedConfig := env.Config.Components["curl"]
+	modifiedConfig.Build.With = []string{"ssl"}
+	env.Config.Components["curl"] = modifiedConfig
+
+	_, err = componentcmds.UpdateComponents(env.Env, options)
+	require.NoError(t, err)
+
+	// Recreate store to bypass read cache.
+	store = lockfile.NewStore(env.TestFS, testLockDir)
+	fp3 := mustGetFingerprint(t, store, "curl")
+	assert.NotEqual(t, fp1, fp3, "config change (Build.With) must produce a different fingerprint")
+}
+
+// TestUpdateComponents_MultipleComponents tests update with multiple components.
+func TestUpdateComponents_MultipleComponents(t *testing.T) {
+	env := testutils.NewTestEnv(t)
+
+	const commit = "multi-commit-hash"
+
+	setupMockGit(env, commit)
+	addUpstreamComponent(env, "curl")
+	addUpstreamComponent(env, "bash")
+
+	require.NoError(t, fileutils.MkdirAll(env.TestFS, testLockDir))
+
+	results, err := componentcmds.UpdateComponents(env.Env, &componentcmds.UpdateComponentOptions{
+		ComponentFilter: components.ComponentFilter{IncludeAllComponents: true},
+	})
+	require.NoError(t, err)
+
+	// Should have results for both (may include skipped too).
+	var changedNames []string
+
+	for _, r := range results {
+		if r.Changed {
+			changedNames = append(changedNames, r.Component)
+		}
+	}
+
+	assert.Contains(t, changedNames, "curl")
+	assert.Contains(t, changedNames, "bash")
+
+	// Both should have lock files with fingerprints.
+	store := lockfile.NewStore(env.TestFS, testLockDir)
+
+	curlFP := mustGetFingerprint(t, store, "curl")
+	bashFP := mustGetFingerprint(t, store, "bash")
+
+	assert.NotEmpty(t, curlFP)
+	assert.NotEmpty(t, bashFP)
+	// Note: components with identical configs (same source type, no overlays, same commit)
+	// will produce the same fingerprint — Name is excluded from the hash by design.
+	// This is correct: the fingerprint captures build-affecting inputs only.
+}
+
+// TestUpdateComponents_SkipsLocalComponent verifies local components are skipped.
+func TestUpdateComponents_SkipsLocalComponent(t *testing.T) {
+	env := testutils.NewTestEnv(t)
+
+	setupMockGit(env, "doesnt-matter")
+
+	// Add a local component (no upstream).
+	specPath := "/project/specs/local-pkg/local-pkg.spec"
+	require.NoError(t, fileutils.WriteFile(env.TestFS, specPath, []byte("Name: local-pkg\n"), fileperms.PrivateFile))
+
+	env.Config.Components["local-pkg"] = projectconfig.ComponentConfig{
+		Name: "local-pkg",
+		Spec: projectconfig.SpecSource{
+			SourceType: projectconfig.SpecSourceTypeLocal,
+			Path:       specPath,
+		},
+	}
+
+	require.NoError(t, fileutils.MkdirAll(env.TestFS, testLockDir))
+
+	results, err := componentcmds.UpdateComponents(env.Env, &componentcmds.UpdateComponentOptions{
+		ComponentFilter: components.ComponentFilter{IncludeAllComponents: true},
+	})
+	require.NoError(t, err)
+
+	// Should be skipped.
+	for _, r := range results {
+		if r.Component == "local-pkg" {
+			assert.True(t, r.Skipped)
+
+			return
+		}
+	}
+
+	// If local-pkg isn't in results at all, that's also acceptable (filtered out).
+}
+
+// mustGetFingerprint reads the fingerprint from a lock file, failing the test on error.
+func mustGetFingerprint(t *testing.T, store *lockfile.Store, name string) string {
+	t.Helper()
+
+	lock, err := store.Get(name)
+	require.NoError(t, err, "loading lock for %q", name)
+
+	return lock.InputFingerprint
 }

--- a/internal/app/azldev/core/testutils/testenv.go
+++ b/internal/app/azldev/core/testutils/testenv.go
@@ -169,6 +169,7 @@ func constructProjectConfig(testMockConfigPath string) *projectconfig.ProjectCon
 	distro.Versions["1.0"] = projectconfig.DistroVersionDefinition{
 		MockConfigPath: testMockConfigPath,
 		DistGitBranch:  "main",
+		ReleaseVer:     "3.0",
 	}
 
 	config.Distros["test-distro"] = distro


### PR DESCRIPTION
Wire fingerprint.ComputeIdentity into the update command's save path. After resolving upstream commits, the fingerprint is recomputed from the resolved component config, lock state (ManualBump, UpstreamCommit), and distro release version, then stored as input-fingerprint in the lock file. In this initial version the fingerprint is recomputed for every resolved component on every update, not just when the upstream commit changes:

Commit changed: Changed=true (as before)
Commit same but fingerprint differs: Changed=true (new)
Both same: skip, no write