### PR TITLE
fix: disallow release bumping on decimal releases

### DIFF
--- a/internal/app/azldev/core/sources/release.go
+++ b/internal/app/azldev/core/sources/release.go
@@ -24,11 +24,12 @@ import (
 //   - conditional form (no fallback): %{?autorelease}
 var autoreleasePattern = regexp.MustCompile(`%(\{[?]?autorelease($|[}\s])|autorelease($|\s))`)
 
-// staticReleasePattern matches a leading integer in a static Release tag value,
-// followed by an optional non-dotted-digit suffix (e.g. "%{?dist}").
-// Release values with dotted numeric prefixes (e.g. "1.39.b1%{?dist}") are
-// rejected because the leading integer is not the build counter in those cases.
-var staticReleasePattern = regexp.MustCompile(`^(\d+)([^.].*|)$`)
+// staticReleasePattern matches only the two Release tag forms we can safely
+// auto-bump: a bare integer (e.g. "1") or an integer followed by the
+// conditional dist macro (e.g. "5%{?dist}"). Any other suffix — dotted
+// segments, unknown macros, etc. — is rejected so the component must use
+// 'release.calculation = "manual"'.
+var staticReleasePattern = regexp.MustCompile(`^(\d+)(%\{\?dist\})?$`)
 
 // GetReleaseTagValue reads the Release tag value from the spec file at specPath.
 // It returns the raw value string as written in the spec (e.g. "1%{?dist}" or "%autorelease").

--- a/internal/app/azldev/core/sources/release.go
+++ b/internal/app/azldev/core/sources/release.go
@@ -25,8 +25,10 @@ import (
 var autoreleasePattern = regexp.MustCompile(`%(\{[?]?autorelease($|[}\s])|autorelease($|\s))`)
 
 // staticReleasePattern matches a leading integer in a static Release tag value,
-// followed by an optional suffix (e.g. "%{?dist}").
-var staticReleasePattern = regexp.MustCompile(`^(\d+)(.*)$`)
+// followed by an optional non-dotted-digit suffix (e.g. "%{?dist}").
+// Release values with dotted numeric prefixes (e.g. "1.39.b1%{?dist}") are
+// rejected because the leading integer is not the build counter in those cases.
+var staticReleasePattern = regexp.MustCompile(`^(\d+)([^.].*|)$`)
 
 // GetReleaseTagValue reads the Release tag value from the spec file at specPath.
 // It returns the raw value string as written in the spec (e.g. "1%{?dist}" or "%autorelease").

--- a/internal/app/azldev/core/sources/release_test.go
+++ b/internal/app/azldev/core/sources/release_test.go
@@ -65,6 +65,12 @@ func TestBumpStaticRelease(t *testing.T) {
 		{"single commit", "1%{?dist}", 1, "2%{?dist}", false},
 		{"no leading int", "%{?dist}", 1, "", true},
 		{"empty string", "", 1, "", true},
+
+		// Dotted decimal releases are rejected (build counter is not the leading integer).
+		{"dotted with beta suffix", "1.39.b1%{?dist}", 3, "", true},
+		{"dotted simple", "1.2%{?dist}", 2, "", true},
+		{"dotted no suffix", "1.10", 5, "", true},
+		{"dotted zero prefix", "0.1", 1, "", true},
 	} {
 		t.Run(testCase.name, func(t *testing.T) {
 			result, err := sources.BumpStaticRelease(testCase.value, testCase.commits)

--- a/internal/app/azldev/core/sources/release_test.go
+++ b/internal/app/azldev/core/sources/release_test.go
@@ -59,18 +59,30 @@ func TestBumpStaticRelease(t *testing.T) {
 		expected    string
 		wantErr     bool
 	}{
+		// Accepted forms: bare integer or integer + %{?dist}.
 		{"simple integer", "1", 3, "4", false},
 		{"with dist tag", "1%{?dist}", 2, "3%{?dist}", false},
 		{"larger base", "10%{?dist}", 5, "15%{?dist}", false},
 		{"single commit", "1%{?dist}", 1, "2%{?dist}", false},
+
+		// Rejected: no leading integer.
 		{"no leading int", "%{?dist}", 1, "", true},
 		{"empty string", "", 1, "", true},
 
-		// Dotted decimal releases are rejected (build counter is not the leading integer).
+		// Rejected: unknown macros in suffix.
+		{"other macros", "17%{someothermacro}%{?dist}", 3, "", true},
+		{"non-conditional dist", "1%{dist}", 1, "", true},
+		{"macro before dist", "0%{rc_subver}%{?dist}", 1, "", true},
+
+		// Rejected: dotted decimal releases.
 		{"dotted with beta suffix", "1.39.b1%{?dist}", 3, "", true},
 		{"dotted simple", "1.2%{?dist}", 2, "", true},
 		{"dotted no suffix", "1.10", 5, "", true},
 		{"dotted zero prefix", "0.1", 1, "", true},
+
+		// Rejected: trailing dot.
+		{"trailing dot before dist", "1.%{?dist}", 1, "", true},
+		{"trailing dot no suffix", "1.", 1, "", true},
 	} {
 		t.Run(testCase.name, func(t *testing.T) {
 			result, err := sources.BumpStaticRelease(testCase.value, testCase.commits)


### PR DESCRIPTION
These changes resolve the unintended behavior of bumping the leading integer in decimal releases that exist in some specs. One such example occurs with the package `cvsps`.

```spec
# Failure
Release:    0.39.b1 -> 1.39.b1 
```