### PR TITLE
feat(update): add --bump flag for manual rebuild counter

### DIFF
--- a/.github/instructions/go.instructions.md
+++ b/.github/instructions/go.instructions.md
@@ -17,7 +17,7 @@ description: "Instructions for working on the azldev Go codebase. IMPORTANT: Alw
 
 ## Coding Standards
 
-- **CRITICAL**: Unit tests must NOT write to real filesystem or spawn external processes. Use `internal/global/testctx` or `afero.NewMemMapFs` directly for in-memory filesystem
+- **CRITICAL**: Unit tests must NOT write to real filesystem or spawn external processes. See `.github/instructions/testing.instructions.md` for test conventions, mock patterns, and test environment setup.
 - Follow common coding principles like:
   - DRY - Don't Repeat Yourself
   - KISS - Keep It Simple, Stupid
@@ -119,12 +119,4 @@ CLI commands should return meaningful structured results. azldev has output form
 - Ensure backward compatibility unless explicitly instructed otherwise
 - Organize imports according to Go best practices
 - Linting: Prefer fixing issues over `//nolint` comments. Use targeted `//nolint:<linter>` if absolutely required
-- Testing: Table-driven tests preferred. Use `scenario/internal/cmdtest` helpers
-
-### Component Command Testing
-
-New component subcommands (`internal/app/azldev/cmds/component/`) require:
-- **Command wiring test** (`*_test.go`, external `package component_test`): verify `NewXxxCmd()` returns a valid command with correct `Use`, `RunE`, and expected flags/defaults.
-- **No-match test**: call `cmd.ExecuteContext(testEnv.Env)` with a nonexistent component to verify error handling.
-- **Helper unit tests** (`*_test.go`, same-package `package component`): test unexported helper functions (e.g., `findSpecFile`, `cleanupStaleRenders`) using `afero.NewMemMapFs`; where needed, follow the existing `//nolint:testpackage` pattern used in this repo.
-- **Snapshot update**: if the command changes the schema or CLI docs, run `mage scenarioUpdate` to update snapshots.
+- Testing: See `.github/instructions/testing.instructions.md` for conventions

--- a/.github/instructions/testing.instructions.md
+++ b/.github/instructions/testing.instructions.md
@@ -1,0 +1,132 @@
+---
+applyTo: "**/*_test.go"
+description: "Testing conventions for the azldev Go codebase. IMPORTANT: Always read these instructions when writing or editing test code."
+---
+
+# Go Testing Conventions
+
+## Test Environment
+
+Use `testutils.NewTestEnv(t)` for tests that need an `azldev.Env`. It provides:
+- In-memory filesystem (`env.TestFS` / `afero.MemMapFs`)
+- Mock command factory (`env.CmdFactory`)
+- Project config with test distro ("test-distro" v1.0, ReleaseVer "3.0")
+- Lock store backed by memfs (at `/project/locks/`)
+
+## Mock Components
+
+Use the **generated** `MockComponent` from `components_testutils`, NOT hand-rolled mock structs:
+
+```go
+import (
+    "github.com/microsoft/azure-linux-dev-tools/internal/app/azldev/core/components/components_testutils"
+    "go.uber.org/mock/gomock"
+)
+
+ctrl := gomock.NewController(t)
+comp := components_testutils.NewMockComponent(ctrl)
+comp.EXPECT().GetName().AnyTimes().Return("curl")
+comp.EXPECT().GetConfig().AnyTimes().Return(&projectconfig.ComponentConfig{
+    Name: "curl",
+    Spec: projectconfig.SpecSource{SourceType: projectconfig.SpecSourceTypeUpstream},
+})
+```
+
+Helper pattern (from `identityprovider_test.go`):
+```go
+func newMockCompWithConfig(ctrl *gomock.Controller, name string, config *projectconfig.ComponentConfig) *components_testutils.MockComponent {
+    comp := components_testutils.NewMockComponent(ctrl)
+    comp.EXPECT().GetName().AnyTimes().Return(name)
+    comp.EXPECT().GetConfig().AnyTimes().Return(config)
+    return comp
+}
+```
+
+Similarly for specs: use `specs_testutils.NewMockComponentSpec(ctrl)`.
+
+### NoOp Mock Wrappers
+
+For common dependencies (DryRunnable, EventListener, SourceManager), pre-built
+NoOp wrappers exist in `*_test/` packages. These are gomock mocks with
+`.AnyTimes()` expectations returning safe defaults:
+
+```go
+import "github.com/microsoft/azure-linux-dev-tools/internal/global/opctx/opctx_test"
+
+dryRunnable := opctx_test.NewNoOpMockDryRunnable(ctrl)
+eventListener := opctx_test.NewNoOpMockEventListener(ctrl)
+```
+
+For interfaces with very few methods (1-2), a hand-rolled stub struct is
+acceptable when it's simpler than a gomock mock:
+
+```go
+type noOpDownloader struct{}
+func (d *noOpDownloader) ExtractSourcesFromRepo(...) error { return nil }
+```
+
+Prefer generated gomock mocks for interfaces with 3+ methods or when you need
+to verify specific call expectations.
+
+## Lock Files in Tests
+
+Use `env.WriteLock(t, name, lock)` to create lock files on the test filesystem:
+
+```go
+lock := lockfile.New()
+lock.UpstreamCommit = "abc123"
+lock.ManualBump = 1
+env.WriteLock(t, "curl", lock)
+```
+
+## Mocking External Commands
+
+`CmdFactory.RunHandler` and `RunAndGetOutputHandler` intercept ALL external
+commands routed through the command factory (not just git). Use them to stub
+any tool (git, mock, rpmbuild, etc.) without spawning real processes:
+
+```go
+env.CmdFactory.RegisterCommandInSearchPath("git")
+env.CmdFactory.RunHandler = func(cmd *exec.Cmd) error {
+    // Intercepts cmd.Run() — handle clone, checkout, etc.
+    return nil
+}
+env.CmdFactory.RunAndGetOutputHandler = func(cmd *exec.Cmd) (string, error) {
+    // Intercepts cmd.RunAndGetOutput() — return stdout for rev-parse, query tools, etc.
+    return "abc123", nil
+}
+```
+
+Use `cmd.Args` to distinguish which command/subcommand is being called and
+return appropriate responses.
+
+## Test File Naming
+
+- `*_test.go` (external package, e.g., `package component_test`) — tests exported APIs only
+- `*_internal_test.go` (same package, e.g., `package component`) — tests unexported functions
+  - Requires `//nolint:testpackage` directive
+  - Use sparingly — prefer testing through exported APIs when possible
+
+## Test Style
+
+- Table-driven tests preferred for testing multiple input/output combinations
+- Use `require` for preconditions that must hold; `assert` for test assertions
+- Use `t.Run(name, func(t *testing.T) { ... })` for subtests
+- Use `t.Helper()` in test helper functions
+
+## Component Command Testing
+
+New component subcommands (`internal/app/azldev/cmds/component/`) require:
+- **Command wiring test** (`*_test.go`, external `package component_test`): verify
+  `NewXxxCmd()` returns a valid command with correct `Use`, `RunE`, and expected flags
+- **No-match test**: call `cmd.ExecuteContext(testEnv.Env)` with a nonexistent component
+  to verify error handling
+- **Snapshot update**: if the command changes CLI help text or schema, run
+  `mage build` (regenerates CLI docs) then `mage scenarioUpdate` (updates snapshots)
+
+## Build System
+
+- Use `mage unit` (NOT `go test`) to run tests — it includes code generation
+- Use `mage check all` to verify lint, formatting, and static analysis
+- Use `mage scenario` for end-to-end tests (slow, requires containers)
+- Use `mage scenarioUpdate` when test expectations change (updates snapshots)

--- a/docs/user/reference/cli/azldev_component_update.md
+++ b/docs/user/reference/cli/azldev_component_update.md
@@ -20,6 +20,10 @@ that no longer exist in the project config) are automatically pruned.
 Orphan pruning is skipped when updating individual components to avoid
 accidentally removing lock files for components not included in the filter.
 
+The --bump flag updates matching lock files to increment the manual-rebuild
+counter, triggering a new release. Useful for mass-rebuild scenarios (e.g.,
+toolchain bug, static library update). Orphan pruning is skipped under --bump.
+
 ```
 azldev component update [flags]
 ```
@@ -35,12 +39,16 @@ azldev component update [flags]
 
   # Update components in a group
   azldev component update -g core
+
+  # Bump rebuild counter for a component (triggers new release)
+  azldev component update --bump curl
 ```
 
 ### Options
 
 ```
   -a, --all-components                Include all components
+      --bump                          increment the manual-rebuild counter to trigger a new release
   -p, --component stringArray         Component name pattern
   -g, --component-group stringArray   Component group name
   -h, --help                          help for update

--- a/internal/app/azldev/cmds/component/update.go
+++ b/internal/app/azldev/cmds/component/update.go
@@ -129,7 +129,7 @@ func UpdateComponents(env *azldev.Env, options *UpdateComponentOptions) ([]Updat
 	// existing locks and should not delete entries for components that may
 	// have been removed.
 	if options.Bump {
-		results, bumpErr := bumpComponents(env, store, comps)
+		results, bumpErr := bumpComponents(env, store, comps, options)
 		if bumpErr != nil {
 			return results, bumpErr
 		}
@@ -281,7 +281,7 @@ func saveComponentLocks(env *azldev.Env, store *lockfile.Store, results []Update
 // incremented ManualBump counter. Does not contact upstream. Triggers a new
 // release without any other input change — used for mass-rebuild scenarios.
 func bumpComponents(
-	env *azldev.Env, store *lockfile.Store, comps []components.Component,
+	env *azldev.Env, store *lockfile.Store, comps []components.Component, options *UpdateComponentOptions,
 ) ([]UpdateResult, error) {
 	results := make([]UpdateResult, 0, len(comps))
 	saved := make([]string, 0, len(comps))
@@ -316,9 +316,13 @@ func bumpComponents(
 		// instead of silently creating an empty lock with no UpstreamCommit.
 		lock, lockErr := store.Get(name)
 		if lockErr != nil {
-			return results, fmt.Errorf(
-				"cannot bump %#q (run 'azldev component update -p %s' first):\n%w",
-				name, name, lockErr)
+			if options.ComponentFilter.IncludeAllComponents {
+				env.AddFixSuggestion("run 'azldev component update -a' first to populate lock files")
+			} else {
+				env.AddFixSuggestion(fmt.Sprintf("run 'azldev component update -p %s' first", name))
+			}
+
+			return results, fmt.Errorf("cannot bump %#q:\n%w", name, lockErr)
 		}
 
 		lock.ManualBump++

--- a/internal/app/azldev/cmds/component/update.go
+++ b/internal/app/azldev/cmds/component/update.go
@@ -22,6 +22,9 @@ import (
 // UpdateComponentOptions holds options for the component update command.
 type UpdateComponentOptions struct {
 	ComponentFilter components.ComponentFilter
+	// Bump increments the manual-rebuild counter on matched components'
+	// lock files. Used for mass-rebuild scenarios.
+	Bump bool
 }
 
 func updateOnAppInit(_ *azldev.App, parentCmd *cobra.Command) {
@@ -47,7 +50,11 @@ Local components are skipped — they have no upstream commit to resolve.
 When updating all components (-a), orphan lock files (locks for components
 that no longer exist in the project config) are automatically pruned.
 Orphan pruning is skipped when updating individual components to avoid
-accidentally removing lock files for components not included in the filter.`,
+accidentally removing lock files for components not included in the filter.
+
+The --bump flag updates matching lock files to increment the manual-rebuild
+counter, triggering a new release. Useful for mass-rebuild scenarios (e.g.,
+toolchain bug, static library update). Orphan pruning is skipped under --bump.`,
 		Example: `  # Update all components
   azldev component update -a
 
@@ -55,7 +62,10 @@ accidentally removing lock files for components not included in the filter.`,
   azldev component update -p curl
 
   # Update components in a group
-  azldev component update -g core`,
+  azldev component update -g core
+
+  # Bump rebuild counter for a component (triggers new release)
+  azldev component update --bump curl`,
 		RunE: azldev.RunFuncWithExtraArgs(func(env *azldev.Env, args []string) (interface{}, error) {
 			// Skip lock validation — update is the lock file writer.
 			options.ComponentFilter.SkipLockValidation = true
@@ -70,6 +80,9 @@ accidentally removing lock files for components not included in the filter.`,
 	}
 
 	components.AddComponentFilterOptionsToCommand(cmd, &options.ComponentFilter)
+
+	cmd.Flags().BoolVar(&options.Bump, "bump", false,
+		"increment the manual-rebuild counter to trigger a new release")
 
 	return cmd
 }
@@ -109,6 +122,21 @@ func UpdateComponents(env *azldev.Env, options *UpdateComponentOptions) ([]Updat
 	store := env.LockStore()
 	if store == nil {
 		return nil, errors.New("no project directory configured; cannot update lock files")
+	}
+
+	// --bump: re-fingerprint existing locks with an incremented ManualBump.
+	// Does not contact upstream. Skips orphan pruning — bump only touches
+	// existing locks and should not delete entries for components that may
+	// have been removed.
+	if options.Bump {
+		results, bumpErr := bumpComponents(env, store, comps)
+		if bumpErr != nil {
+			return results, bumpErr
+		}
+
+		logUpdateSummary(results)
+
+		return filterDisplayResults(results), nil
 	}
 
 	results := resolveUpstreamCommitsParallel(env, comps, store)
@@ -247,6 +275,97 @@ func saveComponentLocks(env *azldev.Env, store *lockfile.Store, results []Update
 	}
 
 	return nil
+}
+
+// bumpComponents re-fingerprints each matched component's lock file with an
+// incremented ManualBump counter. Does not contact upstream. Triggers a new
+// release without any other input change — used for mass-rebuild scenarios.
+func bumpComponents(
+	env *azldev.Env, store *lockfile.Store, comps []components.Component,
+) ([]UpdateResult, error) {
+	results := make([]UpdateResult, 0, len(comps))
+	saved := make([]string, 0, len(comps))
+
+	for _, comp := range comps {
+		// Check for cancellation (Ctrl+C) between components.
+		if env.Context().Err() != nil {
+			if len(saved) > 0 {
+				slog.Info("Lock files bumped before cancellation", "components", saved)
+			}
+
+			return results, fmt.Errorf("bump cancelled; %d of %d components bumped", len(saved), len(comps))
+		}
+
+		name := comp.GetName()
+
+		// Skip non-upstream components — same as the resolve path.
+		sourceType := comp.GetConfig().Spec.SourceType
+		if sourceType != projectconfig.SpecSourceTypeUpstream {
+			results = append(results, UpdateResult{
+				Component:  name,
+				Skipped:    true,
+				SkipReason: fmt.Sprintf("source type %q is not upstream", sourceType),
+			})
+
+			continue
+		}
+
+		// Require an existing lock file — bump only makes sense for
+		// components that have already been updated at least once.
+		// Use Get (not GetOrNew) so missing locks produce a clear error
+		// instead of silently creating an empty lock with no UpstreamCommit.
+		lock, lockErr := store.Get(name)
+		if lockErr != nil {
+			return results, fmt.Errorf(
+				"cannot bump %#q (run 'azldev component update -p %s' first):\n%w",
+				name, name, lockErr)
+		}
+
+		lock.ManualBump++
+
+		slog.Info("Bumping component", "component", name, "manualBump", lock.ManualBump)
+
+		// Resolve per-component distro for ReleaseVer, matching the
+		// per-component resolution used by render/build/prepare-sources.
+		releaseVer, distroErr := resolveReleaseVer(env, comp.GetConfig())
+		if distroErr != nil {
+			return results, fmt.Errorf("resolving distro for %#q:\n%w", name, distroErr)
+		}
+
+		// Recompute fingerprint with the new ManualBump.
+		identity, fpErr := fingerprint.ComputeIdentity(
+			env.FS(),
+			*comp.GetConfig(),
+			releaseVer,
+			fingerprint.IdentityOptions{
+				ManualBump:     lock.ManualBump,
+				SourceIdentity: lock.UpstreamCommit,
+			},
+		)
+		if fpErr != nil {
+			return results, fmt.Errorf("computing fingerprint for %#q:\n%w", name, fpErr)
+		}
+
+		lock.InputFingerprint = identity.Fingerprint
+
+		if saveErr := store.Save(name, lock); saveErr != nil {
+			if len(saved) > 0 {
+				slog.Info("Lock files bumped before failure", "components", saved)
+			}
+
+			return results, fmt.Errorf("saving lock for %#q:\n%w", name, saveErr)
+		}
+
+		saved = append(saved, name)
+
+		results = append(results, UpdateResult{
+			Component:      name,
+			UpstreamCommit: lock.UpstreamCommit,
+			Changed:        true,
+		})
+	}
+
+	return results, nil
 }
 
 // checkUpdateErrors returns an error if any component failed to resolve.

--- a/internal/app/azldev/cmds/component/update_internal_test.go
+++ b/internal/app/azldev/cmds/component/update_internal_test.go
@@ -336,7 +336,8 @@ func TestBumpComponents_MixedComponents(t *testing.T) {
 		Spec: projectconfig.SpecSource{SourceType: projectconfig.SpecSourceTypeLocal},
 	})
 
-	results, err := bumpComponents(env.Env, store, []components.Component{localComp, upstreamComp}, &UpdateComponentOptions{})
+	comps := []components.Component{localComp, upstreamComp}
+	results, err := bumpComponents(env.Env, store, comps, &UpdateComponentOptions{})
 	require.NoError(t, err)
 	require.Len(t, results, 2)
 

--- a/internal/app/azldev/cmds/component/update_internal_test.go
+++ b/internal/app/azldev/cmds/component/update_internal_test.go
@@ -247,7 +247,7 @@ func TestBumpComponents_IncrementsManualBump(t *testing.T) {
 	config := baseConfig("curl")
 	comp := newMockComp(t, "curl", config)
 
-	results, err := bumpComponents(env.Env, store, []components.Component{comp})
+	results, err := bumpComponents(env.Env, store, []components.Component{comp}, &UpdateComponentOptions{})
 	require.NoError(t, err)
 	require.Len(t, results, 1)
 	assert.True(t, results[0].Changed)
@@ -272,13 +272,13 @@ func TestBumpComponents_SequentialBumps(t *testing.T) {
 	comps := []components.Component{comp}
 
 	// First bump.
-	_, err := bumpComponents(env.Env, store, comps)
+	_, err := bumpComponents(env.Env, store, comps, &UpdateComponentOptions{})
 	require.NoError(t, err)
 
 	fp1 := readLock(t, store, "curl").InputFingerprint
 
 	// Second bump.
-	_, err = bumpComponents(env.Env, store, comps)
+	_, err = bumpComponents(env.Env, store, comps, &UpdateComponentOptions{})
 	require.NoError(t, err)
 
 	lock2 := readLock(t, store, "curl")
@@ -299,7 +299,7 @@ func TestBumpComponents_SkipsLocalComponent(t *testing.T) {
 	}
 	comp := newMockComp(t, "local-pkg", localConfig)
 
-	results, err := bumpComponents(env.Env, store, []components.Component{comp})
+	results, err := bumpComponents(env.Env, store, []components.Component{comp}, &UpdateComponentOptions{})
 	require.NoError(t, err)
 	require.Len(t, results, 1)
 	assert.True(t, results[0].Skipped)
@@ -314,10 +314,9 @@ func TestBumpComponents_ErrorOnNoLockFile(t *testing.T) {
 	config := baseConfig("curl")
 	comp := newMockComp(t, "curl", config)
 
-	_, err := bumpComponents(env.Env, store, []components.Component{comp})
+	_, err := bumpComponents(env.Env, store, []components.Component{comp}, &UpdateComponentOptions{})
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "cannot bump")
-	assert.Contains(t, err.Error(), "component update")
 }
 
 // Bumping mixed components: upstream with lock succeeds, local skipped.
@@ -337,7 +336,7 @@ func TestBumpComponents_MixedComponents(t *testing.T) {
 		Spec: projectconfig.SpecSource{SourceType: projectconfig.SpecSourceTypeLocal},
 	})
 
-	results, err := bumpComponents(env.Env, store, []components.Component{localComp, upstreamComp})
+	results, err := bumpComponents(env.Env, store, []components.Component{localComp, upstreamComp}, &UpdateComponentOptions{})
 	require.NoError(t, err)
 	require.Len(t, results, 2)
 

--- a/internal/app/azldev/cmds/component/update_internal_test.go
+++ b/internal/app/azldev/cmds/component/update_internal_test.go
@@ -6,15 +6,21 @@ package component
 import (
 	"testing"
 
+	"github.com/microsoft/azure-linux-dev-tools/internal/app/azldev/core/components"
+	"github.com/microsoft/azure-linux-dev-tools/internal/app/azldev/core/components/components_testutils"
 	"github.com/microsoft/azure-linux-dev-tools/internal/app/azldev/core/testutils"
 	"github.com/microsoft/azure-linux-dev-tools/internal/lockfile"
 	"github.com/microsoft/azure-linux-dev-tools/internal/projectconfig"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
 )
 
 // testLockDir is the lock directory used by TestEnv's project layout.
-const testLockDir = "/project/locks"
+const (
+	testLockDir    = "/project/locks"
+	testCommitHash = "abc123"
+)
 
 // newTestStore creates a lockfile.Store backed by the TestEnv's in-memory filesystem.
 func newTestStore(t *testing.T, env *testutils.TestEnv) *lockfile.Store {
@@ -64,14 +70,14 @@ func TestSaveComponentLocks_ComputesFingerprint(t *testing.T) {
 	store := newTestStore(t, env)
 
 	results := []UpdateResult{
-		makeResult("curl", "abc123", baseConfig("curl")),
+		makeResult("curl", testCommitHash, baseConfig("curl")),
 	}
 
 	err := saveComponentLocks(env.Env, store, results)
 	require.NoError(t, err)
 
 	lock := readLock(t, store, "curl")
-	assert.Equal(t, "abc123", lock.UpstreamCommit)
+	assert.Equal(t, testCommitHash, lock.UpstreamCommit)
 	assert.NotEmpty(t, lock.InputFingerprint, "fingerprint should be computed and stored")
 	assert.Contains(t, lock.InputFingerprint, "sha256:", "fingerprint should have sha256 prefix")
 }
@@ -82,7 +88,7 @@ func TestSaveComponentLocks_DetectsFingerprintChange(t *testing.T) {
 
 	// First save — establishes baseline fingerprint.
 	config1 := baseConfig("curl")
-	results1 := []UpdateResult{makeResult("curl", "abc123", config1)}
+	results1 := []UpdateResult{makeResult("curl", testCommitHash, config1)}
 
 	require.NoError(t, saveComponentLocks(env.Env, store, results1))
 
@@ -96,7 +102,7 @@ func TestSaveComponentLocks_DetectsFingerprintChange(t *testing.T) {
 	results2 := []UpdateResult{
 		{
 			Component:      "curl",
-			UpstreamCommit: "abc123",
+			UpstreamCommit: testCommitHash,
 			Changed:        false, // commit didn't change
 			config:         config2,
 		},
@@ -116,7 +122,7 @@ func TestSaveComponentLocks_SkipsUnchanged(t *testing.T) {
 	config := baseConfig("curl")
 
 	// First save.
-	results1 := []UpdateResult{makeResult("curl", "abc123", config)}
+	results1 := []UpdateResult{makeResult("curl", testCommitHash, config)}
 	require.NoError(t, saveComponentLocks(env.Env, store, results1))
 
 	fp1 := readLock(t, store, "curl").InputFingerprint
@@ -125,7 +131,7 @@ func TestSaveComponentLocks_SkipsUnchanged(t *testing.T) {
 	results2 := []UpdateResult{
 		{
 			Component:      "curl",
-			UpstreamCommit: "abc123",
+			UpstreamCommit: testCommitHash,
 			Changed:        false,
 			config:         config,
 		},
@@ -201,7 +207,7 @@ func TestSaveComponentLocks_ManualBumpAffectsFingerprint(t *testing.T) {
 	config := baseConfig("curl")
 
 	// Save with ManualBump = 0.
-	results1 := []UpdateResult{makeResult("curl", "abc123", config)}
+	results1 := []UpdateResult{makeResult("curl", testCommitHash, config)}
 	require.NoError(t, saveComponentLocks(env.Env, store, results1))
 
 	fp1 := readLock(t, store, "curl").InputFingerprint
@@ -216,7 +222,7 @@ func TestSaveComponentLocks_ManualBumpAffectsFingerprint(t *testing.T) {
 
 	// Re-run save with same commit and config.
 	results2 := []UpdateResult{
-		{Component: "curl", UpstreamCommit: "abc123", Changed: false, config: config},
+		{Component: "curl", UpstreamCommit: testCommitHash, Changed: false, config: config},
 	}
 
 	require.NoError(t, saveComponentLocks(env.Env, store, results2))
@@ -224,4 +230,133 @@ func TestSaveComponentLocks_ManualBumpAffectsFingerprint(t *testing.T) {
 	fp2 := readLock(t, store, "curl").InputFingerprint
 	assert.NotEqual(t, fp1, fp2, "ManualBump change should produce different fingerprint")
 	assert.True(t, results2[0].Changed, "should be marked changed due to fingerprint diff")
+}
+
+// bumpComponents increments ManualBump and recomputes the fingerprint.
+// Verify it changes the lock and produces a different fingerprint.
+func TestBumpComponents_IncrementsManualBump(t *testing.T) {
+	env := testutils.NewTestEnv(t)
+	store := newTestStore(t, env)
+
+	// Pre-populate a lock with ManualBump = 0.
+	lock := lockfile.New()
+	lock.UpstreamCommit = testCommitHash
+
+	require.NoError(t, store.Save("curl", lock))
+
+	config := baseConfig("curl")
+	comp := newMockComp(t, "curl", config)
+
+	results, err := bumpComponents(env.Env, store, []components.Component{comp})
+	require.NoError(t, err)
+	require.Len(t, results, 1)
+	assert.True(t, results[0].Changed)
+
+	bumped := readLock(t, store, "curl")
+	assert.Equal(t, 1, bumped.ManualBump)
+	assert.NotEmpty(t, bumped.InputFingerprint)
+}
+
+// Bumping twice should increment to 2 and produce a different fingerprint each time.
+func TestBumpComponents_SequentialBumps(t *testing.T) {
+	env := testutils.NewTestEnv(t)
+	store := newTestStore(t, env)
+
+	lock := lockfile.New()
+	lock.UpstreamCommit = testCommitHash
+
+	require.NoError(t, store.Save("curl", lock))
+
+	config := baseConfig("curl")
+	comp := newMockComp(t, "curl", config)
+	comps := []components.Component{comp}
+
+	// First bump.
+	_, err := bumpComponents(env.Env, store, comps)
+	require.NoError(t, err)
+
+	fp1 := readLock(t, store, "curl").InputFingerprint
+
+	// Second bump.
+	_, err = bumpComponents(env.Env, store, comps)
+	require.NoError(t, err)
+
+	lock2 := readLock(t, store, "curl")
+	assert.Equal(t, 2, lock2.ManualBump)
+	assert.NotEqual(t, fp1, lock2.InputFingerprint, "second bump should produce different fingerprint")
+}
+
+// Bumping a local component should skip it, not error.
+func TestBumpComponents_SkipsLocalComponent(t *testing.T) {
+	env := testutils.NewTestEnv(t)
+	store := newTestStore(t, env)
+
+	localConfig := &projectconfig.ComponentConfig{
+		Name: "local-pkg",
+		Spec: projectconfig.SpecSource{
+			SourceType: projectconfig.SpecSourceTypeLocal,
+		},
+	}
+	comp := newMockComp(t, "local-pkg", localConfig)
+
+	results, err := bumpComponents(env.Env, store, []components.Component{comp})
+	require.NoError(t, err)
+	require.Len(t, results, 1)
+	assert.True(t, results[0].Skipped)
+	assert.Contains(t, results[0].SkipReason, "not upstream")
+}
+
+// Bumping a component with no lock file should fail with a clear message.
+func TestBumpComponents_ErrorOnNoLockFile(t *testing.T) {
+	env := testutils.NewTestEnv(t)
+	store := newTestStore(t, env)
+
+	config := baseConfig("curl")
+	comp := newMockComp(t, "curl", config)
+
+	_, err := bumpComponents(env.Env, store, []components.Component{comp})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "cannot bump")
+	assert.Contains(t, err.Error(), "component update")
+}
+
+// Bumping mixed components: upstream with lock succeeds, local skipped.
+func TestBumpComponents_MixedComponents(t *testing.T) {
+	env := testutils.NewTestEnv(t)
+	store := newTestStore(t, env)
+
+	// Create lock for upstream component.
+	lock := lockfile.New()
+	lock.UpstreamCommit = testCommitHash
+
+	require.NoError(t, store.Save("curl", lock))
+
+	upstreamComp := newMockComp(t, "curl", baseConfig("curl"))
+	localComp := newMockComp(t, "local-pkg", &projectconfig.ComponentConfig{
+		Name: "local-pkg",
+		Spec: projectconfig.SpecSource{SourceType: projectconfig.SpecSourceTypeLocal},
+	})
+
+	results, err := bumpComponents(env.Env, store, []components.Component{localComp, upstreamComp})
+	require.NoError(t, err)
+	require.Len(t, results, 2)
+
+	// Local should be skipped.
+	assert.True(t, results[0].Skipped)
+
+	// Upstream should be bumped.
+	assert.True(t, results[1].Changed)
+	assert.Equal(t, 1, readLock(t, store, "curl").ManualBump)
+}
+
+// newMockComp creates a MockComponent with the given name and config using gomock.
+func newMockComp(t *testing.T, name string, config *projectconfig.ComponentConfig) components.Component {
+	t.Helper()
+
+	ctrl := gomock.NewController(t)
+	comp := components_testutils.NewMockComponent(ctrl)
+	comp.EXPECT().GetName().AnyTimes().Return(name)
+	comp.EXPECT().GetConfig().AnyTimes().Return(config)
+
+	return comp
 }


### PR DESCRIPTION
Add --bump flag to 'component update' that increments ManualBump in the lock file without re-resolving upstream commits. Used for mass-rebuild scenarios (e.g., gcc had a bug, rebuild everything).

The bump increments ManualBump, recomputes the fingerprint, and saves the lock file. This changes the component's identity, triggering a new release without any other input change.

Also adds:
- testing.instructions.md with test conventions (mock components, NoOp wrappers, lock files, external commands, test file naming) based on experience making these changes.
