### PR TITLE
fix(qemu): swap boot order so disk has priority over ISO

### DIFF
--- a/internal/utils/qemu/qemu.go
+++ b/internal/utils/qemu/qemu.go
@@ -88,8 +88,8 @@ type RunOptions struct {
 	// attached as a non-bootable IDE CD-ROM, independent of any install ISO.
 	CloudInitISOPath string
 	// InstallISOPath is an optional ISO to boot from (e.g., a livecd or installer).
-	// When set, it is attached as a bootable SCSI CD-ROM with bootindex=1 so the VM
-	// boots from the ISO first; the disk receives bootindex=2.
+	// When set, it is attached as a SCSI CD-ROM with bootindex=2 (fallback). The disk
+	// keeps bootindex=1 so that after installation the system boots from disk.
 	InstallISOPath string
 	SecureBoot     bool
 	SSHPort        int
@@ -130,21 +130,21 @@ func (r *Runner) Run(ctx context.Context, options RunOptions) error {
 		"-device", "virtio-scsi-pci,id=scsi",
 	)
 
-	// Boot order: when an install/live ISO is attached, it boots first (bootindex=1)
-	// and the disk follows (bootindex=2). Otherwise, the disk boots first.
-	diskBootIndex := 1
-	if options.InstallISOPath != "" {
-		diskBootIndex = 2
-	}
-
+	// Boot order: the disk always gets bootindex=1 (highest priority). When an
+	// install/live ISO is attached it receives bootindex=2 (fallback). This works
+	// correctly with UEFI/OVMF:
+	//   - First boot (empty disk): firmware tries disk, finds no EFI bootloader,
+	//     falls through to the CD-ROM and the installer runs.
+	//   - After installation + reboot: firmware tries disk, finds the bootloader
+	//     written by the installer, and boots from disk — skipping the ISO.
 	qemuArgs = append(qemuArgs,
-		"-device", fmt.Sprintf("scsi-hd,drive=hd,bootindex=%d", diskBootIndex),
+		"-device", "scsi-hd,drive=hd,bootindex=1",
 	)
 
 	if options.InstallISOPath != "" {
 		qemuArgs = append(qemuArgs,
 			"-drive", fmt.Sprintf("if=none,id=installcd,file=%s,media=cdrom,readonly=on", options.InstallISOPath),
-			"-device", "scsi-cd,drive=installcd,bootindex=1",
+			"-device", "scsi-cd,drive=installcd,bootindex=2",
 		)
 	}
 

--- a/internal/utils/qemu/qemu_test.go
+++ b/internal/utils/qemu/qemu_test.go
@@ -470,7 +470,7 @@ func TestRun(t *testing.T) {
 			wantErrContain: "failed to run VM in QEMU",
 		},
 		{
-			name: "VM with install ISO boots ISO first",
+			name: "VM with install ISO gives disk priority and ISO as fallback",
 			options: qemu.RunOptions{
 				Arch:           qemu.ArchX86_64,
 				FirmwarePath:   "/usr/share/OVMF/OVMF_CODE.fd",
@@ -486,8 +486,8 @@ func TestRun(t *testing.T) {
 			wantArgsContain: []string{
 				"qemu-system-x86_64",
 				"if=none,id=installcd,file=/tmp/installer.iso,media=cdrom,readonly=on",
-				"scsi-cd,drive=installcd,bootindex=1",
-				"scsi-hd,drive=hd,bootindex=2",
+				"scsi-cd,drive=installcd,bootindex=2",
+				"scsi-hd,drive=hd,bootindex=1",
 			},
 		},
 		{


### PR DESCRIPTION
UEFI/OVMF respects bootindex on every boot. Previously the ISO had bootindex=1 (highest) and the disk bootindex=2, causing the VM to always boot the ISO — even after the installer wrote an EFI bootloader to disk.

Give the disk bootindex=1 and the ISO bootindex=2. On first boot the firmware tries the empty disk, finds no bootloader, and falls through to the CD-ROM so the installer runs normally. After installation the firmware finds the new bootloader on disk and boots from it directly.

<!--
PR Title must follow Conventional Commits format. Available types:

- feat: A new feature
- fix: A bug fix
- docs: Documentation only changes
- style: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
- refactor: A code change that neither fixes a bug nor adds a feature
- perf: A code change that improves performance
- test: Adding missing tests or correcting existing tests
- build: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
- ci: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
- chore: Other changes that don't modify src or test files
- revert: Reverts a previous commit

Reference: https://www.conventionalcommits.org/en/v1.0.0/
-->
