### PR TITLE
feat(lock): extend lock files to cover local components

### DIFF
--- a/.github/instructions/go.instructions.md
+++ b/.github/instructions/go.instructions.md
@@ -120,3 +120,18 @@ CLI commands should return meaningful structured results. azldev has output form
 - Organize imports according to Go best practices
 - Linting: Prefer fixing issues over `//nolint` comments. Use targeted `//nolint:<linter>` if absolutely required
 - Testing: See `.github/instructions/testing.instructions.md` for conventions
+
+## Distro Resolution
+
+Components can override the project-default distro via `Spec.UpstreamDistro`. There are three ways to get distro information, each for a different purpose:
+
+| Need | Call | Returns |
+|------|------|---------|
+| Project-default distro (release ver, mock config) | `env.Distro()` | `(DistroDefinition, DistroVersionDefinition, error)` |
+| Per-component distro (for source providers) | `sourceproviders.ResolveDistro(env, comp)` | `ResolvedDistro` (includes ref, definition, version) |
+| Per-component release version only (for fingerprints) | Read `distroVer.ReleaseVer` from the resolved distro | `string` |
+
+**When to use which:**
+- **`env.Distro()`** — safe when all components share the same distro (e.g., iterating over results in `saveComponentLocks`). Breaks if components override the distro.
+- **`sourceproviders.ResolveDistro(env, comp)`** — use when you need the full distro context for a specific component (snapshot time, dist-git branch, lookaside URI). This is what `resolveOneSourceIdentity` uses to create the source manager.
+- **Per-component release version** — when computing fingerprints per-component, resolve the distro per-component to get the correct `ReleaseVer`. Using the project-default release version is wrong when component-level distro overrides exist.

--- a/docs/user/reference/cli/azldev_component.md
+++ b/docs/user/reference/cli/azldev_component.md
@@ -45,5 +45,5 @@ components defined in the project configuration.
 * [azldev component prepare-sources](azldev_component_prepare-sources.md)	 - Prepare buildable sources for components
 * [azldev component query](azldev_component_query.md)	 - Query info for components in this project
 * [azldev component render](azldev_component_render.md)	 - Render post-overlay specs and sidecar files to a checked-in directory
-* [azldev component update](azldev_component_update.md)	 - Resolve and lock upstream commits for components
+* [azldev component update](azldev_component_update.md)	 - Resolve and lock source identities for components
 

--- a/docs/user/reference/cli/azldev_component_update.md
+++ b/docs/user/reference/cli/azldev_component_update.md
@@ -2,18 +2,17 @@
 
 ## azldev component update
 
-Resolve and lock upstream commits for components
+Resolve and lock source identities for components
 
 ### Synopsis
 
-Resolve upstream commit hashes for components and write them to per-component lock files.
+Resolve source identities for components and write them to per-component lock files.
 
 For upstream components, this resolves the effective commit hash using the
 distro snapshot time or explicit pin, then records it in locks/<name>.lock.
-Subsequent commands (render, build) use the locked commit for deterministic,
+For local components, this computes a content hash of the spec directory.
+Subsequent commands (render, build) use the locked state for deterministic,
 reproducible results.
-
-Local components are skipped — they have no upstream commit to resolve.
 
 When updating all components (-a), orphan lock files (locks for components
 that no longer exist in the project config) are automatically pruned.

--- a/internal/app/azldev/cmds/component/update.go
+++ b/internal/app/azldev/cmds/component/update.go
@@ -333,7 +333,7 @@ func bumpComponents(
 		}
 
 		// Determine source identity for fingerprint recomputation.
-		srcIdentity, identityErr := bumpSourceIdentity(env, comp, lock)
+		srcIdentity, identityErr := resolveLockedSourceIdentity(env, comp, lock)
 		if identityErr != nil {
 			return results, identityErr
 		}
@@ -374,14 +374,11 @@ func bumpComponents(
 	return results, nil
 }
 
-// checkUpdateErrors returns an error if any component failed to resolve.
-// Does NOT log a summary — call [logUpdateSummary] after saves are complete
-// so that Changed counts include fingerprint-only diffs.
-// bumpSourceIdentity returns the source identity to use when recomputing a
-// bumped component's fingerprint. For upstream components, this is the locked
-// commit (bump doesn't change it). For local components, it re-hashes the
-// spec directory.
-func bumpSourceIdentity(
+// resolveLockedSourceIdentity returns the source identity to use when
+// recomputing a component's fingerprint during bump. For upstream components,
+// this is the locked commit (bump doesn't change it). For local components,
+// it re-hashes the spec directory.
+func resolveLockedSourceIdentity(
 	env *azldev.Env, comp components.Component, lock *lockfile.ComponentLock,
 ) (string, error) {
 	if lock.UpstreamCommit != "" {
@@ -408,6 +405,9 @@ func bumpSourceIdentity(
 	return identity, nil
 }
 
+// checkUpdateErrors returns an error if any component failed to resolve.
+// Does NOT log a summary — call [logUpdateSummary] after saves are complete
+// so that Changed counts include fingerprint-only diffs.
 func checkUpdateErrors(results []UpdateResult) error {
 	var failedNames []string
 

--- a/internal/app/azldev/cmds/component/update.go
+++ b/internal/app/azldev/cmds/component/update.go
@@ -37,15 +37,14 @@ func NewUpdateCmd() *cobra.Command {
 
 	cmd := &cobra.Command{
 		Use:   "update",
-		Short: "Resolve and lock upstream commits for components",
-		Long: `Resolve upstream commit hashes for components and write them to per-component lock files.
+		Short: "Resolve and lock source identities for components",
+		Long: `Resolve source identities for components and write them to per-component lock files.
 
 For upstream components, this resolves the effective commit hash using the
 distro snapshot time or explicit pin, then records it in locks/<name>.lock.
-Subsequent commands (render, build) use the locked commit for deterministic,
+For local components, this computes a content hash of the spec directory.
+Subsequent commands (render, build) use the locked state for deterministic,
 reproducible results.
-
-Local components are skipped — they have no upstream commit to resolve.
 
 When updating all components (-a), orphan lock files (locks for components
 that no longer exist in the project config) are automatically pruned.
@@ -101,9 +100,15 @@ type UpdateResult struct {
 	// config is the resolved component config, used for fingerprint computation.
 	// Not serialized — only needed during the update pipeline.
 	config *projectconfig.ComponentConfig `json:"-" table:"-"`
+
+	// sourceIdentity is the opaque identity string from the source provider.
+	// For upstream components this is the resolved commit hash (same as UpstreamCommit);
+	// for local components this is a content hash of the spec directory.
+	// Used as SourceIdentity input for fingerprint computation.
+	sourceIdentity string `json:"-" table:"-"`
 }
 
-// UpdateComponents resolves upstream commits for all selected components and
+// UpdateComponents resolves source identities for all selected components and
 // writes the results to per-component lock files under locks/.
 func UpdateComponents(env *azldev.Env, options *UpdateComponentOptions) ([]UpdateResult, error) {
 	resolver := components.NewResolver(env)
@@ -142,7 +147,7 @@ func UpdateComponents(env *azldev.Env, options *UpdateComponentOptions) ([]Updat
 		return filterDisplayResults(results), nil
 	}
 
-	results := resolveUpstreamCommitsParallel(env, comps, store)
+	results := resolveSourceIdentitiesParallel(env, comps, store)
 
 	// Don't save if the context was cancelled (Ctrl+C).
 	if env.Context().Err() != nil {
@@ -246,7 +251,7 @@ func saveComponentLocks(env *azldev.Env, store *lockfile.Store, results []Update
 			releaseVer,
 			fingerprint.IdentityOptions{
 				ManualBump:     lock.ManualBump,
-				SourceIdentity: lock.UpstreamCommit,
+				SourceIdentity: results[idx].sourceIdentity,
 			},
 		)
 		if fpErr != nil {
@@ -282,7 +287,7 @@ func saveComponentLocks(env *azldev.Env, store *lockfile.Store, results []Update
 
 // bumpComponents re-fingerprints each matched component's lock file with an
 // incremented ManualBump counter. Does not contact upstream. Triggers a new
-// release without any other input change — used for mass-rebuild scenarios.
+// release without any other input change - used for mass-rebuild scenarios.
 func bumpComponents(
 	env *azldev.Env, store *lockfile.Store, comps []components.Component, options *UpdateComponentOptions,
 ) ([]UpdateResult, error) {
@@ -301,22 +306,10 @@ func bumpComponents(
 
 		name := comp.GetName()
 
-		// Skip non-upstream components — same as the resolve path.
-		sourceType := comp.GetConfig().Spec.SourceType
-		if sourceType != projectconfig.SpecSourceTypeUpstream {
-			results = append(results, UpdateResult{
-				Component:  name,
-				Skipped:    true,
-				SkipReason: fmt.Sprintf("source type %q is not upstream", sourceType),
-			})
-
-			continue
-		}
-
-		// Require an existing lock file — bump only makes sense for
+		// Require an existing lock file - bump only makes sense for
 		// components that have already been updated at least once.
 		// Use Get (not GetOrNew) so missing locks produce a clear error
-		// instead of silently creating an empty lock with no UpstreamCommit.
+		// instead of silently creating an empty lock.
 		lock, lockErr := store.Get(name)
 		if lockErr != nil {
 			if options.ComponentFilter.IncludeAllComponents {
@@ -339,6 +332,12 @@ func bumpComponents(
 			return results, fmt.Errorf("resolving distro for %#q:\n%w", name, distroErr)
 		}
 
+		// Determine source identity for fingerprint recomputation.
+		srcIdentity, identityErr := bumpSourceIdentity(env, comp, lock)
+		if identityErr != nil {
+			return results, identityErr
+		}
+
 		// Recompute fingerprint with the new ManualBump.
 		identity, fpErr := fingerprint.ComputeIdentity(
 			env.FS(),
@@ -346,7 +345,7 @@ func bumpComponents(
 			releaseVer,
 			fingerprint.IdentityOptions{
 				ManualBump:     lock.ManualBump,
-				SourceIdentity: lock.UpstreamCommit,
+				SourceIdentity: srcIdentity,
 			},
 		)
 		if fpErr != nil {
@@ -378,6 +377,37 @@ func bumpComponents(
 // checkUpdateErrors returns an error if any component failed to resolve.
 // Does NOT log a summary — call [logUpdateSummary] after saves are complete
 // so that Changed counts include fingerprint-only diffs.
+// bumpSourceIdentity returns the source identity to use when recomputing a
+// bumped component's fingerprint. For upstream components, this is the locked
+// commit (bump doesn't change it). For local components, it re-hashes the
+// spec directory.
+func bumpSourceIdentity(
+	env *azldev.Env, comp components.Component, lock *lockfile.ComponentLock,
+) (string, error) {
+	if lock.UpstreamCommit != "" {
+		return lock.UpstreamCommit, nil
+	}
+
+	name := comp.GetName()
+
+	distro, err := sourceproviders.ResolveDistro(env, comp)
+	if err != nil {
+		return "", fmt.Errorf("resolving distro for %#q:\n%w", name, err)
+	}
+
+	sourceManager, err := sourceproviders.NewSourceManager(env, distro)
+	if err != nil {
+		return "", fmt.Errorf("creating source manager for %#q:\n%w", name, err)
+	}
+
+	identity, err := sourceManager.ResolveSourceIdentity(env.Context(), comp)
+	if err != nil {
+		return "", fmt.Errorf("resolving source identity for %#q:\n%w", name, err)
+	}
+
+	return identity, nil
+}
+
 func checkUpdateErrors(results []UpdateResult) error {
 	var failedNames []string
 
@@ -433,7 +463,7 @@ func filterDisplayResults(results []UpdateResult) []UpdateResult {
 	return tableResults
 }
 
-func resolveUpstreamCommitsParallel(
+func resolveSourceIdentitiesParallel(
 	env *azldev.Env,
 	comps []components.Component,
 	store *lockfile.Store,
@@ -445,20 +475,12 @@ func resolveUpstreamCommitsParallel(
 
 	var waitGroup sync.WaitGroup
 
-	// Each resolution involves a metadata-only git clone, in practice highly-parallelizable.
+	// Each resolution may involve network I/O (upstream git clone) or
+	// filesystem traversal (local spec-dir hashing), so we parallelize.
 	semaphore := make(chan struct{}, env.FastConcurrency())
 
 	for idx, comp := range comps {
 		results[idx].Component = comp.GetName()
-
-		// Skip non-upstream components.
-		sourceType := comp.GetConfig().Spec.SourceType
-		if sourceType != projectconfig.SpecSourceTypeUpstream {
-			results[idx].Skipped = true
-			results[idx].SkipReason = fmt.Sprintf("source type %q is not upstream", sourceType)
-
-			continue
-		}
 
 		waitGroup.Add(1)
 
@@ -477,12 +499,12 @@ func resolveUpstreamCommitsParallel(
 			}
 
 			// Drop populated lock data so the source provider re-resolves
-			// from upstream (snapshot/HEAD or pinned commit) instead of
-			// short-circuiting with the existing locked commit. We're
-			// about to overwrite the lock anyway.
+			// from upstream (snapshot/HEAD or pinned commit) or re-hashes
+			// local spec content instead of short-circuiting with stale
+			// locked values. We're about to overwrite the lock anyway.
 			comp.GetConfig().Locked = nil
 
-			commitHash, resolveErr := resolveOneUpstreamCommit(workerEnv, comp)
+			identity, resolveErr := resolveOneSourceIdentity(workerEnv, comp)
 			if resolveErr != nil {
 				results[idx].Error = resolveErr.Error()
 
@@ -492,10 +514,16 @@ func resolveUpstreamCommitsParallel(
 				return
 			}
 
-			results[idx].UpstreamCommit = commitHash
+			results[idx].sourceIdentity = identity
 			results[idx].config = comp.GetConfig()
 
-			// Check existing lock to determine if the commit changed.
+			// For upstream components, the identity IS the commit hash.
+			// For local components, UpstreamCommit stays empty.
+			if comp.GetConfig().Spec.SourceType == projectconfig.SpecSourceTypeUpstream {
+				results[idx].UpstreamCommit = identity
+			}
+
+			// Check existing lock to determine if the component changed.
 			checkLockChanged(store, comp.GetName(), &results[idx])
 		}()
 	}
@@ -505,9 +533,11 @@ func resolveUpstreamCommitsParallel(
 	return results
 }
 
-// checkLockChanged compares the resolved commit against the existing lock file
-// to determine if the component changed. Distinguishes "not found" (new
-// component) from real errors (corrupt/unreadable lock file).
+// checkLockChanged compares the resolved state against the existing lock file
+// to determine if the component changed. For upstream components, compares the
+// upstream commit hash. For local components (empty UpstreamCommit), marks as
+// changed unconditionally — the fingerprint comparison in saveComponentLocks
+// will determine the actual Changed status.
 func checkLockChanged(store *lockfile.Store, componentName string, result *UpdateResult) {
 	exists, existsErr := store.Exists(componentName)
 	if existsErr != nil {
@@ -533,7 +563,7 @@ func checkLockChanged(store *lockfile.Store, componentName string, result *Updat
 	result.Changed = existingLock.UpstreamCommit != result.UpstreamCommit
 }
 
-func resolveOneUpstreamCommit(
+func resolveOneSourceIdentity(
 	env *azldev.Env,
 	comp components.Component,
 ) (string, error) {
@@ -554,7 +584,7 @@ func resolveOneUpstreamCommit(
 		return "", fmt.Errorf("resolving identity for %#q:\n%w", componentName, err)
 	}
 
-	slog.Info("Resolved upstream commit", "component", componentName, "commit", identity)
+	slog.Info("Resolved source identity", "component", componentName, "identity", identity)
 
 	return identity, nil
 }

--- a/internal/app/azldev/cmds/component/update.go
+++ b/internal/app/azldev/cmds/component/update.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"path/filepath"
 	"strings"
 	"sync"
 
@@ -229,6 +230,13 @@ func saveComponentLocks(env *azldev.Env, store *lockfile.Store, results []Update
 
 		lock.UpstreamCommit = results[idx].UpstreamCommit
 
+		// Clear upstream-only fields for local components so a source-type
+		// transition (upstream → local) doesn't leave stale data in the lock.
+		if results[idx].config != nil &&
+			results[idx].config.Spec.SourceType != projectconfig.SpecSourceTypeUpstream {
+			lock.ImportCommit = ""
+		}
+
 		// Recompute fingerprint from resolved config + lock state.
 		if results[idx].config == nil {
 			retErr = fmt.Errorf("no resolved config for %#q; cannot compute fingerprint", results[idx].Component)
@@ -377,32 +385,40 @@ func bumpComponents(
 // resolveLockedSourceIdentity returns the source identity to use when
 // recomputing a component's fingerprint during bump. For upstream components,
 // this is the locked commit (bump doesn't change it). For local components,
-// it re-hashes the spec directory.
+// it re-hashes the spec directory. Does not perform network I/O.
 func resolveLockedSourceIdentity(
 	env *azldev.Env, comp components.Component, lock *lockfile.ComponentLock,
 ) (string, error) {
-	if lock.UpstreamCommit != "" {
-		return lock.UpstreamCommit, nil
-	}
-
 	name := comp.GetName()
+	sourceType := comp.GetConfig().Spec.SourceType
 
-	distro, err := sourceproviders.ResolveDistro(env, comp)
-	if err != nil {
-		return "", fmt.Errorf("resolving distro for %#q:\n%w", name, err)
+	switch sourceType {
+	case projectconfig.SpecSourceTypeUpstream:
+		if lock.UpstreamCommit == "" {
+			return "", fmt.Errorf(
+				"lock file for upstream component %#q has no upstream-commit; "+
+					"run 'azldev component update -p %s' to populate it before bumping",
+				name, name)
+		}
+
+		return lock.UpstreamCommit, nil
+
+	case projectconfig.SpecSourceTypeLocal, projectconfig.SpecSourceTypeUnspecified:
+		specPath := comp.GetConfig().Spec.Path
+		if specPath == "" {
+			return "", fmt.Errorf("component %#q has no spec path configured", name)
+		}
+
+		identity, err := sourceproviders.ResolveLocalSourceIdentity(env.FS(), filepath.Dir(specPath))
+		if err != nil {
+			return "", fmt.Errorf("resolving local source identity for %#q:\n%w", name, err)
+		}
+
+		return identity, nil
+
+	default:
+		return "", fmt.Errorf("unsupported source type %#q for component %#q", sourceType, name)
 	}
-
-	sourceManager, err := sourceproviders.NewSourceManager(env, distro)
-	if err != nil {
-		return "", fmt.Errorf("creating source manager for %#q:\n%w", name, err)
-	}
-
-	identity, err := sourceManager.ResolveSourceIdentity(env.Context(), comp)
-	if err != nil {
-		return "", fmt.Errorf("resolving source identity for %#q:\n%w", name, err)
-	}
-
-	return identity, nil
 }
 
 // checkUpdateErrors returns an error if any component failed to resolve.
@@ -533,11 +549,13 @@ func resolveSourceIdentitiesParallel(
 	return results
 }
 
-// checkLockChanged compares the resolved state against the existing lock file
-// to determine if the component changed. For upstream components, compares the
-// upstream commit hash. For local components (empty UpstreamCommit), marks as
-// changed unconditionally — the fingerprint comparison in saveComponentLocks
-// will determine the actual Changed status.
+// checkLockChanged compares the resolved upstream commit against the existing
+// lock file to determine if the component changed. For new components (no lock
+// file), marks as Changed unconditionally. For existing locks, compares
+// UpstreamCommit values — for local components both sides are empty, so
+// Changed stays false. The fingerprint comparison in [saveComponentLocks] is
+// the definitive source of truth and will flip Changed to true when content
+// actually changed.
 func checkLockChanged(store *lockfile.Store, componentName string, result *UpdateResult) {
 	exists, existsErr := store.Exists(componentName)
 	if existsErr != nil {

--- a/internal/app/azldev/cmds/component/update_internal_test.go
+++ b/internal/app/azldev/cmds/component/update_internal_test.go
@@ -11,6 +11,8 @@ import (
 	"github.com/microsoft/azure-linux-dev-tools/internal/app/azldev/core/testutils"
 	"github.com/microsoft/azure-linux-dev-tools/internal/lockfile"
 	"github.com/microsoft/azure-linux-dev-tools/internal/projectconfig"
+	"github.com/microsoft/azure-linux-dev-tools/internal/utils/fileperms"
+	"github.com/microsoft/azure-linux-dev-tools/internal/utils/fileutils"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/mock/gomock"
@@ -38,12 +40,13 @@ func makeResult(name, commit string, config *projectconfig.ComponentConfig) Upda
 		UpstreamCommit: commit,
 		Changed:        true,
 		config:         config,
+		sourceIdentity: commit,
 	}
 }
 
 // readLock loads a lock file from the store and returns it. Fails the test on error.
 //
-//nolint:unparam // Helper is generic; tests happen to use "curl" consistently.
+
 func readLock(t *testing.T, store *lockfile.Store, name string) *lockfile.ComponentLock {
 	t.Helper()
 
@@ -105,6 +108,7 @@ func TestSaveComponentLocks_DetectsFingerprintChange(t *testing.T) {
 			UpstreamCommit: testCommitHash,
 			Changed:        false, // commit didn't change
 			config:         config2,
+			sourceIdentity: testCommitHash,
 		},
 	}
 
@@ -134,6 +138,7 @@ func TestSaveComponentLocks_SkipsUnchanged(t *testing.T) {
 			UpstreamCommit: testCommitHash,
 			Changed:        false,
 			config:         config,
+			sourceIdentity: testCommitHash,
 		},
 	}
 
@@ -222,7 +227,7 @@ func TestSaveComponentLocks_ManualBumpAffectsFingerprint(t *testing.T) {
 
 	// Re-run save with same commit and config.
 	results2 := []UpdateResult{
-		{Component: "curl", UpstreamCommit: testCommitHash, Changed: false, config: config},
+		{Component: "curl", UpstreamCommit: testCommitHash, Changed: false, config: config, sourceIdentity: testCommitHash},
 	}
 
 	require.NoError(t, saveComponentLocks(env.Env, store, results2))
@@ -286,8 +291,8 @@ func TestBumpComponents_SequentialBumps(t *testing.T) {
 	assert.NotEqual(t, fp1, lock2.InputFingerprint, "second bump should produce different fingerprint")
 }
 
-// Bumping a local component should skip it, not error.
-func TestBumpComponents_SkipsLocalComponent(t *testing.T) {
+// Bumping a local component with no lock file should error (same as upstream).
+func TestBumpComponents_ErrorOnLocalNoLock(t *testing.T) {
 	env := testutils.NewTestEnv(t)
 	store := newTestStore(t, env)
 
@@ -295,6 +300,34 @@ func TestBumpComponents_SkipsLocalComponent(t *testing.T) {
 		Name: "local-pkg",
 		Spec: projectconfig.SpecSource{
 			SourceType: projectconfig.SpecSourceTypeLocal,
+			Path:       "/specs/local-pkg/local-pkg.spec",
+		},
+	}
+	comp := newMockComp(t, "local-pkg", localConfig)
+
+	_, err := bumpComponents(env.Env, store, []components.Component{comp}, &UpdateComponentOptions{})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "cannot bump")
+}
+
+// Bumping a local component with an existing lock should succeed.
+func TestBumpComponents_BumpsLocalWithLock(t *testing.T) {
+	env := testutils.NewTestEnv(t)
+	store := newTestStore(t, env)
+
+	specPath := "/specs/local-pkg/local-pkg.spec"
+	require.NoError(t, fileutils.WriteFile(env.TestFS, specPath, []byte("Name: local-pkg\n"), fileperms.PrivateFile))
+
+	lock := lockfile.New()
+	lock.InputFingerprint = "sha256:old-fingerprint"
+
+	require.NoError(t, store.Save("local-pkg", lock))
+
+	localConfig := &projectconfig.ComponentConfig{
+		Name: "local-pkg",
+		Spec: projectconfig.SpecSource{
+			SourceType: projectconfig.SpecSourceTypeLocal,
+			Path:       specPath,
 		},
 	}
 	comp := newMockComp(t, "local-pkg", localConfig)
@@ -302,8 +335,12 @@ func TestBumpComponents_SkipsLocalComponent(t *testing.T) {
 	results, err := bumpComponents(env.Env, store, []components.Component{comp}, &UpdateComponentOptions{})
 	require.NoError(t, err)
 	require.Len(t, results, 1)
-	assert.True(t, results[0].Skipped)
-	assert.Contains(t, results[0].SkipReason, "not upstream")
+	assert.True(t, results[0].Changed)
+
+	bumpedLock := readLock(t, store, "local-pkg")
+	assert.Equal(t, 1, bumpedLock.ManualBump)
+	assert.NotEqual(t, "sha256:old-fingerprint", bumpedLock.InputFingerprint,
+		"fingerprint must change after bump")
 }
 
 // Bumping a component with no lock file should fail with a clear message.
@@ -319,21 +356,33 @@ func TestBumpComponents_ErrorOnNoLockFile(t *testing.T) {
 	assert.Contains(t, err.Error(), "cannot bump")
 }
 
-// Bumping mixed components: upstream with lock succeeds, local skipped.
+// Bumping mixed components: upstream and local with locks both succeed.
 func TestBumpComponents_MixedComponents(t *testing.T) {
 	env := testutils.NewTestEnv(t)
 	store := newTestStore(t, env)
 
 	// Create lock for upstream component.
-	lock := lockfile.New()
-	lock.UpstreamCommit = testCommitHash
+	upstreamLock := lockfile.New()
+	upstreamLock.UpstreamCommit = testCommitHash
 
-	require.NoError(t, store.Save("curl", lock))
+	require.NoError(t, store.Save("curl", upstreamLock))
+
+	// Create lock and spec for local component.
+	specPath := "/specs/local-pkg/local-pkg.spec"
+	require.NoError(t, fileutils.WriteFile(env.TestFS, specPath, []byte("Name: local-pkg\n"), fileperms.PrivateFile))
+
+	localLock := lockfile.New()
+	localLock.InputFingerprint = "sha256:local-fp"
+
+	require.NoError(t, store.Save("local-pkg", localLock))
 
 	upstreamComp := newMockComp(t, "curl", baseConfig("curl"))
 	localComp := newMockComp(t, "local-pkg", &projectconfig.ComponentConfig{
 		Name: "local-pkg",
-		Spec: projectconfig.SpecSource{SourceType: projectconfig.SpecSourceTypeLocal},
+		Spec: projectconfig.SpecSource{
+			SourceType: projectconfig.SpecSourceTypeLocal,
+			Path:       specPath,
+		},
 	})
 
 	comps := []components.Component{localComp, upstreamComp}
@@ -341,11 +390,11 @@ func TestBumpComponents_MixedComponents(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, results, 2)
 
-	// Local should be skipped.
-	assert.True(t, results[0].Skipped)
-
-	// Upstream should be bumped.
+	// Both should be bumped.
+	assert.True(t, results[0].Changed)
 	assert.True(t, results[1].Changed)
+
+	assert.Equal(t, 1, readLock(t, store, "local-pkg").ManualBump)
 	assert.Equal(t, 1, readLock(t, store, "curl").ManualBump)
 }
 

--- a/internal/app/azldev/cmds/component/update_test.go
+++ b/internal/app/azldev/cmds/component/update_test.go
@@ -232,13 +232,13 @@ func TestUpdateComponents_MultipleComponents(t *testing.T) {
 	// This is correct: the fingerprint captures build-affecting inputs only.
 }
 
-// TestUpdateComponents_SkipsLocalComponent verifies local components are skipped.
-func TestUpdateComponents_SkipsLocalComponent(t *testing.T) {
+// TestUpdateComponents_LocalComponentWritesLock verifies that local components
+// get lock files with empty upstream-commit and populated fingerprint.
+func TestUpdateComponents_LocalComponentWritesLock(t *testing.T) {
 	env := testutils.NewTestEnv(t)
 
 	setupMockGit(env, "doesnt-matter")
 
-	// Add a local component (no upstream).
 	specPath := "/project/specs/local-pkg/local-pkg.spec"
 	require.NoError(t, fileutils.WriteFile(env.TestFS, specPath, []byte("Name: local-pkg\n"), fileperms.PrivateFile))
 
@@ -257,16 +257,73 @@ func TestUpdateComponents_SkipsLocalComponent(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	// Should be skipped.
+	// Local component should appear in results as changed (new lock).
+	foundChanged := false
+
 	for _, r := range results {
 		if r.Component == "local-pkg" {
-			assert.True(t, r.Skipped)
+			assert.True(t, r.Changed, "new local component should be marked changed")
+			assert.Empty(t, r.UpstreamCommit, "local components have no upstream commit")
 
-			return
+			foundChanged = true
 		}
 	}
 
-	// If local-pkg isn't in results at all, that's also acceptable (filtered out).
+	assert.True(t, foundChanged, "local-pkg should appear in results")
+
+	// Lock file should exist with empty upstream-commit and populated fingerprint.
+	store := lockfile.NewStore(env.TestFS, testLockDir)
+
+	lock, loadErr := store.Get("local-pkg")
+	require.NoError(t, loadErr)
+	assert.Empty(t, lock.UpstreamCommit, "local lock should have empty upstream-commit")
+	assert.NotEmpty(t, lock.InputFingerprint, "local lock should have a fingerprint")
+	assert.Contains(t, lock.InputFingerprint, "sha256:")
+}
+
+// TestUpdateComponents_LocalSpecChangeRefreshesFingerprint verifies that
+// modifying a local spec file causes update to produce a different fingerprint.
+func TestUpdateComponents_LocalSpecChangeRefreshesFingerprint(t *testing.T) {
+	env := testutils.NewTestEnv(t)
+
+	setupMockGit(env, "doesnt-matter")
+
+	specPath := "/project/specs/local-pkg/local-pkg.spec"
+	specContent := []byte("Name: local-pkg\nVersion: 1.0\n")
+	require.NoError(t, fileutils.WriteFile(env.TestFS, specPath, specContent, fileperms.PrivateFile))
+
+	env.Config.Components["local-pkg"] = projectconfig.ComponentConfig{
+		Name: "local-pkg",
+		Spec: projectconfig.SpecSource{
+			SourceType: projectconfig.SpecSourceTypeLocal,
+			Path:       specPath,
+		},
+	}
+
+	require.NoError(t, fileutils.MkdirAll(env.TestFS, testLockDir))
+
+	options := &componentcmds.UpdateComponentOptions{
+		ComponentFilter: components.ComponentFilter{IncludeAllComponents: true},
+	}
+
+	// Phase 1: initial update.
+	_, err := componentcmds.UpdateComponents(env.Env, options)
+	require.NoError(t, err)
+
+	store := lockfile.NewStore(env.TestFS, testLockDir)
+	fp1 := mustGetFingerprint(t, store, "local-pkg")
+
+	// Phase 2: modify spec content.
+	specContentV2 := []byte("Name: local-pkg\nVersion: 2.0\n")
+	require.NoError(t, fileutils.WriteFile(env.TestFS, specPath, specContentV2, fileperms.PrivateFile))
+
+	_, err = componentcmds.UpdateComponents(env.Env, options)
+	require.NoError(t, err)
+
+	store = lockfile.NewStore(env.TestFS, testLockDir)
+	fp2 := mustGetFingerprint(t, store, "local-pkg")
+
+	assert.NotEqual(t, fp1, fp2, "fingerprint must change when spec content changes")
 }
 
 // mustGetFingerprint reads the fingerprint from a lock file, failing the test on error.

--- a/internal/app/azldev/core/components/resolver.go
+++ b/internal/app/azldev/core/components/resolver.go
@@ -505,17 +505,14 @@ func (r *Resolver) createComponentFromConfig(componentConfig *projectconfig.Comp
 // all downstream commands (render, build, prepare-sources, diff-sources) get
 // locked state automatically via config.Locked.
 //
+// Works for both upstream and local components. For local components, the lock
+// file will have empty UpstreamCommit/ImportCommit fields but a populated
+// InputFingerprint.
+//
 // IMPORTANT: This must NEVER overwrite user-specified config values. Lock data
 // goes into the separate Locked field, preserving the manifest/lock boundary:
 // Spec.UpstreamCommit = user intent, Locked.UpstreamCommit = resolved reality.
 func (r *Resolver) populateFromLock(config *projectconfig.ComponentConfig) {
-	// Lock state is only meaningful for upstream components. Local and
-	// unspecified-source components do not have upstream commits to track,
-	// and any orphaned same-name lock file should not leak into their config.
-	if config.Spec.SourceType != projectconfig.SpecSourceTypeUpstream {
-		return
-	}
-
 	reader := r.env.LockReader()
 	if reader == nil {
 		return

--- a/internal/app/azldev/core/components/resolver_test.go
+++ b/internal/app/azldev/core/components/resolver_test.go
@@ -789,9 +789,8 @@ func TestFindComponents_ExplicitPinPreserved(t *testing.T) {
 	assert.Equal(t, "locked-commit-different", comp.GetConfig().Locked.UpstreamCommit)
 }
 
-// Local components (specs on disk, no upstream) don't have lock files.
-// The resolver should leave Locked as nil — no error, no special handling.
-func TestFindComponents_LocalComponentNoLockPopulation(t *testing.T) {
+// When no lock file exists for a local component, Locked stays nil.
+func TestFindComponents_LocalComponentNoLockFile(t *testing.T) {
 	env := testutils.NewTestEnv(t)
 
 	specPath := "/specs/local-pkg/local-pkg.spec"
@@ -805,7 +804,6 @@ func TestFindComponents_LocalComponentNoLockPopulation(t *testing.T) {
 		},
 	}
 
-	// No lock file for local component — this is normal.
 	filter := &components.ComponentFilter{IncludeAllComponents: true}
 
 	resolved, err := components.NewResolver(env.Env).FindComponents(filter)
@@ -814,7 +812,44 @@ func TestFindComponents_LocalComponentNoLockPopulation(t *testing.T) {
 	comp, ok := resolved.TryGet("local-pkg")
 	require.True(t, ok)
 
-	assert.Nil(t, comp.GetConfig().Locked, "local components should not have lock data")
+	assert.Nil(t, comp.GetConfig().Locked, "no lock file → Locked must be nil")
+}
+
+// When a lock file exists for a local component (written by a prior 'update'),
+// the resolver should populate Locked with the stored data.
+func TestFindComponents_LocalComponentWithLockFile(t *testing.T) {
+	env := testutils.NewTestEnv(t)
+
+	specPath := "/specs/local-pkg/local-pkg.spec"
+	require.NoError(t, fileutils.WriteFile(env.TestFS, specPath, []byte("Name: local-pkg\n"), fileperms.PrivateFile))
+
+	env.Config.Components["local-pkg"] = projectconfig.ComponentConfig{
+		Name: "local-pkg",
+		Spec: projectconfig.SpecSource{
+			SourceType: projectconfig.SpecSourceTypeLocal,
+			Path:       specPath,
+		},
+	}
+
+	// Write a lock file for the local component.
+	lock := lockfile.New()
+	lock.InputFingerprint = "sha256:test-local-fingerprint"
+	lock.ManualBump = 1
+
+	env.WriteLock(t, "local-pkg", lock)
+
+	filter := &components.ComponentFilter{IncludeAllComponents: true}
+
+	resolved, err := components.NewResolver(env.Env).FindComponents(filter)
+	require.NoError(t, err)
+
+	comp, ok := resolved.TryGet("local-pkg")
+	require.True(t, ok)
+
+	require.NotNil(t, comp.GetConfig().Locked, "lock file exists → Locked must be populated")
+	assert.Equal(t, "sha256:test-local-fingerprint", comp.GetConfig().Locked.InputFingerprint)
+	assert.Equal(t, 1, comp.GetConfig().Locked.ManualBump)
+	assert.Empty(t, comp.GetConfig().Locked.UpstreamCommit, "local components have no upstream commit")
 }
 
 // A corrupt or unparseable lock file should not silently fall back to


### PR DESCRIPTION
Local components (spec-on-disk, no upstream) now get lock files written by 'component update' and read by the resolver, the same as upstream components. Lock files for local components have empty upstream-commit and import-commit fields but populated input-fingerprint, enabling uniform change detection across all component types.

Key changes:
- Rename resolveUpstreamCommitsParallel → resolveSourceIdentitiesParallel and resolveOneUpstreamCommit → resolveOneSourceIdentity to reflect that both source types are now handled
- Drop the upstream-only skip in the resolve loop; local components flow through the same goroutine path using ResolveSourceIdentity (which returns a content hash for local specs)
- Add sourceIdentity field to UpdateResult so saveComponentLocks uses the correct identity (commit hash for upstream, content hash for local) when computing fingerprints
- Drop the upstream-only skip in bumpComponents; local components get their ManualBump incremented with source identity re-resolved from the spec directory
- Remove SpecSourceTypeUpstream gate in populateFromLock so the resolver populates Locked for any component with a lock file
- Add distro resolution guidance to go.instructions.md

New tests:
- Local component writes lock with empty upstream-commit and populated fingerprint
- Local spec content change refreshes fingerprint on re-update
- Bump works for local components (increments ManualBump, recomputes fingerprint)
- Resolver populates Locked for local components with lock files
- Resolver leaves Locked nil for local components without lock files

