### PR TITLE
fix(component): support git worktrees in synthetic history generation

### DIFF
--- a/internal/app/azldev/core/sources/synthistory.go
+++ b/internal/app/azldev/core/sources/synthistory.go
@@ -233,7 +233,8 @@ func resolveConfigFilePath(config *projectconfig.ComponentConfig, componentName 
 // walking up the directory tree.
 func openProjectRepo(configFilePath string) (*gogit.Repository, error) {
 	repo, err := gogit.PlainOpenWithOptions(filepath.Dir(configFilePath), &gogit.PlainOpenOptions{
-		DetectDotGit: true,
+		DetectDotGit:          true,
+		EnableDotGitCommonDir: true,
 	})
 	if err != nil {
 		return nil, fmt.Errorf("failed to find project repository for config file %#q:\n%w",


### PR DESCRIPTION
Fixes #124

When running `azldev component render` from inside a git worktree, synthetic history generation failed while resolving HEAD:

```
failed to get HEAD reference:
reference not found
```

A linked worktree's `.git` is a file pointing at `<main>/.git/worktrees/<name>`, and refs/HEAD live in the common git directory. Setting `EnableDotGitCommonDir: true` on the `gogit.PlainOpenOptions` makes go-git resolve the common dir correctly.

The other `gogit.PlainOpen` site in `sourceprep.go` operates on a repository azldev creates itself via `PlainInit`, so it is never a worktree and does not need the same change.

---
Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>