### PR TITLE
fix(dist-git): fix render staging, import-commit seeding, and commit …

### DIFF
--- a/internal/app/azldev/cmds/component/render.go
+++ b/internal/app/azldev/cmds/component/render.go
@@ -157,8 +157,9 @@ func RenderComponents(env *azldev.Env, options *RenderOptions) ([]*RenderResult,
 
 	// Create a shared staging directory. Each component gets a subdirectory
 	// named by component name, enabling a single bind mount for the batch
-	// mock invocation.
-	stagingDir, err := fileutils.MkdirTempInTempDir(env.FS(), "azldev-render-staging-")
+	// mock invocation. Use the project work dir instead of /tmp to avoid
+	// filling up tmpfs on large renders.
+	stagingDir, err := fileutils.MkdirTemp(env.FS(), env.Config().Project.WorkDir, "azldev-render-staging-")
 	if err != nil {
 		return nil, fmt.Errorf("creating staging directory:\n%w", err)
 	}

--- a/internal/app/azldev/cmds/component/render.go
+++ b/internal/app/azldev/cmds/component/render.go
@@ -159,7 +159,11 @@ func RenderComponents(env *azldev.Env, options *RenderOptions) ([]*RenderResult,
 	// named by component name, enabling a single bind mount for the batch
 	// mock invocation. Use the project work dir instead of /tmp to avoid
 	// filling up tmpfs on large renders.
-	stagingDir, err := fileutils.MkdirTemp(env.FS(), env.Config().Project.WorkDir, "azldev-render-staging-")
+	if err := env.FS().MkdirAll(env.WorkDir(), fileperms.PublicDir); err != nil {
+		return nil, fmt.Errorf("creating work directory:\n%w", err)
+	}
+
+	stagingDir, err := fileutils.MkdirTemp(env.FS(), env.WorkDir(), "azldev-render-staging-")
 	if err != nil {
 		return nil, fmt.Errorf("creating staging directory:\n%w", err)
 	}

--- a/internal/app/azldev/cmds/component/update.go
+++ b/internal/app/azldev/cmds/component/update.go
@@ -237,6 +237,13 @@ func saveComponentLocks(env *azldev.Env, store *lockfile.Store, results []Update
 			lock.ImportCommit = ""
 		}
 
+		// Seed import-commit on first update so the synthetic history walk
+		// has a bounded starting point instead of walking the entire repo.
+		if lock.ImportCommit == "" && results[idx].config != nil &&
+			results[idx].config.Spec.SourceType == projectconfig.SpecSourceTypeUpstream {
+			lock.ImportCommit = results[idx].UpstreamCommit
+		}
+
 		// Recompute fingerprint from resolved config + lock state.
 		if results[idx].config == nil {
 			retErr = fmt.Errorf("no resolved config for %#q; cannot compute fingerprint", results[idx].Component)

--- a/internal/app/azldev/cmds/component/update.go
+++ b/internal/app/azldev/cmds/component/update.go
@@ -221,83 +221,89 @@ func saveComponentLocks(env *azldev.Env, store *lockfile.Store, results []Update
 			continue
 		}
 
-		lock, lockErr := store.GetOrNew(results[idx].Component)
-		if lockErr != nil {
-			retErr = fmt.Errorf("loading lock for %#q:\n%w", results[idx].Component, lockErr)
+		written, err := updateComponentLock(env, store, &results[idx])
+		if err != nil {
+			retErr = err
 
 			return retErr
 		}
 
-		lock.UpstreamCommit = results[idx].UpstreamCommit
-
-		// Clear upstream-only fields for local components so a source-type
-		// transition (upstream → local) doesn't leave stale data in the lock.
-		if results[idx].config != nil &&
-			results[idx].config.Spec.SourceType != projectconfig.SpecSourceTypeUpstream {
-			lock.ImportCommit = ""
+		if written {
+			saved = append(saved, results[idx].Component)
 		}
-
-		// Seed import-commit on first update so the synthetic history walk
-		// has a bounded starting point instead of walking the entire repo.
-		if lock.ImportCommit == "" && results[idx].config != nil &&
-			results[idx].config.Spec.SourceType == projectconfig.SpecSourceTypeUpstream {
-			lock.ImportCommit = results[idx].UpstreamCommit
-		}
-
-		// Recompute fingerprint from resolved config + lock state.
-		if results[idx].config == nil {
-			retErr = fmt.Errorf("no resolved config for %#q; cannot compute fingerprint", results[idx].Component)
-
-			return retErr
-		}
-
-		// Resolve per-component distro for ReleaseVer, matching the
-		// per-component resolution used by render/build/prepare-sources.
-		releaseVer, distroErr := resolveReleaseVer(env, results[idx].config)
-		if distroErr != nil {
-			retErr = fmt.Errorf("resolving distro for %#q:\n%w", results[idx].Component, distroErr)
-
-			return retErr
-		}
-
-		identity, fpErr := fingerprint.ComputeIdentity(
-			env.FS(),
-			*results[idx].config,
-			releaseVer,
-			fingerprint.IdentityOptions{
-				ManualBump:     lock.ManualBump,
-				SourceIdentity: results[idx].sourceIdentity,
-			},
-		)
-		if fpErr != nil {
-			retErr = fmt.Errorf("computing fingerprint for %#q:\n%w", results[idx].Component, fpErr)
-
-			return retErr
-		}
-
-		// Mark as changed if fingerprint differs (catches config/overlay edits
-		// even when the upstream commit is unchanged).
-		if lock.InputFingerprint != identity.Fingerprint {
-			results[idx].Changed = true
-		}
-
-		lock.InputFingerprint = identity.Fingerprint
-
-		// Only write if something actually changed.
-		if !results[idx].Changed {
-			continue
-		}
-
-		if saveErr := store.Save(results[idx].Component, lock); saveErr != nil {
-			retErr = fmt.Errorf("saving lock file for %#q:\n%w", results[idx].Component, saveErr)
-
-			return retErr
-		}
-
-		saved = append(saved, results[idx].Component)
 	}
 
 	return nil
+}
+
+// updateComponentLock recomputes the fingerprint for a single component and
+// writes its lock file if anything changed. Returns true when the lock file
+// was written.
+func updateComponentLock(env *azldev.Env, store *lockfile.Store, result *UpdateResult) (bool, error) {
+	lock, lockErr := store.GetOrNew(result.Component)
+	if lockErr != nil {
+		return false, fmt.Errorf("loading lock for %#q:\n%w", result.Component, lockErr)
+	}
+
+	lock.UpstreamCommit = result.UpstreamCommit
+
+	// Clear upstream-only fields for local components so a source-type
+	// transition (upstream → local) doesn't leave stale data in the lock.
+	if result.config != nil &&
+		result.config.Spec.SourceType != projectconfig.SpecSourceTypeUpstream {
+		lock.ImportCommit = ""
+	}
+
+	// Seed import-commit on first update so the synthetic history walk
+	// has a bounded starting point instead of walking the entire repo.
+	if lock.ImportCommit == "" && result.config != nil &&
+		result.config.Spec.SourceType == projectconfig.SpecSourceTypeUpstream {
+		lock.ImportCommit = result.UpstreamCommit
+	}
+
+	// Recompute fingerprint from resolved config + lock state.
+	if result.config == nil {
+		return false, fmt.Errorf("no resolved config for %#q; cannot compute fingerprint", result.Component)
+	}
+
+	// Resolve per-component distro for ReleaseVer, matching the
+	// per-component resolution used by render/build/prepare-sources.
+	releaseVer, distroErr := resolveReleaseVer(env, result.config)
+	if distroErr != nil {
+		return false, fmt.Errorf("resolving distro for %#q:\n%w", result.Component, distroErr)
+	}
+
+	identity, fpErr := fingerprint.ComputeIdentity(
+		env.FS(),
+		*result.config,
+		releaseVer,
+		fingerprint.IdentityOptions{
+			ManualBump:     lock.ManualBump,
+			SourceIdentity: result.sourceIdentity,
+		},
+	)
+	if fpErr != nil {
+		return false, fmt.Errorf("computing fingerprint for %#q:\n%w", result.Component, fpErr)
+	}
+
+	// Mark as changed if fingerprint differs (catches config/overlay edits
+	// even when the upstream commit is unchanged).
+	if lock.InputFingerprint != identity.Fingerprint {
+		result.Changed = true
+	}
+
+	lock.InputFingerprint = identity.Fingerprint
+
+	// Only write if something actually changed.
+	if !result.Changed {
+		return false, nil
+	}
+
+	if saveErr := store.Save(result.Component, lock); saveErr != nil {
+		return false, fmt.Errorf("saving lock file for %#q:\n%w", result.Component, saveErr)
+	}
+
+	return true, nil
 }
 
 // bumpComponents re-fingerprints each matched component's lock file with an

--- a/internal/app/azldev/core/sources/synthistory.go
+++ b/internal/app/azldev/core/sources/synthistory.go
@@ -709,7 +709,7 @@ func gitLogFileMetadata(
 	var metas []CommitMetadata //nolint:prealloc // trailing empty block after split.
 
 	for _, block := range blocks {
-		block = strings.TrimRight(block, "\r\n")
+		block = strings.Trim(block, "\r\n")
 		if block == "" {
 			continue
 		}


### PR DESCRIPTION
…parsing

- Use project WorkDir for render staging instead of /tmp to avoid filling tmpfs on large batch renders with synthetic git history.
- Seed import-commit on first update so synthetic history walks have a bounded starting point instead of traversing entire repo histories.
- Fix TrimRight -> Trim in commit metadata parsing to handle leading newlines that caused hash parse failures.

<!--
PR Title must follow Conventional Commits format. Available types:

- feat: A new feature
- fix: A bug fix
- docs: Documentation only changes
- style: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
- refactor: A code change that neither fixes a bug nor adds a feature
- perf: A code change that improves performance
- test: Adding missing tests or correcting existing tests
- build: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
- ci: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
- chore: Other changes that don't modify src or test files
- revert: Reverts a previous commit

Reference: https://www.conventionalcommits.org/en/v1.0.0/
-->
