### PR TITLE
feat(lock): populate resolved lock data onto components during resolu…

### DIFF
--- a/internal/app/azldev/cmds/component/update.go
+++ b/internal/app/azldev/cmds/component/update.go
@@ -94,6 +94,9 @@ type UpdateResult struct {
 // writes the results to per-component lock files under locks/.
 func UpdateComponents(env *azldev.Env, options *UpdateComponentOptions) ([]UpdateResult, error) {
 	resolver := components.NewResolver(env)
+	// Suppress staleness warnings — we're about to refresh the locks ourselves,
+	// so warning the user to "run component update" would be self-referential noise.
+	resolver.SuppressLockWarnings = true
 
 	resolved, err := resolver.FindComponents(&options.ComponentFilter)
 	if err != nil {
@@ -349,6 +352,12 @@ func resolveUpstreamCommitsParallel(
 
 				return
 			}
+
+			// Drop populated lock data so the source provider re-resolves
+			// from upstream (snapshot/HEAD or pinned commit) instead of
+			// short-circuiting with the existing locked commit. We're
+			// about to overwrite the lock anyway.
+			comp.GetConfig().Locked = nil
 
 			commitHash, resolveErr := resolveOneUpstreamCommit(workerEnv, comp)
 			if resolveErr != nil {

--- a/internal/app/azldev/cmds/component/update_test.go
+++ b/internal/app/azldev/cmds/component/update_test.go
@@ -278,3 +278,52 @@ func mustGetFingerprint(t *testing.T, store *lockfile.Store, name string) string
 
 	return lock.InputFingerprint
 }
+
+// TestUpdateComponents_AdvancesStaleLock is a regression test for the case
+// where a pre-existing lock at commit A and an upstream that has moved to
+// commit B must result in B being written (not A echoed back). Without
+// clearing populated lock data before re-resolution, the source provider's
+// locked-commit short-circuit in ResolveIdentity would return A and the
+// lock would never advance.
+func TestUpdateComponents_AdvancesStaleLock(t *testing.T) {
+	env := testutils.NewTestEnv(t)
+
+	const initialCommit = "initial-aaa111"
+
+	const advancedCommit = "advanced-bbb222"
+
+	// Pre-populate a lock at initialCommit (simulates a previous update run).
+	require.NoError(t, fileutils.MkdirAll(env.TestFS, testLockDir))
+
+	preExistingLock := lockfile.New()
+	preExistingLock.UpstreamCommit = initialCommit
+
+	store := lockfile.NewStore(env.TestFS, testLockDir)
+	require.NoError(t, store.Save("curl", preExistingLock))
+
+	addUpstreamComponent(env, "curl")
+
+	// Mock git now resolves to a NEW commit — upstream moved.
+	setupMockGit(env, advancedCommit)
+
+	results, err := componentcmds.UpdateComponents(env.Env, &componentcmds.UpdateComponentOptions{
+		ComponentFilter: components.ComponentFilter{IncludeAllComponents: true},
+	})
+	require.NoError(t, err)
+	require.Len(t, results, 1)
+
+	assert.Equal(t, advancedCommit, results[0].UpstreamCommit,
+		"update must re-resolve and return the advanced commit, not echo the locked one")
+	assert.True(t, results[0].Changed, "lock advanced from initial to advanced commit")
+	assert.Equal(t, initialCommit, results[0].PreviousCommit,
+		"PreviousCommit should track what was in the lock before update")
+
+	// Verify the lock on disk was actually updated. Use a fresh store to
+	// bypass the cache held by the pre-population store.
+	freshStore := lockfile.NewStore(env.TestFS, testLockDir)
+
+	updatedLock, loadErr := freshStore.Get("curl")
+	require.NoError(t, loadErr)
+	assert.Equal(t, advancedCommit, updatedLock.UpstreamCommit,
+		"lock file on disk must contain the new commit")
+}

--- a/internal/app/azldev/core/components/resolver.go
+++ b/internal/app/azldev/core/components/resolver.go
@@ -64,6 +64,8 @@ func (r *Resolver) FindComponents(filter *ComponentFilter) (components *Componen
 			return allComps, findErr
 		}
 
+		r.warnOnLockDrift(allComps)
+
 		return allComps, r.validateLockFiles(allComps, true, skipValidation)
 	}
 
@@ -92,6 +94,8 @@ func (r *Resolver) FindComponents(filter *ComponentFilter) (components *Componen
 			return components, err
 		}
 	}
+
+	r.warnOnLockDrift(components)
 
 	return components, r.validateLockFiles(components, false, skipValidation)
 }
@@ -540,21 +544,6 @@ func (r *Resolver) populateFromLock(config *projectconfig.ComponentConfig) {
 		return
 	}
 
-	// Warn when locked commit differs from explicit config pin - this is a
-	// staleness signal. Validation catches it as an error when enabled, but
-	// during the rollout transition we surface it as a warning. Suppressed
-	// for callers (e.g., 'component update') that are about to refresh the
-	// lock themselves.
-	if !r.SuppressLockWarnings &&
-		config.Spec.UpstreamCommit != "" &&
-		lock.UpstreamCommit != "" &&
-		config.Spec.UpstreamCommit != lock.UpstreamCommit {
-		slog.Warn("Lock differs from config pin - run 'component update' to refresh",
-			"component", config.Name,
-			"configPin", config.Spec.UpstreamCommit,
-			"lockedCommit", lock.UpstreamCommit)
-	}
-
 	config.Locked = &projectconfig.ComponentLockData{
 		UpstreamCommit:   lock.UpstreamCommit,
 		ImportCommit:     lock.ImportCommit,
@@ -563,6 +552,35 @@ func (r *Resolver) populateFromLock(config *projectconfig.ComponentConfig) {
 	}
 
 	slog.Debug("Populated lock data", "component", config.Name, "commit", lock.UpstreamCommit)
+}
+
+// warnOnLockDrift emits a staleness warning for each component in the resolved
+// set whose explicit config pin (Spec.UpstreamCommit) disagrees with its locked
+// commit. This runs against the filtered set so users only see warnings about
+// components they asked about, not about all components in the project.
+//
+// No-op when [Resolver.SuppressLockWarnings] is set (e.g., during component
+// update, which is about to refresh the lock).
+func (r *Resolver) warnOnLockDrift(resolved *ComponentSet) {
+	if r.SuppressLockWarnings {
+		return
+	}
+
+	for _, comp := range resolved.Components() {
+		cfg := comp.GetConfig()
+		if cfg.Locked == nil {
+			continue
+		}
+
+		if cfg.Spec.UpstreamCommit != "" &&
+			cfg.Locked.UpstreamCommit != "" &&
+			cfg.Spec.UpstreamCommit != cfg.Locked.UpstreamCommit {
+			slog.Warn("Lock differs from config pin - run 'component update' to refresh",
+				"component", cfg.Name,
+				"configPin", cfg.Spec.UpstreamCommit,
+				"lockedCommit", cfg.Locked.UpstreamCommit)
+		}
+	}
 }
 
 // Given an explicit component config, apply all inherited defaults.

--- a/internal/app/azldev/core/components/resolver.go
+++ b/internal/app/azldev/core/components/resolver.go
@@ -24,6 +24,12 @@ var ErrComponentGroupNotFound = errors.New("component group not found")
 // Resolver is a utility for resolving components in an environment.
 type Resolver struct {
 	env *azldev.Env
+	// SuppressLockWarnings disables advisory warnings emitted during lock
+	// population (e.g., staleness warning when config pin differs from locked
+	// commit). Set this for commands that are about to refresh the lock
+	// themselves (e.g., 'component update') to avoid noise telling the user
+	// to do what they're already doing.
+	SuppressLockWarnings bool
 }
 
 // NewResolver constructs a new [Resolver] for the given environment.
@@ -479,10 +485,84 @@ func (r *Resolver) createComponentFromConfig(componentConfig *projectconfig.Comp
 		componentConfig.Release.Calculation = projectconfig.ReleaseCalculationAuto
 	}
 
+	// Populate locked state onto the component config. This makes lock data
+	// available to all downstream consumers (render, build, prepare-sources,
+	// diff-sources) without each needing lock-file awareness.
+	r.populateFromLock(componentConfig)
+
 	return &resolvedComponent{
 		env:    r.env,
 		config: *componentConfig,
 	}, nil
+}
+
+// populateFromLock reads lock file data and attaches it to the component config
+// as [projectconfig.ComponentLockData]. This centralizes lock-file consumption so
+// all downstream commands (render, build, prepare-sources, diff-sources) get
+// locked state automatically via config.Locked.
+//
+// IMPORTANT: This must NEVER overwrite user-specified config values. Lock data
+// goes into the separate Locked field, preserving the manifest/lock boundary:
+// Spec.UpstreamCommit = user intent, Locked.UpstreamCommit = resolved reality.
+func (r *Resolver) populateFromLock(config *projectconfig.ComponentConfig) {
+	// Lock state is only meaningful for upstream components. Local and
+	// unspecified-source components do not have upstream commits to track,
+	// and any orphaned same-name lock file should not leak into their config.
+	if config.Spec.SourceType != projectconfig.SpecSourceTypeUpstream {
+		return
+	}
+
+	reader := r.env.LockReader()
+	if reader == nil {
+		return
+	}
+
+	// Distinguish "not found" from real errors. A missing lock is normal
+	// (new component, or lock validation disabled); a corrupt/unreadable
+	// lock should be surfaced so it doesn't silently fall back to live
+	// upstream resolution.
+	exists, existsErr := reader.Exists(config.Name)
+	if existsErr != nil {
+		slog.Warn("Cannot check lock file", "component", config.Name, "error", existsErr)
+
+		return
+	}
+
+	if !exists {
+		return
+	}
+
+	lock, err := reader.Get(config.Name)
+	if err != nil {
+		slog.Warn("Lock file exists but is unreadable (corrupt or unsupported version)",
+			"component", config.Name, "error", err)
+
+		return
+	}
+
+	// Warn when locked commit differs from explicit config pin - this is a
+	// staleness signal. Validation catches it as an error when enabled, but
+	// during the rollout transition we surface it as a warning. Suppressed
+	// for callers (e.g., 'component update') that are about to refresh the
+	// lock themselves.
+	if !r.SuppressLockWarnings &&
+		config.Spec.UpstreamCommit != "" &&
+		lock.UpstreamCommit != "" &&
+		config.Spec.UpstreamCommit != lock.UpstreamCommit {
+		slog.Warn("Lock differs from config pin - run 'component update' to refresh",
+			"component", config.Name,
+			"configPin", config.Spec.UpstreamCommit,
+			"lockedCommit", lock.UpstreamCommit)
+	}
+
+	config.Locked = &projectconfig.ComponentLockData{
+		UpstreamCommit:   lock.UpstreamCommit,
+		ImportCommit:     lock.ImportCommit,
+		ManualBump:       lock.ManualBump,
+		InputFingerprint: lock.InputFingerprint,
+	}
+
+	slog.Debug("Populated lock data", "component", config.Name, "commit", lock.UpstreamCommit)
 }
 
 // Given an explicit component config, apply all inherited defaults.

--- a/internal/app/azldev/core/components/resolver_test.go
+++ b/internal/app/azldev/core/components/resolver_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/microsoft/azure-linux-dev-tools/internal/app/azldev/core/components"
 	"github.com/microsoft/azure-linux-dev-tools/internal/app/azldev/core/testutils"
+	"github.com/microsoft/azure-linux-dev-tools/internal/lockfile"
 	"github.com/microsoft/azure-linux-dev-tools/internal/projectconfig"
 	"github.com/microsoft/azure-linux-dev-tools/internal/utils/fileperms"
 	"github.com/microsoft/azure-linux-dev-tools/internal/utils/fileutils"
@@ -672,4 +673,224 @@ func TestFindAllSpecPaths_MultipleSpecs(t *testing.T) {
 	specPaths, err := components.FindAllSpecPaths(env.Env)
 	require.NoError(t, err)
 	assert.ElementsMatch(t, []string{"/specs/a/test-a.spec", "/specs/b/test-b.spec"}, specPaths)
+}
+
+// When a lock file exists for a component, the resolver should attach all of
+// its data (commit, import-commit, manual-bump, fingerprint) to the resolved
+// component via the Locked field — without touching the original Spec config.
+// This is how downstream commands (render, build) get the locked commit.
+func TestFindComponents_PopulatesLockedData(t *testing.T) {
+	env := testutils.NewTestEnv(t)
+
+	// Add an upstream component with no explicit pin.
+	env.Config.Components["curl"] = projectconfig.ComponentConfig{
+		Name: "curl",
+		Spec: projectconfig.SpecSource{
+			SourceType: projectconfig.SpecSourceTypeUpstream,
+		},
+	}
+
+	// Create a lock file with upstream commit.
+	lock := lockfile.New()
+	lock.UpstreamCommit = "locked-commit-abc123"
+	lock.ImportCommit = "import-commit-def456"
+	lock.ManualBump = 2
+	lock.InputFingerprint = "sha256:test-fingerprint"
+
+	env.WriteLock(t, "curl", lock)
+
+	filter := &components.ComponentFilter{IncludeAllComponents: true}
+
+	resolved, err := components.NewResolver(env.Env).FindComponents(filter)
+	require.NoError(t, err)
+
+	comp, ok := resolved.TryGet("curl")
+	require.True(t, ok)
+
+	// Locked field should be populated from the lock file.
+	require.NotNil(t, comp.GetConfig().Locked, "Locked should be populated when lock file exists")
+	assert.Equal(t, "locked-commit-abc123", comp.GetConfig().Locked.UpstreamCommit)
+	assert.Equal(t, "import-commit-def456", comp.GetConfig().Locked.ImportCommit)
+	assert.Equal(t, 2, comp.GetConfig().Locked.ManualBump)
+	assert.Equal(t, "sha256:test-fingerprint", comp.GetConfig().Locked.InputFingerprint)
+
+	// Original config field should NOT be modified.
+	assert.Empty(t, comp.GetConfig().Spec.UpstreamCommit,
+		"Spec.UpstreamCommit should remain empty — lock data goes into Locked, not Spec")
+}
+
+// When no lock file exists (e.g., new component that hasn't been updated yet),
+// the Locked field should be nil. Downstream commands will fall back to the old
+// resolution path (snapshot/HEAD) until the user runs 'component update'.
+//
+// TODO(lockfiles): Once lock validation is default-on, a missing lock for an
+// upstream component should be an error, not a silent nil. Update this test to
+// expect FindComponents to return an error, and remove the fallback path.
+//
+//nolint:godox // tracked by TODO(lockfiles) tag.
+func TestFindComponents_LockedNilWhenNoLockFile(t *testing.T) {
+	env := testutils.NewTestEnv(t)
+
+	// Add component with no lock file.
+	env.Config.Components["bash"] = projectconfig.ComponentConfig{
+		Name: "bash",
+		Spec: projectconfig.SpecSource{
+			SourceType: projectconfig.SpecSourceTypeUpstream,
+		},
+	}
+
+	filter := &components.ComponentFilter{IncludeAllComponents: true}
+
+	resolved, err := components.NewResolver(env.Env).FindComponents(filter)
+	require.NoError(t, err)
+
+	comp, ok := resolved.TryGet("bash")
+	require.True(t, ok)
+
+	assert.Nil(t, comp.GetConfig().Locked, "Locked should be nil when no lock file exists")
+}
+
+// When a user explicitly pins a commit in their component config (intent),
+// that pin must survive lock population unchanged. The lock's commit goes
+// into Locked.UpstreamCommit separately. This separation is what allows
+// validation to detect "config says X but lock says Y" staleness.
+func TestFindComponents_ExplicitPinPreserved(t *testing.T) {
+	env := testutils.NewTestEnv(t)
+
+	// Component with explicit upstream-commit pin in config.
+	env.Config.Components["curl"] = projectconfig.ComponentConfig{
+		Name: "curl",
+		Spec: projectconfig.SpecSource{
+			SourceType:     projectconfig.SpecSourceTypeUpstream,
+			UpstreamCommit: "config-pinned-commit",
+		},
+	}
+
+	// Lock file has a different commit.
+	lock := lockfile.New()
+	lock.UpstreamCommit = "locked-commit-different"
+
+	env.WriteLock(t, "curl", lock)
+
+	filter := &components.ComponentFilter{IncludeAllComponents: true}
+
+	resolved, err := components.NewResolver(env.Env).FindComponents(filter)
+	require.NoError(t, err)
+
+	comp, ok := resolved.TryGet("curl")
+	require.True(t, ok)
+
+	// Explicit pin must be preserved in Spec.
+	assert.Equal(t, "config-pinned-commit", comp.GetConfig().Spec.UpstreamCommit,
+		"explicit config pin must not be overwritten by lock data")
+
+	// Locked should still be populated with the correct data from the lock file.
+	require.NotNil(t, comp.GetConfig().Locked)
+	assert.Equal(t, "locked-commit-different", comp.GetConfig().Locked.UpstreamCommit)
+}
+
+// Local components (specs on disk, no upstream) don't have lock files.
+// The resolver should leave Locked as nil — no error, no special handling.
+func TestFindComponents_LocalComponentNoLockPopulation(t *testing.T) {
+	env := testutils.NewTestEnv(t)
+
+	specPath := "/specs/local-pkg/local-pkg.spec"
+	require.NoError(t, fileutils.WriteFile(env.TestFS, specPath, []byte("Name: local-pkg\n"), fileperms.PrivateFile))
+
+	env.Config.Components["local-pkg"] = projectconfig.ComponentConfig{
+		Name: "local-pkg",
+		Spec: projectconfig.SpecSource{
+			SourceType: projectconfig.SpecSourceTypeLocal,
+			Path:       specPath,
+		},
+	}
+
+	// No lock file for local component — this is normal.
+	filter := &components.ComponentFilter{IncludeAllComponents: true}
+
+	resolved, err := components.NewResolver(env.Env).FindComponents(filter)
+	require.NoError(t, err)
+
+	comp, ok := resolved.TryGet("local-pkg")
+	require.True(t, ok)
+
+	assert.Nil(t, comp.GetConfig().Locked, "local components should not have lock data")
+}
+
+// A corrupt or unparseable lock file should not silently fall back to
+// unlocked live resolution. populateFromLock should leave Locked nil and
+// log a warning (no error returned, since validation is gated separately).
+func TestFindComponents_CorruptLockSurfaces(t *testing.T) {
+	env := testutils.NewTestEnv(t)
+
+	env.Config.Components["curl"] = projectconfig.ComponentConfig{
+		Name: "curl",
+		Spec: projectconfig.SpecSource{
+			SourceType: projectconfig.SpecSourceTypeUpstream,
+		},
+	}
+
+	// Write garbage to the lock file path so Load() returns a parse error.
+	lockPath := "/project/locks/curl.lock"
+	require.NoError(t, fileutils.WriteFile(env.TestFS, lockPath,
+		[]byte("this is not valid TOML \x00\x01\x02"), fileperms.PrivateFile))
+
+	filter := &components.ComponentFilter{IncludeAllComponents: true}
+
+	resolved, err := components.NewResolver(env.Env).FindComponents(filter)
+	require.NoError(t, err, "corrupt lock should warn, not fail (validation is separate)")
+
+	comp, ok := resolved.TryGet("curl")
+	require.True(t, ok)
+
+	assert.Nil(t, comp.GetConfig().Locked,
+		"corrupt lock must NOT silently populate — leaves Locked nil and warns")
+}
+
+// When the explicit config pin and the locked commit differ, the lock wins
+// and a staleness warning fires (during normal resolution). The warning is
+// suppressed when SuppressLockWarnings is set (e.g., during component update).
+func TestFindComponents_PinDiffersFromLock(t *testing.T) {
+	env := testutils.NewTestEnv(t)
+
+	env.Config.Components["curl"] = projectconfig.ComponentConfig{
+		Name: "curl",
+		Spec: projectconfig.SpecSource{
+			SourceType:     projectconfig.SpecSourceTypeUpstream,
+			UpstreamCommit: "config-pin-aaa",
+		},
+	}
+
+	lock := lockfile.New()
+	lock.UpstreamCommit = "lock-commit-bbb"
+
+	env.WriteLock(t, "curl", lock)
+
+	filter := &components.ComponentFilter{IncludeAllComponents: true}
+
+	resolved, err := components.NewResolver(env.Env).FindComponents(filter)
+	require.NoError(t, err)
+
+	comp, found := resolved.TryGet("curl")
+	require.True(t, found)
+
+	// Lock value populated; user intent preserved on Spec.
+	require.NotNil(t, comp.GetConfig().Locked)
+	assert.Equal(t, "lock-commit-bbb", comp.GetConfig().Locked.UpstreamCommit,
+		"lock value populated despite differing config pin")
+	assert.Equal(t, "config-pin-aaa", comp.GetConfig().Spec.UpstreamCommit,
+		"user intent preserved on Spec.UpstreamCommit")
+
+	// Re-resolve with SuppressLockWarnings — should still populate, just no warning.
+	suppressed := components.NewResolver(env.Env)
+	suppressed.SuppressLockWarnings = true
+
+	resolved2, err := suppressed.FindComponents(filter)
+	require.NoError(t, err)
+
+	comp2, found := resolved2.TryGet("curl")
+	require.True(t, found)
+	require.NotNil(t, comp2.GetConfig().Locked)
+	assert.Equal(t, "lock-commit-bbb", comp2.GetConfig().Locked.UpstreamCommit,
+		"suppression doesn't change the populated data, only the warning emission")
 }

--- a/internal/app/azldev/core/testutils/testenv.go
+++ b/internal/app/azldev/core/testutils/testenv.go
@@ -13,6 +13,7 @@ import (
 	"github.com/microsoft/azure-linux-dev-tools/internal/app/azldev"
 	"github.com/microsoft/azure-linux-dev-tools/internal/global/opctx"
 	"github.com/microsoft/azure-linux-dev-tools/internal/global/testctx"
+	"github.com/microsoft/azure-linux-dev-tools/internal/lockfile"
 	"github.com/microsoft/azure-linux-dev-tools/internal/projectconfig"
 	"github.com/microsoft/azure-linux-dev-tools/internal/utils/fileperms"
 	"github.com/microsoft/azure-linux-dev-tools/internal/utils/fileutils"
@@ -185,4 +186,13 @@ func (e *TestEnv) FS() opctx.FS {
 // FS implements the [opctx.OSEnvFactory] interface.
 func (e *TestEnv) OSEnv() opctx.OSEnv {
 	return e.TestOSEnv
+}
+
+// WriteLock creates a lock file on the test filesystem for the given component.
+// Uses the same lock directory layout as the production [lockfile.Store].
+func (e *TestEnv) WriteLock(t *testing.T, name string, lock *lockfile.ComponentLock) {
+	t.Helper()
+
+	store := lockfile.NewStore(e.TestFS, "/project/"+lockfile.LockDir)
+	require.NoError(t, store.Save(name, lock))
 }

--- a/internal/projectconfig/component.go
+++ b/internal/projectconfig/component.go
@@ -149,6 +149,25 @@ type ReleaseConfig struct {
 	Calculation ReleaseCalculation `toml:"calculation,omitempty" json:"calculation,omitempty" validate:"omitempty,oneof=auto manual" jsonschema:"enum=auto,enum=manual,default=auto,title=Release calculation,description=Controls how the Release tag is managed during rendering. Empty or omitted means auto."`
 }
 
+// ComponentLockData holds resolved lock file state attached to a component at
+// resolve time. This separates user intent (config fields) from resolved reality
+// (lock data). Populated by the component resolver from the lock store; nil when
+// no lock file exists for this component.
+//
+// Not serialized or fingerprinted — runtime-only. The pointer must not be
+// shared across value-copied configs; the resolver always allocates a fresh
+// struct per component.
+type ComponentLockData struct {
+	// UpstreamCommit is the resolved upstream commit from the lock file.
+	UpstreamCommit string `json:"upstreamCommit,omitempty"`
+	// ImportCommit is the upstream commit at fork time (write-once).
+	ImportCommit string `json:"importCommit,omitempty"`
+	// ManualBump is the extra rebuild counter.
+	ManualBump int `json:"manualBump,omitempty"`
+	// InputFingerprint is the stored fingerprint from the last update.
+	InputFingerprint string `json:"inputFingerprint,omitempty"`
+}
+
 // Defines a component.
 type ComponentConfig struct {
 	// The component's name; not actually present in serialized files.
@@ -162,6 +181,11 @@ type ComponentConfig struct {
 	// Derived at resolve time from the project's rendered-specs-dir setting; not present
 	// in serialized files. Empty when rendered-specs-dir is not configured.
 	RenderedSpecDir string `toml:"-" json:"renderedSpecDir,omitempty" table:"-" fingerprint:"-"`
+
+	// Locked holds resolved lock file state for this component. Populated by
+	// the component resolver from the lock store. Nil when no lock file exists
+	// or when lock population is skipped (e.g., during 'component update').
+	Locked *ComponentLockData `toml:"-" json:"locked,omitempty" table:"-" fingerprint:"-"`
 
 	// Where to get its spec and adjacent files from.
 	Spec SpecSource `toml:"spec,omitempty" json:"spec,omitempty" jsonschema:"title=Spec,description=Identifies where to find the spec for this component"`
@@ -209,6 +233,17 @@ func (c *ComponentConfig) MergeUpdatesFrom(other *ComponentConfig) error {
 	}
 
 	return nil
+}
+
+// EffectiveUpstreamCommit returns the commit to use for upstream operations.
+// Prefers the locked commit (resolved reality) over the config pin (user intent).
+// Returns empty string when neither is set.
+func (c *ComponentConfig) EffectiveUpstreamCommit() string {
+	if c.Locked != nil && c.Locked.UpstreamCommit != "" {
+		return c.Locked.UpstreamCommit
+	}
+
+	return c.Spec.UpstreamCommit
 }
 
 // ResolveComponentConfig applies the full config inheritance chain for a single component:
@@ -262,6 +297,7 @@ func (c *ComponentConfig) WithAbsolutePaths(referenceDir string) *ComponentConfi
 		Name:             c.Name,
 		SourceConfigFile: c.SourceConfigFile,
 		RenderedSpecDir:  c.RenderedSpecDir,
+		Locked:           c.Locked,
 		Release:          c.Release,
 		Spec:             deep.MustCopy(c.Spec),
 		Build:            deep.MustCopy(c.Build),

--- a/internal/projectconfig/component.go
+++ b/internal/projectconfig/component.go
@@ -154,9 +154,11 @@ type ReleaseConfig struct {
 // (lock data). Populated by the component resolver from the lock store; nil when
 // no lock file exists for this component.
 //
-// Not serialized or fingerprinted — runtime-only. The pointer must not be
-// shared across value-copied configs; the resolver always allocates a fresh
-// struct per component.
+// Not serialized to TOML config and not fingerprinted - runtime-only. The data
+// IS included in JSON output (e.g., 'component list -O json') under "locked"
+// so users can inspect resolved lock state. The pointer must not be shared
+// across value-copied configs; the resolver always allocates a fresh struct
+// per component, and [ComponentConfig.WithAbsolutePaths] deep-copies it.
 type ComponentLockData struct {
 	// UpstreamCommit is the resolved upstream commit from the lock file.
 	UpstreamCommit string `json:"upstreamCommit,omitempty"`
@@ -183,8 +185,9 @@ type ComponentConfig struct {
 	RenderedSpecDir string `toml:"-" json:"renderedSpecDir,omitempty" table:"-" fingerprint:"-"`
 
 	// Locked holds resolved lock file state for this component. Populated by
-	// the component resolver from the lock store. Nil when no lock file exists
-	// or when lock population is skipped (e.g., during 'component update').
+	// the component resolver from the lock store. Nil when no lock file exists.
+	// During 'component update', this field may be cleared before re-resolving
+	// to prevent the source provider from short-circuiting with stale values.
 	Locked *ComponentLockData `toml:"-" json:"locked,omitempty" table:"-" fingerprint:"-"`
 
 	// Where to get its spec and adjacent files from.
@@ -238,6 +241,11 @@ func (c *ComponentConfig) MergeUpdatesFrom(other *ComponentConfig) error {
 // EffectiveUpstreamCommit returns the commit to use for upstream operations.
 // Prefers the locked commit (resolved reality) over the config pin (user intent).
 // Returns empty string when neither is set.
+//
+// TODO(lockfiles): Once lock validation is default-on, drop the Spec.UpstreamCommit
+// fallback - a missing lock will be a hard error before we reach this code.
+//
+//nolint:godox // tracked by TODO(lockfiles) tag.
 func (c *ComponentConfig) EffectiveUpstreamCommit() string {
 	if c.Locked != nil && c.Locked.UpstreamCommit != "" {
 		return c.Locked.UpstreamCommit
@@ -297,7 +305,7 @@ func (c *ComponentConfig) WithAbsolutePaths(referenceDir string) *ComponentConfi
 		Name:             c.Name,
 		SourceConfigFile: c.SourceConfigFile,
 		RenderedSpecDir:  c.RenderedSpecDir,
-		Locked:           c.Locked,
+		Locked:           deep.MustCopy(c.Locked),
 		Release:          c.Release,
 		Spec:             deep.MustCopy(c.Spec),
 		Build:            deep.MustCopy(c.Build),

--- a/internal/projectconfig/fingerprint_test.go
+++ b/internal/projectconfig/fingerprint_test.go
@@ -47,6 +47,9 @@ func TestAllFingerprintedFieldsHaveDecision(t *testing.T) {
 		"ComponentConfig.SourceConfigFile": true,
 		// ComponentConfig.RenderedSpecDir — derived output path that varies by checkout location.
 		"ComponentConfig.RenderedSpecDir": true,
+		// ComponentConfig.Locked — runtime lock state populated by resolver, not a build input.
+		// Lock data is an output of the update command, not a config-level input.
+		"ComponentConfig.Locked": true,
 
 		// ComponentBuildConfig.Failure — CI policy (expected failure tracking), not a build input.
 		"ComponentBuildConfig.Failure": true,

--- a/internal/providers/sourceproviders/fedorasourceprovider.go
+++ b/internal/providers/sourceproviders/fedorasourceprovider.go
@@ -108,11 +108,7 @@ func (g *FedoraSourcesProviderImpl) GetComponent(
 
 	gitRepoURL := strings.ReplaceAll(g.distroGitBaseURI, "$pkg", upstreamNameToUse)
 
-	// Use the effective upstream commit (locked > config pin).
-	//nolint:godox // tracked by TODO(lockfiles) tag.
-	// TODO(lockfiles): Once lock validation is default-on, remove the fallback
-	// to Spec.UpstreamCommit — a missing lock will be caught by validation before
-	// we get here, and the snapshot/HEAD resolution path becomes dead code.
+	// Get the calculated effective commit.
 	effectiveCommit := component.GetConfig().EffectiveUpstreamCommit()
 
 	slog.Info("Getting component from git repo",

--- a/internal/providers/sourceproviders/fedorasourceprovider.go
+++ b/internal/providers/sourceproviders/fedorasourceprovider.go
@@ -108,11 +108,18 @@ func (g *FedoraSourcesProviderImpl) GetComponent(
 
 	gitRepoURL := strings.ReplaceAll(g.distroGitBaseURI, "$pkg", upstreamNameToUse)
 
+	// Use the effective upstream commit (locked > config pin).
+	//nolint:godox // tracked by TODO(lockfiles) tag.
+	// TODO(lockfiles): Once lock validation is default-on, remove the fallback
+	// to Spec.UpstreamCommit — a missing lock will be caught by validation before
+	// we get here, and the snapshot/HEAD resolution path becomes dead code.
+	effectiveCommit := component.GetConfig().EffectiveUpstreamCommit()
+
 	slog.Info("Getting component from git repo",
 		"component", componentName,
 		"upstreamComponent", upstreamNameToUse,
 		"branch", g.distroGitBranch,
-		"upstreamCommit", component.GetConfig().Spec.UpstreamCommit,
+		"upstreamCommit", effectiveCommit,
 		"snapshot", g.snapshotTime)
 
 	// Clone to a temp directory first, then copy files to destination.
@@ -145,7 +152,7 @@ func (g *FedoraSourcesProviderImpl) GetComponent(
 	}
 
 	// Process the cloned repo: checkout target commit, extract sources, copy to destination.
-	return g.processClonedRepo(ctx, component.GetConfig().Spec.UpstreamCommit,
+	return g.processClonedRepo(ctx, effectiveCommit,
 		tempDir, upstreamNameToUse, componentName, destDirPath, skipFileNames, resolved)
 }
 
@@ -244,14 +251,22 @@ func (g *FedoraSourcesProviderImpl) checkoutTargetCommit(
 }
 
 // ResolveIdentity implements [SourceIdentityProvider] by resolving the upstream
-// commit hash for the component. All resolution priority logic is in
-// [resolveEffectiveCommitHash], called via [resolveCommit].
+// commit hash for the component. Prefers the locked commit when available;
+// falls back to live resolution (clone + snapshot/HEAD) when no lock exists.
 func (g *FedoraSourcesProviderImpl) ResolveIdentity(
 	ctx context.Context,
 	component components.Component,
 ) (string, error) {
 	if component.GetName() == "" {
 		return "", errors.New("component name cannot be empty")
+	}
+
+	// Use locked commit if available — no clone needed.
+	//nolint:godox // tracked by TODO(lockfiles) tag.
+	// TODO(lockfiles): Once lock validation is default-on, a missing lock is an
+	// error caught before we get here. Remove the fallback to resolveCommit.
+	if locked := component.GetConfig().Locked; locked != nil && locked.UpstreamCommit != "" {
+		return locked.UpstreamCommit, nil
 	}
 
 	upstreamName := component.GetConfig().Spec.UpstreamName

--- a/internal/providers/sourceproviders/fedorasourceprovider_test.go
+++ b/internal/providers/sourceproviders/fedorasourceprovider_test.go
@@ -1042,3 +1042,64 @@ func TestCheckoutTargetCommit_UpstreamCommit(t *testing.T) {
 		assert.ErrorIs(t, err, checkoutError)
 	})
 }
+
+// TestGetComponent_LockedCommitTakesPriorityOverConfigPin verifies that the
+// fetch path (used by render/build) honors the same locked-beats-pin
+// precedence rule as ResolveIdentity. When both Locked.UpstreamCommit and
+// Spec.UpstreamCommit are set, Checkout must be called with the locked value.
+func TestGetComponent_LockedCommitTakesPriorityOverConfigPin(t *testing.T) {
+	env := testutils.NewTestEnv(t)
+
+	ctrl := gomock.NewController(t)
+	mockGitProvider := git_test.NewMockGitProvider(ctrl)
+	mockExtractor := fedorasource_test.NewMockFedoraSourceDownloader(ctrl)
+
+	const (
+		configPinCommit = "config-pin-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+		lockedCommit    = "locked-commit-bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+	)
+
+	provider, err := sourceproviders.NewFedoraSourcesProviderImpl(
+		env.FS(),
+		env.DryRunnable,
+		mockGitProvider,
+		mockExtractor,
+		testResolvedDistro(),
+		retry.Disabled(),
+	)
+	require.NoError(t, err)
+
+	mockComponent := components_testutils.NewMockComponent(ctrl)
+	mockComponent.EXPECT().GetName().AnyTimes().Return(testPackageName)
+	mockComponent.EXPECT().GetConfig().AnyTimes().Return(&projectconfig.ComponentConfig{
+		Name: testPackageName,
+		Spec: projectconfig.SpecSource{
+			SourceType:     projectconfig.SpecSourceTypeUpstream,
+			UpstreamCommit: configPinCommit,
+		},
+		Locked: &projectconfig.ComponentLockData{
+			UpstreamCommit: lockedCommit,
+		},
+	})
+
+	mockGitProvider.EXPECT().
+		Clone(gomock.Any(), repoURL, gomock.Any(), gomock.Any()).
+		DoAndReturn(func(_ context.Context, _, cloneDir string, _ ...git.GitOptions) error {
+			specPath := cloneDir + "/" + testPackageName + ".spec"
+
+			return fileutils.WriteFile(env.FS(), specPath, []byte("Name: "+testPackageName), fileperms.PublicFile)
+		})
+
+	// Critical: Checkout must use the LOCKED commit, not the config pin.
+	// gomock will fail the test if Checkout is called with anything else.
+	mockGitProvider.EXPECT().
+		Checkout(gomock.Any(), gomock.Any(), lockedCommit).
+		Return(nil)
+
+	mockExtractor.EXPECT().
+		ExtractSourcesFromRepo(gomock.Any(), gomock.Any(), testPackageName, gomock.Any(), gomock.Any()).
+		Return(nil)
+
+	err = provider.GetComponent(context.Background(), mockComponent, destDir)
+	require.NoError(t, err)
+}

--- a/internal/providers/sourceproviders/identityprovider_test.go
+++ b/internal/providers/sourceproviders/identityprovider_test.go
@@ -296,3 +296,112 @@ func (d *noOpDownloader) ExtractSourcesFromRepo(
 ) error {
 	return nil
 }
+
+// --- Lock data integration tests ---
+
+// TestFedoraProvider_ResolveIdentity_UsesLockedCommit verifies that ResolveIdentity
+// returns the locked commit immediately without cloning when Locked data is present.
+func TestFedoraProvider_ResolveIdentity_UsesLockedCommit(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	mockGitProvider := git_test.NewMockGitProvider(ctrl)
+
+	provider, err := sourceproviders.NewFedoraSourcesProviderImpl(
+		afero.NewMemMapFs(),
+		newNoOpDryRunnable(),
+		mockGitProvider,
+		newNoOpDownloader(),
+		testResolvedDistro(),
+		retry.Disabled(),
+	)
+	require.NoError(t, err)
+
+	lockedCommit := "locked-abc123"
+
+	comp := newMockCompWithConfig(ctrl, testPackageName, &projectconfig.ComponentConfig{
+		Name: testPackageName,
+		Spec: projectconfig.SpecSource{
+			SourceType: projectconfig.SpecSourceTypeUpstream,
+		},
+		Locked: &projectconfig.ComponentLockData{
+			UpstreamCommit: lockedCommit,
+		},
+	})
+
+	// No git expectations — locked commit should be returned without any clone.
+	identity, resolveErr := provider.ResolveIdentity(t.Context(), comp)
+	require.NoError(t, resolveErr)
+	assert.Equal(t, lockedCommit, identity, "should return locked commit without cloning")
+}
+
+// TestFedoraProvider_ResolveIdentity_FallsBackWithoutLock verifies that when no
+// Locked data is present, ResolveIdentity falls back to the old resolution path.
+func TestFedoraProvider_ResolveIdentity_FallsBackWithoutLock(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	mockGitProvider := git_test.NewMockGitProvider(ctrl)
+
+	provider, err := sourceproviders.NewFedoraSourcesProviderImpl(
+		afero.NewMemMapFs(),
+		newNoOpDryRunnable(),
+		mockGitProvider,
+		newNoOpDownloader(),
+		testResolvedDistro(),
+		retry.Disabled(),
+	)
+	require.NoError(t, err)
+
+	headCommit := "head-fallback-commit"
+
+	comp := newMockCompWithConfig(ctrl, testPackageName, &projectconfig.ComponentConfig{
+		Name: testPackageName,
+		Spec: projectconfig.SpecSource{
+			SourceType: projectconfig.SpecSourceTypeUpstream,
+			// No UpstreamCommit pin, no Locked data → falls back to clone + HEAD.
+		},
+	})
+
+	// Expect clone + GetCurrentCommit (fallback path).
+	mockGitProvider.EXPECT().
+		Clone(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+		Return(nil)
+	mockGitProvider.EXPECT().
+		GetCurrentCommit(gomock.Any(), gomock.Any()).
+		Return(headCommit, nil)
+
+	identity, resolveErr := provider.ResolveIdentity(t.Context(), comp)
+	require.NoError(t, resolveErr)
+	assert.Equal(t, headCommit, identity, "should fall back to HEAD when no lock data")
+}
+
+// TestFedoraProvider_ResolveIdentity_LockedTakesPriorityOverConfigPin verifies
+// that Locked.UpstreamCommit is used even when Spec.UpstreamCommit is also set.
+func TestFedoraProvider_ResolveIdentity_LockedTakesPriorityOverConfigPin(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	mockGitProvider := git_test.NewMockGitProvider(ctrl)
+
+	provider, err := sourceproviders.NewFedoraSourcesProviderImpl(
+		afero.NewMemMapFs(),
+		newNoOpDryRunnable(),
+		mockGitProvider,
+		newNoOpDownloader(),
+		testResolvedDistro(),
+		retry.Disabled(),
+	)
+	require.NoError(t, err)
+
+	comp := newMockCompWithConfig(ctrl, testPackageName, &projectconfig.ComponentConfig{
+		Name: testPackageName,
+		Spec: projectconfig.SpecSource{
+			SourceType:     projectconfig.SpecSourceTypeUpstream,
+			UpstreamCommit: "config-pinned-commit",
+		},
+		Locked: &projectconfig.ComponentLockData{
+			UpstreamCommit: "locked-commit-wins",
+		},
+	})
+
+	// No git expectations — locked commit returned directly.
+	identity, resolveErr := provider.ResolveIdentity(t.Context(), comp)
+	require.NoError(t, resolveErr)
+	assert.Equal(t, "locked-commit-wins", identity,
+		"locked commit should take priority over config pin for identity resolution")
+}


### PR DESCRIPTION
…tion

Adds a runtime-only Locked *ComponentLockData field to ComponentConfig, populated by the resolver from the lock store at component creation time. This separates user intent (Spec.UpstreamCommit = config pin) from resolved reality (Locked.UpstreamCommit = lock file state).

The Fedora source provider now prefers the locked commit over the config pin in GetComponent and short-circuits ResolveIdentity when a locked commit is present, avoiding unnecessary git clones.

Centralizing lock consumption in the resolver keeps render, build, prepare-sources, and diff-sources oblivious to the lock store — they just read config.Locked.

Key behaviors:
- populateFromLock distinguishes 'not found' (normal) from 'corrupt' (warns) so a malformed lock doesn't silently fall back to live HEAD
- Gated on SpecSourceTypeUpstream so orphaned same-name lock files don't leak into local-component configs
- Resolver.SuppressLockWarnings flag silences the staleness warning during 'component update' (the user is already running the fix)
- Update command clears Locked before re-resolution so the source provider's locked-commit short-circuit doesn't echo back stale values
- EffectiveUpstreamCommit() helper centralizes the locked-beats-pin precedence rule used by GetComponent
- WithAbsolutePaths carries Locked through so resolved configs don't silently lose lock data on subsequent transformations

<!--
PR Title must follow Conventional Commits format. Available types:

- feat: A new feature
- fix: A bug fix
- docs: Documentation only changes
- style: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
- refactor: A code change that neither fixes a bug nor adds a feature
- perf: A code change that improves performance
- test: Adding missing tests or correcting existing tests
- build: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
- ci: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
- chore: Other changes that don't modify src or test files
- revert: Reverts a previous commit

Reference: https://www.conventionalcommits.org/en/v1.0.0/
-->
