### PR TITLE
feat(overlays): add spec-remove-subpackage overlay

### DIFF
--- a/docs/user/reference/config/overlays.md
+++ b/docs/user/reference/config/overlays.md
@@ -23,6 +23,7 @@ These overlays modify `.spec` files using the structured spec parser, allowing p
 | `spec-append-lines` | Appends lines to the end of a section; **fails if section doesn't exist** | `lines` |
 | `spec-search-replace` | Regex-based search and replace on spec content | `regex` |
 | `spec-remove-section` | Removes an entire section from the spec; **fails if section doesn't exist** | `section` |
+| `spec-remove-subpackage` | Removes every section associated with a sub-package (e.g. its `%package`, `%description`, `%files`, `%post`, `%postun`, ...); **fails if no such sections exist** | `package` |
 | `patch-add` | Adds a patch file and registers it in the spec (PatchN tag or %patchlist) | `source` |
 | `patch-remove` | Removes patch files and their spec references matching a glob pattern | `file` |
 
@@ -55,7 +56,7 @@ successfully makes a replacement to at least one matching file.
 | Tag | `tag` | The spec tag name (e.g., `BuildRequires`, `Requires`, `Version`) | `spec-add-tag`, `spec-insert-tag`, `spec-set-tag`, `spec-update-tag`, `spec-remove-tag` |
 | Value | `value` | The tag value to set, or value to match for removal | `spec-add-tag`, `spec-insert-tag`, `spec-set-tag`, `spec-update-tag`, `spec-remove-tag` (optional for matching) |
 | Section | `section` | The spec section to target (e.g., `%build`, `%install`, `%files`, `%description`) | `spec-prepend-lines`, `spec-append-lines`, `spec-search-replace` (optional), `spec-remove-section` |
-| Package | `package` | The sub-package name for multi-package specs; omit to target the main package | All spec overlays (optional) |
+| Package | `package` | The sub-package name for multi-package specs; omit to target the main package | All spec overlays (optional, except `spec-remove-subpackage` which **requires** it) |
 | Regex | `regex` | Regular expression pattern to match | `spec-search-replace`, `file-search-replace` |
 | Replacement | `replacement` | Literal replacement text; capture group references like `$1` are **not** expanded. Omit or leave empty to delete matched text. | `spec-search-replace`, `file-search-replace`, `file-rename` |
 | Lines | `lines` | Array of text lines to insert | `spec-prepend-lines`, `spec-append-lines`, `file-prepend-lines` |
@@ -295,6 +296,47 @@ section = "%files"
 package = "devel"
 description = "Remove devel sub-package files section"
 ```
+
+### Removing an Entire Sub-package
+
+The `spec-remove-subpackage` overlay removes **every** section associated with a given
+sub-package — its `%package` preamble as well as any per-section directives that target
+it (e.g. `%description`, `%files`, `%post`, `%postun`, `%pre`, `%trigger*`, etc.).
+Only the `package` field is needed; you do **not** need to enumerate each section.
+
+This is the preferred way to drop an unwanted sub-package: it avoids having to author
+multiple `spec-remove-section` overlays (and remember to keep them in sync if upstream
+later adds new sub-package scriptlets).
+
+```toml
+[[components.mypackage.overlays]]
+type = "spec-remove-subpackage"
+package = "devel"
+description = "Drop the devel sub-package; not shipped in Azure Linux"
+```
+
+The overlay fails if the spec contains no sections matching the indicated sub-package.
+Specifying a `section` field on this overlay is rejected at config-load time, since
+the overlay always removes every section associated with the sub-package.
+
+> **Note:** `spec-remove-subpackage` only edits the spec. If other parts of the project
+> reference the removed sub-package (for example, dependency lists in other components),
+> those references must be cleaned up separately.
+
+> **Note:** RPM permits two forms for declaring sub-package sections — a suffix form
+> (e.g. `%package devel`, which declares a sub-package named `<base>-devel`) and an
+> absolute form (e.g. `%package -n my-other-pkg`). The `package` value here must match
+> whichever form the spec uses on the section headers: `package = "devel"` matches
+> sections written as `%files devel`, while `package = "my-other-pkg"` matches sections
+> written as `%files -n my-other-pkg`. Specs that mix both forms for the same sub-package
+> (uncommon but legal) require a separate overlay per form.
+
+> **Limitation:** Like `spec-remove-section`, this overlay operates on whole-section line
+> ranges and does **not** understand `%if`/`%endif` conditionals. If a sub-package is wrapped
+> in a conditional block (e.g. `%if 0%{?with_devel} … %endif`), the `%endif` will typically
+> be consumed as part of the trailing sub-package section while the `%if` remains, producing
+> an invalid spec. For specs that conditionalize sub-packages, use a `spec-search-replace`
+> overlay (or remove the conditional first via additional overlays) instead.
 
 ## Validation
 

--- a/internal/app/azldev/core/sources/overlays.go
+++ b/internal/app/azldev/core/sources/overlays.go
@@ -167,6 +167,11 @@ func ApplySpecOverlay(overlay projectconfig.ComponentOverlay, openedSpec *spec.S
 		if err != nil {
 			return fmt.Errorf("failed to remove section from spec:\n%w", err)
 		}
+	case projectconfig.ComponentOverlayRemoveSubpackage:
+		err := openedSpec.RemoveSubpackage(overlay.PackageName)
+		if err != nil {
+			return fmt.Errorf("failed to remove sub-package from spec:\n%w", err)
+		}
 	case projectconfig.ComponentOverlayAddPatch:
 		destFilename := overlay.Filename
 		if destFilename == "" {

--- a/internal/app/azldev/core/sources/overlays_test.go
+++ b/internal/app/azldev/core/sources/overlays_test.go
@@ -1287,3 +1287,69 @@ make
 		assert.Contains(t, err.Error(), "not found")
 	})
 }
+
+func TestApplyRemoveSubpackageOverlay(t *testing.T) {
+	t.Run("removes all sections for a sub-package", func(t *testing.T) {
+		specContent := `Name: test
+Version: 1.0
+
+%description
+Main description.
+
+%package devel
+Summary: Devel files
+Requires: test = 1.0
+
+%description devel
+Devel description.
+
+%files
+/usr/bin/test
+
+%files devel
+/usr/include/test.h
+
+%post devel
+echo posting
+`
+		overlay := projectconfig.ComponentOverlay{
+			Type:        projectconfig.ComponentOverlayRemoveSubpackage,
+			PackageName: "devel",
+		}
+
+		result, err := applyOverlayToSpecContents(t, overlay, specContent)
+		require.NoError(t, err)
+
+		// Main package content should remain.
+		assert.Contains(t, result, "Main description.")
+		assert.Contains(t, result, "/usr/bin/test")
+
+		// All devel-scoped sections should be gone.
+		assert.NotContains(t, result, "%package devel")
+		assert.NotContains(t, result, "%description devel")
+		assert.NotContains(t, result, "%files devel")
+		assert.NotContains(t, result, "%post devel")
+		assert.NotContains(t, result, "Devel description.")
+		assert.NotContains(t, result, "/usr/include/test.h")
+		assert.NotContains(t, result, "echo posting")
+	})
+
+	t.Run("fails when sub-package has no sections", func(t *testing.T) {
+		specContent := `Name: test
+
+%description
+Main.
+
+%files
+/usr/bin/test
+`
+		overlay := projectconfig.ComponentOverlay{
+			Type:        projectconfig.ComponentOverlayRemoveSubpackage,
+			PackageName: "devel",
+		}
+
+		_, err := applyOverlayToSpecContents(t, overlay, specContent)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "not found")
+	})
+}

--- a/internal/projectconfig/overlay.go
+++ b/internal/projectconfig/overlay.go
@@ -17,7 +17,7 @@ import (
 // ComponentOverlay represents an overlay that may be applied to a component's spec and/or its sources.
 type ComponentOverlay struct {
 	// The type of overlay to apply.
-	Type ComponentOverlayType `toml:"type" json:"type" validate:"required" jsonschema:"enum=spec-add-tag,enum=spec-insert-tag,enum=spec-set-tag,enum=spec-update-tag,enum=spec-remove-tag,enum=spec-prepend-lines,enum=spec-append-lines,enum=spec-search-replace,enum=spec-remove-section,enum=patch-add,enum=patch-remove,enum=file-prepend-lines,enum=file-search-replace,enum=file-add,enum=file-remove,enum=file-rename,title=Overlay type,description=The type of overlay to apply"`
+	Type ComponentOverlayType `toml:"type" json:"type" validate:"required" jsonschema:"enum=spec-add-tag,enum=spec-insert-tag,enum=spec-set-tag,enum=spec-update-tag,enum=spec-remove-tag,enum=spec-prepend-lines,enum=spec-append-lines,enum=spec-search-replace,enum=spec-remove-section,enum=spec-remove-subpackage,enum=patch-add,enum=patch-remove,enum=file-prepend-lines,enum=file-search-replace,enum=file-add,enum=file-remove,enum=file-rename,title=Overlay type,description=The type of overlay to apply"`
 	// Human readable description of overlay; primarily present to document the need for the change.
 	Description string `toml:"description,omitempty" json:"description,omitempty" jsonschema:"title=Description,description=Human readable description of overlay" fingerprint:"-"`
 
@@ -114,6 +114,7 @@ func (c *ComponentOverlay) ModifiesSpec() bool {
 		c.Type == ComponentOverlayAppendSpecLines ||
 		c.Type == ComponentOverlaySearchAndReplaceInSpec ||
 		c.Type == ComponentOverlayRemoveSection ||
+		c.Type == ComponentOverlayRemoveSubpackage ||
 		c.Type == ComponentOverlayAddPatch ||
 		c.Type == ComponentOverlayRemovePatch
 }
@@ -159,6 +160,11 @@ const (
 	// ComponentOverlayRemoveSection is an overlay that removes an entire section from the spec;
 	// fails if the section doesn't exist.
 	ComponentOverlayRemoveSection ComponentOverlayType = "spec-remove-section"
+	// ComponentOverlayRemoveSubpackage is an overlay that removes every section in the spec
+	// that belongs to a given sub-package (e.g. its `%package`, `%description`, `%files`,
+	// `%post`, `%postun`, etc. sections). Fails if the spec has no sections matching the
+	// indicated sub-package.
+	ComponentOverlayRemoveSubpackage ComponentOverlayType = "spec-remove-subpackage"
 	// ComponentOverlayAddPatch is an overlay that adds a patch file and registers it in the spec.
 	// It copies the source file into the component sources and adds a PatchN tag (or appends to
 	// %%patchlist if one exists).
@@ -190,6 +196,10 @@ func (c *ComponentOverlay) Validate() error {
 
 	missingField := func(fieldName string) error {
 		return fmt.Errorf("overlay type %#q requires %#q field: %s", c.Type, fieldName, desc)
+	}
+
+	unexpectedField := func(fieldName string) error {
+		return fmt.Errorf("overlay type %#q does not accept %#q field: %s", c.Type, fieldName, desc)
 	}
 
 	requireRelativePath := func(fieldName, value string) error {
@@ -291,6 +301,14 @@ func (c *ComponentOverlay) Validate() error {
 	case ComponentOverlayRemoveSection:
 		if c.SectionName == "" {
 			return missingField("section")
+		}
+	case ComponentOverlayRemoveSubpackage:
+		if c.PackageName == "" {
+			return missingField("package")
+		}
+
+		if c.SectionName != "" {
+			return unexpectedField("section")
 		}
 	case ComponentOverlayAddPatch:
 		if c.Source == "" {

--- a/internal/projectconfig/overlay_test.go
+++ b/internal/projectconfig/overlay_test.go
@@ -385,6 +385,33 @@ func TestComponentOverlay_Validate(t *testing.T) {
 			errorExpected: true,
 			errorContains: "section",
 		},
+		// spec-remove-subpackage tests
+		{
+			name: "spec-remove-subpackage valid",
+			overlay: projectconfig.ComponentOverlay{
+				Type:        projectconfig.ComponentOverlayRemoveSubpackage,
+				PackageName: "devel",
+			},
+			errorExpected: false,
+		},
+		{
+			name: "spec-remove-subpackage missing package",
+			overlay: projectconfig.ComponentOverlay{
+				Type: projectconfig.ComponentOverlayRemoveSubpackage,
+			},
+			errorExpected: true,
+			errorContains: "package",
+		},
+		{
+			name: "spec-remove-subpackage rejects section field",
+			overlay: projectconfig.ComponentOverlay{
+				Type:        projectconfig.ComponentOverlayRemoveSubpackage,
+				PackageName: "devel",
+				SectionName: "%files",
+			},
+			errorExpected: true,
+			errorContains: "section",
+		},
 	}
 
 	for _, testCase := range testCases {
@@ -417,6 +444,7 @@ func TestComponentOverlay_ModifiesSpec(t *testing.T) {
 		projectconfig.ComponentOverlayAppendSpecLines,
 		projectconfig.ComponentOverlaySearchAndReplaceInSpec,
 		projectconfig.ComponentOverlayRemoveSection,
+		projectconfig.ComponentOverlayRemoveSubpackage,
 		projectconfig.ComponentOverlayAddPatch,
 		projectconfig.ComponentOverlayRemovePatch,
 	}

--- a/internal/rpm/spec/edit.go
+++ b/internal/rpm/spec/edit.go
@@ -734,9 +734,14 @@ func (s *Spec) GetHighestPatchTagNumber() (int, error) {
 	return highest, err
 }
 
-// RemoveSection removes an entire section from the spec, including its header line and all
-// body lines. The section is identified by name and optional package qualifier. Returns
-// [ErrSectionNotFound] if the section doesn't exist.
+// RemoveSection removes every section from the spec whose name and package qualifier
+// match the supplied values, including each section's header line and all body lines.
+//
+// In valid RPM specs the `(sectionName, packageName)` pair is unique, so this is
+// effectively a single-section removal. When a spec lexically contains multiple
+// sections with the same identity (e.g. inside mutually-exclusive `%if`/`%else`
+// branches), every such section is removed. Returns [ErrSectionNotFound] if no
+// matching section exists.
 func (s *Spec) RemoveSection(sectionName, packageName string) error {
 	slog.Debug("Removing section from spec", "section", sectionName, "package", packageName)
 
@@ -744,45 +749,120 @@ func (s *Spec) RemoveSection(sectionName, packageName string) error {
 		return errors.New("cannot remove the global/preamble section")
 	}
 
-	// Find the start and end line numbers for the section.
-	startLine := -1
-	endLine := -1
-
-	err := s.Visit(func(ctx *Context) error {
-		if startLine >= 0 && endLine >= 0 {
-			// Already found the section boundaries.
-			return nil
-		}
-
-		if ctx.Target.TargetType == SectionStartTarget {
-			if ctx.CurrentSection.SectName == sectionName && ctx.CurrentSection.Package == packageName {
-				startLine = ctx.CurrentLineNum
-			}
-		}
-
-		if ctx.Target.TargetType == SectionEndTarget {
-			if ctx.CurrentSection.SectName == sectionName && ctx.CurrentSection.Package == packageName {
-				endLine = ctx.CurrentLineNum
-			}
-		}
-
-		return nil
+	ranges, err := s.collectSectionRanges(func(sn, pn string) bool {
+		return sn == sectionName && pn == packageName
 	})
 	if err != nil {
 		return fmt.Errorf("failed to scan spec for section %#q (package=%#q):\n%w", sectionName, packageName, err)
 	}
 
-	if startLine < 0 {
+	if len(ranges) == 0 {
 		return fmt.Errorf("section %#q (package=%#q) not found:\n%w", sectionName, packageName, ErrSectionNotFound)
 	}
 
-	// endLine is the virtual end marker at the start of the next section (or EOF).
-	// We remove rawLines[startLine..endLine-1] inclusive.
-	if endLine < 0 {
-		endLine = len(s.rawLines)
-	}
-
-	s.RemoveLines(startLine, endLine)
+	s.removeRanges(ranges)
 
 	return nil
+}
+
+// RemoveSubpackage removes every section in the spec that is associated with the given
+// sub-package name (i.e. every section whose package qualifier equals packageName).
+// This includes the sub-package's own `%package` preamble section as well as any
+// per-section directives that target it (e.g. `%description -n pkg`, `%files pkg`,
+// `%post pkg`, etc.).
+//
+// Returns an error if packageName is empty or if the spec contains no sections
+// associated with the given sub-package.
+//
+// packageName matching: RPM permits two forms for declaring sub-package sections — the
+// suffix form (e.g. `%package devel`, which declares a sub-package named `<base>-devel`)
+// and the absolute form (e.g. `%package -n my-pkg`). Each section is matched against
+// packageName using the form that appears on its header line; callers should pass
+// whichever form the spec uses. Specs that mix both forms for the same sub-package
+// (uncommon but legal) require a call per form.
+//
+// Limitation: this method operates on whole-section line ranges and does not understand
+// `%if`/`%endif` conditionals. Sub-packages wrapped in a conditional block will leave
+// an unbalanced `%if` (the `%endif` is typically consumed as part of the trailing
+// sub-package section). Callers that need to handle conditionalized sub-packages must
+// adjust the conditionals themselves.
+func (s *Spec) RemoveSubpackage(packageName string) error {
+	slog.Debug("Removing sub-package from spec", "package", packageName)
+
+	if packageName == "" {
+		return errors.New("cannot remove sub-package with empty name")
+	}
+
+	ranges, err := s.collectSectionRanges(func(_, pn string) bool {
+		return pn == packageName
+	})
+	if err != nil {
+		return fmt.Errorf("failed to scan spec for sub-package %#q:\n%w", packageName, err)
+	}
+
+	if len(ranges) == 0 {
+		return fmt.Errorf("sub-package %#q not found:\n%w", packageName, ErrSectionNotFound)
+	}
+
+	s.removeRanges(ranges)
+
+	return nil
+}
+
+// sectionLineRange identifies a half-open `[start, end)` range of raw line numbers
+// covering one section, from its header line through (but not including) the start
+// of the next section.
+type sectionLineRange struct {
+	start int
+	end   int
+}
+
+// collectSectionRanges walks the spec and returns one [sectionLineRange] for every
+// section whose `(sectName, packageName)` pair satisfies the predicate, in the order
+// they appear in the spec.
+func (s *Spec) collectSectionRanges(
+	matches func(sectName, packageName string) bool,
+) ([]sectionLineRange, error) {
+	var (
+		ranges   []sectionLineRange
+		curStart = -1
+	)
+
+	err := s.Visit(func(ctx *Context) error {
+		matched := matches(ctx.CurrentSection.SectName, ctx.CurrentSection.Package)
+
+		//nolint:exhaustive // We intentionally only react to section boundaries.
+		switch ctx.Target.TargetType {
+		case SectionStartTarget:
+			if matched {
+				curStart = ctx.CurrentLineNum
+			}
+		case SectionEndTarget:
+			if matched && curStart >= 0 {
+				ranges = append(ranges, sectionLineRange{start: curStart, end: ctx.CurrentLineNum})
+				curStart = -1
+			}
+		}
+
+		return nil
+	})
+
+	// Defensive fallback: today [Spec.Visit] always emits a trailing SectionEndTarget at
+	// EOF, so this branch is unreachable. We keep it so that this helper does not silently
+	// misbehave if that invariant ever changes (a section running to EOF would otherwise
+	// be silently dropped from the result).
+	if curStart >= 0 {
+		ranges = append(ranges, sectionLineRange{start: curStart, end: len(s.rawLines)})
+	}
+
+	return ranges, err
+}
+
+// removeRanges deletes the given line ranges from the spec. Ranges must be
+// non-overlapping and in ascending order (as produced by [Spec.collectSectionRanges]);
+// they are removed from last to first so earlier indices remain valid.
+func (s *Spec) removeRanges(ranges []sectionLineRange) {
+	for i := len(ranges) - 1; i >= 0; i-- {
+		s.RemoveLines(ranges[i].start, ranges[i].end)
+	}
 }

--- a/internal/rpm/spec/edit_test.go
+++ b/internal/rpm/spec/edit_test.go
@@ -1613,6 +1613,40 @@ make
 make
 `,
 		},
+		{
+			// Locks in the contract documented on RemoveSection: when a spec lexically
+			// contains multiple sections with the same (section, package) identity (e.g.
+			// inside mutually-exclusive %if/%else branches), every such section is removed.
+			name: "removes every match when (section, package) appears more than once",
+			input: `Name: test
+
+%description
+Main.
+
+%files devel
+/usr/include/v1.h
+
+%files
+/usr/bin/test
+
+%files devel
+/usr/include/v2.h
+
+%changelog
+`,
+			sectionName: "%files",
+			packageName: "devel",
+			expectedOutput: `Name: test
+
+%description
+Main.
+
+%files
+/usr/bin/test
+
+%changelog
+`,
+		},
 	}
 
 	for _, testCase := range tests {
@@ -1621,6 +1655,186 @@ make
 			require.NoError(t, err)
 
 			err = specFile.RemoveSection(testCase.sectionName, testCase.packageName)
+
+			if testCase.errorExpected {
+				require.Error(t, err)
+
+				if testCase.errorContains != "" {
+					assert.Contains(t, err.Error(), testCase.errorContains)
+				}
+
+				return
+			}
+
+			require.NoError(t, err)
+
+			var buf bytes.Buffer
+			require.NoError(t, specFile.Serialize(&buf))
+			assert.Equal(t, testCase.expectedOutput, buf.String())
+		})
+	}
+}
+
+func TestRemoveSubpackage(t *testing.T) {
+	tests := []struct {
+		name           string
+		input          string
+		packageName    string
+		expectedOutput string
+		errorExpected  bool
+		errorContains  string
+	}{
+		{
+			name: "removes all sections for a sub-package",
+			input: `Name: test
+Version: 1.0
+
+%description
+Main description.
+
+%package devel
+Summary: Devel files
+Requires: test = 1.0
+
+%description devel
+Devel description.
+
+%files
+/usr/bin/test
+
+%files devel
+/usr/include/test.h
+
+%post devel
+echo posting
+
+%changelog
+`,
+			packageName: "devel",
+			expectedOutput: `Name: test
+Version: 1.0
+
+%description
+Main description.
+
+%files
+/usr/bin/test
+
+%changelog
+`,
+		},
+		{
+			name: "handles -n style sub-package",
+			input: `Name: test
+
+%description
+Main.
+
+%package -n other-pkg
+Summary: Other
+
+%description -n other-pkg
+Other description.
+
+%files -n other-pkg
+/usr/bin/other
+
+%files
+/usr/bin/test
+`,
+			packageName: "other-pkg",
+			expectedOutput: `Name: test
+
+%description
+Main.
+
+%files
+/usr/bin/test
+`,
+		},
+		{
+			name: "removes sub-package whose final section runs to EOF",
+			input: `Name: test
+
+%description
+Main.
+
+%package devel
+Summary: Devel
+
+%files devel
+/usr/include/test.h
+`,
+			packageName: "devel",
+			expectedOutput: `Name: test
+
+%description
+Main.
+
+`,
+		},
+		{
+			name: "fails when sub-package has no sections",
+			input: `Name: test
+
+%description
+Main.
+
+%files
+/usr/bin/test
+`,
+			packageName:   "devel",
+			errorExpected: true,
+			errorContains: "not found",
+		},
+		{
+			name: "fails on empty package name",
+			input: `Name: test
+%description
+Main.
+`,
+			packageName:   "",
+			errorExpected: true,
+			errorContains: "empty",
+		},
+		{
+			name: "does not affect main-package sections with the same name",
+			input: `Name: test
+
+%description
+Main description.
+
+%package devel
+Summary: Devel
+
+%description devel
+Devel description.
+
+%files
+/usr/bin/test
+
+%files devel
+/usr/include/test.h
+`,
+			packageName: "devel",
+			expectedOutput: `Name: test
+
+%description
+Main description.
+
+%files
+/usr/bin/test
+
+`,
+		},
+	}
+
+	for _, testCase := range tests {
+		t.Run(testCase.name, func(t *testing.T) {
+			specFile, err := spec.OpenSpec(strings.NewReader(testCase.input))
+			require.NoError(t, err)
+
+			err = specFile.RemoveSubpackage(testCase.packageName)
 
 			if testCase.errorExpected {
 				require.Error(t, err)

--- a/scenario/__snapshots__/TestSnapshotsContainer_config_generate-schema_stdout_1.snap
+++ b/scenario/__snapshots__/TestSnapshotsContainer_config_generate-schema_stdout_1.snap
@@ -214,6 +214,7 @@
             "spec-append-lines",
             "spec-search-replace",
             "spec-remove-section",
+            "spec-remove-subpackage",
             "patch-add",
             "patch-remove",
             "file-prepend-lines",

--- a/scenario/__snapshots__/TestSnapshots_config_generate-schema_stdout_1.snap
+++ b/scenario/__snapshots__/TestSnapshots_config_generate-schema_stdout_1.snap
@@ -214,6 +214,7 @@
             "spec-append-lines",
             "spec-search-replace",
             "spec-remove-section",
+            "spec-remove-subpackage",
             "patch-add",
             "patch-remove",
             "file-prepend-lines",

--- a/schemas/azldev.schema.json
+++ b/schemas/azldev.schema.json
@@ -214,6 +214,7 @@
             "spec-append-lines",
             "spec-search-replace",
             "spec-remove-section",
+            "spec-remove-subpackage",
             "patch-add",
             "patch-remove",
             "file-prepend-lines",


### PR DESCRIPTION
Adds a new overlay type that removes every section in a spec belonging to a given sub-package (its %package preamble plus any %description, %files, %post, %postun, etc. sections targeting it). This avoids having to author one spec-remove-section overlay per section just to drop a single sub-package, and removes the risk of missing scriptlets that upstream may add later.

The overlay requires the 'package' field and fails if the spec contains no sections matching the indicated sub-package.

Example:

```toml
[[components.mypackage.overlays]]
type = "spec-remove-subpackage"
package = "gui"
description = "Drop the gui sub-package; not shipped in Azure Linux"
```

Resolves #22 