### PR TITLE
fix(dist-git): Static release bumping from lock history

### DIFF
--- a/internal/app/azldev/core/sources/release.go
+++ b/internal/app/azldev/core/sources/release.go
@@ -5,16 +5,25 @@ package sources
 
 import (
 	"fmt"
+	"io"
 	"log/slog"
 	"regexp"
 	"strconv"
 	"strings"
 
+	"github.com/go-git/go-git/v5/plumbing"
+	"github.com/go-git/go-git/v5/plumbing/object"
 	"github.com/microsoft/azure-linux-dev-tools/internal/app/azldev/core/components"
 	"github.com/microsoft/azure-linux-dev-tools/internal/global/opctx"
 	"github.com/microsoft/azure-linux-dev-tools/internal/projectconfig"
 	"github.com/microsoft/azure-linux-dev-tools/internal/rpm/spec"
 )
+
+// commitResolver abstracts the ability to look up a commit by hash.
+// This is satisfied by [*gogit.Repository] and can be replaced in tests.
+type commitResolver interface {
+	CommitObject(hash plumbing.Hash) (*object.Commit, error)
+}
 
 // autoreleasePattern matches the %autorelease macro invocation in a Release tag value.
 // This covers:
@@ -72,6 +81,132 @@ func ReleaseUsesAutorelease(releaseValue string) bool {
 	return autoreleasePattern.MatchString(releaseValue)
 }
 
+// GetVersionTagFromReader reads the Version tag value from a spec parsed from an [io.Reader].
+// Returns the raw value string (e.g. "1.0.0" or "%{base_version}").
+// Returns [spec.ErrNoSuchTag] if no Version tag is found.
+func GetVersionTagFromReader(reader io.Reader) (string, error) {
+	openedSpec, err := spec.OpenSpec(reader)
+	if err != nil {
+		return "", fmt.Errorf("failed to parse spec:\n%w", err)
+	}
+
+	var versionValue string
+
+	err = openedSpec.VisitTagsPackage("", func(tagLine *spec.TagLine, _ *spec.Context) error {
+		if strings.EqualFold(tagLine.Tag, "Version") {
+			versionValue = tagLine.Value
+		}
+
+		return nil
+	})
+	if err != nil {
+		return "", fmt.Errorf("failed to visit tags:\n%w", err)
+	}
+
+	if versionValue == "" {
+		return "", fmt.Errorf("version tag not found:\n%w", spec.ErrNoSuchTag)
+	}
+
+	return versionValue, nil
+}
+
+// getVersionAtUpstreamCommit reads the Version tag from a component's spec file
+// at a specific upstream commit in the dist-git repository. The spec file is
+// located by name (e.g. "package.spec") within the commit's tree.
+func getVersionAtUpstreamCommit(
+	resolver commitResolver,
+	commitHash string,
+	specFileName string,
+) (string, error) {
+	commitObj, err := resolver.CommitObject(plumbing.NewHash(commitHash))
+	if err != nil {
+		return "", fmt.Errorf("failed to get commit %#q:\n%w", commitHash, err)
+	}
+
+	tree, err := commitObj.Tree()
+	if err != nil {
+		return "", fmt.Errorf("failed to get tree for commit %#q:\n%w", commitHash, err)
+	}
+
+	file, err := tree.File(specFileName)
+	if err != nil {
+		return "", fmt.Errorf("spec file %#q not found at commit %#q:\n%w", specFileName, commitHash, err)
+	}
+
+	reader, err := file.Reader()
+	if err != nil {
+		return "", fmt.Errorf("failed to read spec file %#q at commit %#q:\n%w", specFileName, commitHash, err)
+	}
+	defer reader.Close()
+
+	return GetVersionTagFromReader(reader)
+}
+
+// CountCommitsSinceVersionChange determines how many synthetic commits should
+// contribute to the static Release bump. It walks the [FingerprintChange] list
+// (chronological, oldest first), reads the Version tag from the dist-git spec
+// at each unique [FingerprintChange.UpstreamCommit], and finds the point where
+// the Version last changed. Only synthetic commits after that point contribute
+// to the count.
+// When the Version tag cannot be read at a historical commit (e.g. the spec was
+// renamed), the function falls back to len(changes).
+func CountCommitsSinceVersionChange(
+	resolver commitResolver,
+	specFileName string,
+	changes []FingerprintChange,
+) int {
+	if len(changes) == 0 {
+		return 0
+	}
+
+	if resolver == nil {
+		return len(changes)
+	}
+
+	// Walk changes newest-to-oldest, resolving the Version tag at each unique
+	// upstream commit. Stop as soon as a version change is detected.
+	versionCache := make(map[string]string)
+	count := 0
+
+	latestVersion := ""
+
+	for idx := len(changes) - 1; idx >= 0; idx-- {
+		hash := changes[idx].UpstreamCommit
+
+		version, ok := versionCache[hash]
+		if !ok {
+			var err error
+
+			version, err = getVersionAtUpstreamCommit(resolver, hash, specFileName)
+			if err != nil {
+				slog.Warn("Failed to read Version tag at upstream commit; falling back to total commit count",
+					"commit", hash, "error", err)
+
+				return len(changes)
+			}
+
+			versionCache[hash] = version
+		}
+
+		if latestVersion == "" {
+			latestVersion = version
+		}
+
+		if version != latestVersion {
+			break
+		}
+
+		count++
+	}
+
+	slog.Info("Computed version-aware release bump count",
+		"latestVersion", latestVersion,
+		"totalChanges", len(changes),
+		"sinceVersionChange", count)
+
+	return count
+}
+
 // BumpStaticRelease increments the leading integer in a static Release tag value
 // by the given commit count.
 func BumpStaticRelease(releaseValue string, commitCount int) (string, error) {
@@ -92,10 +227,8 @@ func BumpStaticRelease(releaseValue string, commitCount int) (string, error) {
 }
 
 // tryBumpStaticRelease checks whether the component's spec uses %autorelease.
-// If not, it bumps the static Release tag by commitCount and applies the change
-// as an overlay to the spec file in-place. This ensures that components with static
-// release numbers get deterministic version bumps matching the number of synthetic
-// commits applied from the project repository.
+// If not, it computes a version-aware bump count via [CountCommitsSinceVersionChange]
+// and applies the change as an overlay to the spec file in-place.
 //
 // When the component's release calculation is "manual", this function is a no-op.
 //
@@ -110,7 +243,8 @@ func BumpStaticRelease(releaseValue string, commitCount int) (string, error) {
 func (p *sourcePreparerImpl) tryBumpStaticRelease(
 	component components.Component,
 	sourcesDirPath string,
-	commitCount int,
+	repo commitResolver,
+	changes []FingerprintChange,
 ) error {
 	if component.GetConfig().Release.Calculation == projectconfig.ReleaseCalculationManual {
 		slog.Debug("Component uses manual release calculation; skipping static release bump",
@@ -136,6 +270,12 @@ func (p *sourcePreparerImpl) tryBumpStaticRelease(
 
 		return nil
 	}
+
+	// Only compute the version-aware commit count after confirming the spec
+	// uses a static release, to avoid unnecessary git tree traversals for
+	// components that use %autorelease or manual mode.
+	specFileName := component.GetName() + ".spec"
+	commitCount := CountCommitsSinceVersionChange(repo, specFileName, changes)
 
 	newRelease, err := BumpStaticRelease(releaseValue, commitCount)
 	if err != nil {

--- a/internal/app/azldev/core/sources/release.go
+++ b/internal/app/azldev/core/sources/release.go
@@ -142,33 +142,23 @@ func getVersionAtUpstreamCommit(
 	return GetVersionTagFromReader(reader)
 }
 
-// CountCommitsSinceVersionChange determines how many synthetic commits should
-// contribute to the static Release bump. It walks the [FingerprintChange] list
-// (chronological, oldest first), reads the Version tag from the dist-git spec
-// at each unique [FingerprintChange.UpstreamCommit], and finds the point where
-// the Version last changed. Only synthetic commits after that point contribute
-// to the count.
+// CountCommitsSinceVersionChange counts how many [FingerprintChange] entries
+// since the last Version tag change should contribute to a static Release bump.
 //
-// When the Version tag cannot be read at a historical commit (e.g. because of
-// a shallow clone, a force-push that rewrote upstream history, or a spec
-// rename), the unresolvable commit is treated as a version boundary and the
-// walk stops — only the already-counted commits contribute. This mirrors how
-// [buildInterleavedSequence] drops orphaned commits rather than placing them on
-// top of the synthetic history.
-//
-// When the resolver is nil (local components with no upstream repo), all
-// changes are counted because there is no version history to consult.
+// Unresolvable upstream commits are treated as version boundaries. A nil
+// resolver (local components) counts all changes. Returns an error if the
+// Version tag contains unexpanded RPM macros (e.g. "%{base_version}").
 func CountCommitsSinceVersionChange(
 	resolver commitResolver,
 	specFileName string,
 	changes []FingerprintChange,
-) int {
+) (int, error) {
 	if len(changes) == 0 {
-		return 0
+		return 0, nil
 	}
 
 	if resolver == nil {
-		return len(changes)
+		return len(changes), nil
 	}
 
 	// Walk changes newest-to-oldest, resolving the Version tag at each unique
@@ -181,6 +171,14 @@ func CountCommitsSinceVersionChange(
 	for idx := len(changes) - 1; idx >= 0; idx-- {
 		hash := changes[idx].UpstreamCommit
 
+		if hash == "" {
+			// Local or synthetic changes are not tied to a resolvable upstream
+			// commit. Count them all since there's no version history to consult.
+			count++
+
+			continue
+		}
+
 		version, ok := versionCache[hash]
 		if !ok {
 			var err error
@@ -191,6 +189,13 @@ func CountCommitsSinceVersionChange(
 					"commit", hash, "error", err)
 
 				break
+			}
+
+			if strings.Contains(version, "%") {
+				return 0, fmt.Errorf(
+					"version tag at commit %#q contains unexpanded macro %#q; "+
+						"version-change detection requires macro expansion which is not available here",
+					hash, version)
 			}
 
 			versionCache[hash] = version
@@ -212,7 +217,7 @@ func CountCommitsSinceVersionChange(
 		"totalChanges", len(changes),
 		"sinceVersionChange", count)
 
-	return count
+	return count, nil
 }
 
 // BumpStaticRelease increments the leading integer in a static Release tag value
@@ -283,7 +288,15 @@ func (p *sourcePreparerImpl) tryBumpStaticRelease(
 	// uses a static release, to avoid unnecessary git tree traversals for
 	// components that use %autorelease or manual mode.
 	specFileName := component.GetName() + ".spec"
-	commitCount := CountCommitsSinceVersionChange(repo, specFileName, changes)
+
+	commitCount, err := CountCommitsSinceVersionChange(repo, specFileName, changes)
+	if err != nil {
+		return fmt.Errorf(
+			"component %#q has a Version tag that cannot be resolved for auto-release calculation; "+
+				"set 'release.calculation = \"manual\"' in the component configuration "+
+				"and add a \"spec-set-tag\" overlay for the Release tag if needed:\n%w",
+			component.GetName(), err)
+	}
 
 	newRelease, err := BumpStaticRelease(releaseValue, commitCount)
 	if err != nil {

--- a/internal/app/azldev/core/sources/release.go
+++ b/internal/app/azldev/core/sources/release.go
@@ -148,8 +148,16 @@ func getVersionAtUpstreamCommit(
 // at each unique [FingerprintChange.UpstreamCommit], and finds the point where
 // the Version last changed. Only synthetic commits after that point contribute
 // to the count.
-// When the Version tag cannot be read at a historical commit (e.g. the spec was
-// renamed), the function falls back to len(changes).
+//
+// When the Version tag cannot be read at a historical commit (e.g. because of
+// a shallow clone, a force-push that rewrote upstream history, or a spec
+// rename), the unresolvable commit is treated as a version boundary and the
+// walk stops — only the already-counted commits contribute. This mirrors how
+// [buildInterleavedSequence] drops orphaned commits rather than placing them on
+// top of the synthetic history.
+//
+// When the resolver is nil (local components with no upstream repo), all
+// changes are counted because there is no version history to consult.
 func CountCommitsSinceVersionChange(
 	resolver commitResolver,
 	specFileName string,
@@ -179,10 +187,10 @@ func CountCommitsSinceVersionChange(
 
 			version, err = getVersionAtUpstreamCommit(resolver, hash, specFileName)
 			if err != nil {
-				slog.Warn("Failed to read Version tag at upstream commit; falling back to total commit count",
+				slog.Warn("Failed to read Version tag at upstream commit; treating as version boundary",
 					"commit", hash, "error", err)
 
-				return len(changes)
+				break
 			}
 
 			versionCache[hash] = version

--- a/internal/app/azldev/core/sources/release.go
+++ b/internal/app/azldev/core/sources/release.go
@@ -181,6 +181,14 @@ func CountCommitsSinceVersionChange(
 	for idx := len(changes) - 1; idx >= 0; idx-- {
 		hash := changes[idx].UpstreamCommit
 
+		if hash == "" {
+			// Local or synthetic changes are not tied to a resolvable upstream
+			// commit. Count them all since there's no version history to consult.
+			count++
+
+			continue
+		}
+
 		version, ok := versionCache[hash]
 		if !ok {
 			var err error

--- a/internal/app/azldev/core/sources/release.go
+++ b/internal/app/azldev/core/sources/release.go
@@ -199,7 +199,7 @@ func CountCommitsSinceVersionChange(
 		count++
 	}
 
-	slog.Info("Computed version-aware release bump count",
+	slog.Debug("Computed version-aware release bump count",
 		"latestVersion", latestVersion,
 		"totalChanges", len(changes),
 		"sinceVersionChange", count)

--- a/internal/app/azldev/core/sources/release_internal_test.go
+++ b/internal/app/azldev/core/sources/release_internal_test.go
@@ -59,7 +59,7 @@ func TestTryBumpStaticRelease_ManualSkips(t *testing.T) {
 	})
 
 	// No spec file needed — should skip before reading anything.
-	err := preparer.tryBumpStaticRelease(comp, testSourcesDir, 3)
+	err := preparer.tryBumpStaticRelease(comp, testSourcesDir, nil, nil)
 	require.NoError(t, err)
 }
 
@@ -76,7 +76,7 @@ func TestTryBumpStaticRelease_AutoreleaseSkips(t *testing.T) {
 		},
 	})
 
-	err := preparer.tryBumpStaticRelease(comp, filepath.Join(testSourcesDir, "test-pkg"), 3)
+	err := preparer.tryBumpStaticRelease(comp, filepath.Join(testSourcesDir, "test-pkg"), nil, nil)
 	require.NoError(t, err)
 }
 
@@ -93,14 +93,16 @@ func TestTryBumpStaticRelease_StaticBumps(t *testing.T) {
 		},
 	})
 
-	err := preparer.tryBumpStaticRelease(comp, filepath.Join(testSourcesDir, "test-pkg"), 3)
+	// Pass nil repo so CountCommitsSinceVersionChange falls back to len(changes).
+	changes := make([]FingerprintChange, 5)
+	err := preparer.tryBumpStaticRelease(comp, filepath.Join(testSourcesDir, "test-pkg"), nil, changes)
 	require.NoError(t, err)
 
 	// Verify the spec was updated.
 	specPath := filepath.Join(testSourcesDir, "test-pkg", "test-pkg.spec")
 	content, err := fileutils.ReadFile(memFS, specPath)
 	require.NoError(t, err)
-	assert.Contains(t, string(content), "Release: 4%{?dist}")
+	assert.Contains(t, string(content), "Release: 6%{?dist}")
 }
 
 func TestTryBumpStaticRelease_NonStandardErrorsWithoutManual(t *testing.T) {
@@ -116,7 +118,7 @@ func TestTryBumpStaticRelease_NonStandardErrorsWithoutManual(t *testing.T) {
 		},
 	})
 
-	err := preparer.tryBumpStaticRelease(comp, filepath.Join(testSourcesDir, "kernel"), 3)
+	err := preparer.tryBumpStaticRelease(comp, filepath.Join(testSourcesDir, "kernel"), nil, nil)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "cannot be auto-bumped")
 	assert.Contains(t, err.Error(), "release.calculation")
@@ -135,6 +137,6 @@ func TestTryBumpStaticRelease_NonStandardSucceedsWithManual(t *testing.T) {
 		},
 	})
 
-	err := preparer.tryBumpStaticRelease(comp, filepath.Join(testSourcesDir, "kernel"), 3)
+	err := preparer.tryBumpStaticRelease(comp, filepath.Join(testSourcesDir, "kernel"), nil, nil)
 	require.NoError(t, err)
 }

--- a/internal/app/azldev/core/sources/release_test.go
+++ b/internal/app/azldev/core/sources/release_test.go
@@ -215,6 +215,7 @@ func TestCountCommitsSinceVersionChange(t *testing.T) {
 	const (
 		nonExistentHash = -1 // valid hex format but not in repo
 		malformedHash   = -2 // invalid hash format
+		emptyHash       = -3 // empty string (local component, no upstream)
 	)
 
 	for _, testCase := range []struct {
@@ -235,6 +236,7 @@ func TestCountCommitsSinceVersionChange(t *testing.T) {
 		{"non-existent commit hash", []string{"1.0"}, []int{nonExistentHash, nonExistentHash, nonExistentHash}, "", 0},
 		{"invalid hash string", []string{"1.0"}, []int{malformedHash, malformedHash}, "", 0},
 		{"partially resolvable", []string{"1.0"}, []int{nonExistentHash, 0, 0}, "", 2},
+		{"empty upstream (local component)", []string{"1.0"}, []int{emptyHash, emptyHash, emptyHash}, "", 3},
 	} {
 		t.Run(testCase.name, func(t *testing.T) {
 			repo, hashes := createRepoWithVersionCommits(t, testCase.versions)
@@ -256,6 +258,8 @@ func TestCountCommitsSinceVersionChange(t *testing.T) {
 					upstream = "deadbeefdeadbeefdeadbeefdeadbeefdeadbeef"
 				case idx == malformedHash:
 					upstream = "not-a-valid-hash"
+				case idx == emptyHash:
+					upstream = ""
 				}
 
 				changes = append(changes, sources.FingerprintChange{

--- a/internal/app/azldev/core/sources/release_test.go
+++ b/internal/app/azldev/core/sources/release_test.go
@@ -211,93 +211,61 @@ func createRepoWithVersionCommits(t *testing.T, versions []string) (*gogit.Repos
 	return repo, hashes
 }
 
-func TestCountCommitsSinceVersionChange_NoVersionChange(t *testing.T) {
-	// All synthetic commits reference the same upstream commit → all count.
-	repo, hashes := createRepoWithVersionCommits(t, []string{"1.0"})
+func TestCountCommitsSinceVersionChange(t *testing.T) {
+	const (
+		nonExistentHash = -1 // valid hex format but not in repo
+		malformedHash   = -2 // invalid hash format
+	)
 
-	changes := []sources.FingerprintChange{
-		{CommitMetadata: sources.CommitMetadata{Hash: "a1"}, UpstreamCommit: hashes[0]},
-		{CommitMetadata: sources.CommitMetadata{Hash: "a2"}, UpstreamCommit: hashes[0]},
-		{CommitMetadata: sources.CommitMetadata{Hash: "a3"}, UpstreamCommit: hashes[0]},
+	for _, testCase := range []struct {
+		name     string
+		versions []string // versions to commit in the upstream repo
+		// Index into created hashes; negative values use sentinel literals.
+		upstreamCommits []int
+		specFile        string // override spec filename (default: "package.spec")
+		expected        int
+	}{
+		{"no version change", []string{"1.0"}, []int{0, 0, 0}, "", 3},
+		{"version change mid-stream", []string{"1.0", "2.0"}, []int{0, 0, 1}, "", 1},
+		{"multiple version jumps", []string{"1.0", "2.0", "3.0"}, []int{0, 1, 2, 2}, "", 2},
+		{"same version multiple upstreams", []string{"1.0", "1.0"}, []int{0, 1, 1}, "", 3},
+		{"single change", []string{"1.0"}, []int{0}, "", 1},
+		{"empty changes", []string{"1.0"}, nil, "", 0},
+		{"spec not found", []string{"1.0"}, []int{0, 0}, "nonexistent.spec", 0},
+		{"non-existent commit hash", []string{"1.0"}, []int{nonExistentHash, nonExistentHash, nonExistentHash}, "", 0},
+		{"invalid hash string", []string{"1.0"}, []int{malformedHash, malformedHash}, "", 0},
+		{"partially resolvable", []string{"1.0"}, []int{nonExistentHash, 0, 0}, "", 2},
+	} {
+		t.Run(testCase.name, func(t *testing.T) {
+			repo, hashes := createRepoWithVersionCommits(t, testCase.versions)
+
+			specFile := testCase.specFile
+			if specFile == "" {
+				specFile = "package.spec"
+			}
+
+			var changes []sources.FingerprintChange
+
+			for changeIdx, idx := range testCase.upstreamCommits {
+				var upstream string
+
+				switch {
+				case idx >= 0:
+					upstream = hashes[idx]
+				case idx == nonExistentHash:
+					upstream = "deadbeefdeadbeefdeadbeefdeadbeefdeadbeef"
+				case idx == malformedHash:
+					upstream = "not-a-valid-hash"
+				}
+
+				changes = append(changes, sources.FingerprintChange{
+					CommitMetadata: sources.CommitMetadata{Hash: fmt.Sprintf("a%d", changeIdx+1)},
+					UpstreamCommit: upstream,
+				})
+			}
+
+			count := sources.CountCommitsSinceVersionChange(repo, specFile, changes)
+			assert.Equal(t, testCase.expected, count)
+		})
 	}
-
-	count := sources.CountCommitsSinceVersionChange(repo, "package.spec", changes)
-	assert.Equal(t, 3, count)
-}
-
-func TestCountCommitsSinceVersionChange_VersionChangeMidStream(t *testing.T) {
-	// Upstream goes 1.0 → 2.0. Two synthetic commits for 1.0, one for 2.0.
-	// Only the one after 2.0 should count.
-	repo, hashes := createRepoWithVersionCommits(t, []string{"1.0", "2.0"})
-
-	changes := []sources.FingerprintChange{
-		{CommitMetadata: sources.CommitMetadata{Hash: "a1"}, UpstreamCommit: hashes[0]},
-		{CommitMetadata: sources.CommitMetadata{Hash: "a2"}, UpstreamCommit: hashes[0]},
-		{CommitMetadata: sources.CommitMetadata{Hash: "a3"}, UpstreamCommit: hashes[1]},
-	}
-
-	count := sources.CountCommitsSinceVersionChange(repo, "package.spec", changes)
-	assert.Equal(t, 1, count)
-}
-
-func TestCountCommitsSinceVersionChange_MultipleVersionJumps(t *testing.T) {
-	// Upstream goes 1.0 → 2.0 → 3.0. Synth commits: 1 for 1.0, 1 for 2.0, 2 for 3.0.
-	// Only the 2 after 3.0 should count.
-	repo, hashes := createRepoWithVersionCommits(t, []string{"1.0", "2.0", "3.0"})
-
-	changes := []sources.FingerprintChange{
-		{CommitMetadata: sources.CommitMetadata{Hash: "a1"}, UpstreamCommit: hashes[0]},
-		{CommitMetadata: sources.CommitMetadata{Hash: "a2"}, UpstreamCommit: hashes[1]},
-		{CommitMetadata: sources.CommitMetadata{Hash: "a3"}, UpstreamCommit: hashes[2]},
-		{CommitMetadata: sources.CommitMetadata{Hash: "a4"}, UpstreamCommit: hashes[2]},
-	}
-
-	count := sources.CountCommitsSinceVersionChange(repo, "package.spec", changes)
-	assert.Equal(t, 2, count)
-}
-
-func TestCountCommitsSinceVersionChange_SameVersionMultipleUpstreams(t *testing.T) {
-	// Upstream has two commits but Version stays the same → all count (no version change).
-	repo, hashes := createRepoWithVersionCommits(t, []string{"1.0", "1.0"})
-
-	changes := []sources.FingerprintChange{
-		{CommitMetadata: sources.CommitMetadata{Hash: "a1"}, UpstreamCommit: hashes[0]},
-		{CommitMetadata: sources.CommitMetadata{Hash: "a2"}, UpstreamCommit: hashes[1]},
-		{CommitMetadata: sources.CommitMetadata{Hash: "a3"}, UpstreamCommit: hashes[1]},
-	}
-
-	count := sources.CountCommitsSinceVersionChange(repo, "package.spec", changes)
-	assert.Equal(t, 3, count)
-}
-
-func TestCountCommitsSinceVersionChange_SingleChange(t *testing.T) {
-	repo, hashes := createRepoWithVersionCommits(t, []string{"1.0"})
-
-	changes := []sources.FingerprintChange{
-		{CommitMetadata: sources.CommitMetadata{Hash: "a1"}, UpstreamCommit: hashes[0]},
-	}
-
-	count := sources.CountCommitsSinceVersionChange(repo, "package.spec", changes)
-	assert.Equal(t, 1, count)
-}
-
-func TestCountCommitsSinceVersionChange_EmptyChanges(t *testing.T) {
-	repo, _ := createRepoWithVersionCommits(t, []string{"1.0"})
-
-	count := sources.CountCommitsSinceVersionChange(repo, "package.spec", nil)
-	assert.Equal(t, 0, count)
-}
-
-func TestCountCommitsSinceVersionChange_SpecNotFound(t *testing.T) {
-	// When the spec file doesn't exist at a commit, fall back to total count.
-	repo, hashes := createRepoWithVersionCommits(t, []string{"1.0"})
-
-	changes := []sources.FingerprintChange{
-		{CommitMetadata: sources.CommitMetadata{Hash: "a1"}, UpstreamCommit: hashes[0]},
-		{CommitMetadata: sources.CommitMetadata{Hash: "a2"}, UpstreamCommit: hashes[0]},
-	}
-
-	// Use a wrong spec filename to trigger fallback.
-	count := sources.CountCommitsSinceVersionChange(repo, "nonexistent.spec", changes)
-	assert.Equal(t, 2, count)
 }

--- a/internal/app/azldev/core/sources/release_test.go
+++ b/internal/app/azldev/core/sources/release_test.go
@@ -4,8 +4,15 @@
 package sources_test
 
 import (
+	"fmt"
+	"strings"
 	"testing"
+	"time"
 
+	memfs "github.com/go-git/go-billy/v5/memfs"
+	gogit "github.com/go-git/go-git/v5"
+	"github.com/go-git/go-git/v5/plumbing/object"
+	"github.com/go-git/go-git/v5/storage/memory"
 	"github.com/microsoft/azure-linux-dev-tools/internal/app/azldev/core/sources"
 	"github.com/microsoft/azure-linux-dev-tools/internal/global/testctx"
 	"github.com/microsoft/azure-linux-dev-tools/internal/rpm/spec"
@@ -132,4 +139,165 @@ func TestGetReleaseTagValue_FileNotFound(t *testing.T) {
 	ctx := testctx.NewCtx()
 	_, err := sources.GetReleaseTagValue(ctx.FS(), "/nonexistent.spec")
 	require.Error(t, err)
+}
+
+func TestGetVersionTagFromReader(t *testing.T) {
+	for _, testCase := range []struct {
+		name, specContent, expected string
+		wantErr                     bool
+	}{
+		{"simple version", "Name: pkg\nVersion: 1.0.0\nRelease: 1\n", "1.0.0", false},
+		{"version with macro", "Name: pkg\nVersion: %{base_version}\nRelease: 1\n", "%{base_version}", false},
+		{"no version tag", "Name: pkg\nRelease: 1\nSummary: Test\n", "", true},
+	} {
+		t.Run(testCase.name, func(t *testing.T) {
+			result, err := sources.GetVersionTagFromReader(strings.NewReader(testCase.specContent))
+			if testCase.wantErr {
+				require.ErrorIs(t, err, spec.ErrNoSuchTag)
+			} else {
+				require.NoError(t, err)
+				assert.Equal(t, testCase.expected, result)
+			}
+		})
+	}
+}
+
+// makeTestSpecContent returns a minimal spec file string with the given version.
+// The index parameter ensures unique file content across commits so go-git
+// doesn't reject them as empty commits.
+func makeTestSpecContent(version string, index int) string {
+	return fmt.Sprintf("Name: package\nVersion: %s\nRelease: 1%%{?dist}\nSummary: Test %d\n", version, index)
+}
+
+// createRepoWithVersionCommits creates an in-memory git repo with commits that have
+// spec files at specified versions. Returns the repo and the commit hashes in order.
+func createRepoWithVersionCommits(t *testing.T, versions []string) (*gogit.Repository, []string) {
+	t.Helper()
+
+	memFS := memfs.New()
+	storer := memory.NewStorage()
+
+	repo, err := gogit.Init(storer, memFS)
+	require.NoError(t, err)
+
+	worktree, err := repo.Worktree()
+	require.NoError(t, err)
+
+	hashes := make([]string, 0, len(versions))
+
+	for versionIdx, version := range versions {
+		file, err := memFS.Create("package.spec")
+		require.NoError(t, err)
+
+		_, err = file.Write([]byte(makeTestSpecContent(version, versionIdx)))
+		require.NoError(t, err)
+		require.NoError(t, file.Close())
+
+		_, err = worktree.Add("package.spec")
+		require.NoError(t, err)
+
+		hash, err := worktree.Commit("upstream: v"+version, &gogit.CommitOptions{
+			Author: &object.Signature{
+				Name:  "Upstream",
+				Email: "upstream@fedora.org",
+				When:  time.Date(2024, 1, 1+versionIdx, 0, 0, 0, 0, time.UTC),
+			},
+		})
+		require.NoError(t, err)
+
+		hashes = append(hashes, hash.String())
+	}
+
+	return repo, hashes
+}
+
+func TestCountCommitsSinceVersionChange_NoVersionChange(t *testing.T) {
+	// All synthetic commits reference the same upstream commit → all count.
+	repo, hashes := createRepoWithVersionCommits(t, []string{"1.0"})
+
+	changes := []sources.FingerprintChange{
+		{CommitMetadata: sources.CommitMetadata{Hash: "a1"}, UpstreamCommit: hashes[0]},
+		{CommitMetadata: sources.CommitMetadata{Hash: "a2"}, UpstreamCommit: hashes[0]},
+		{CommitMetadata: sources.CommitMetadata{Hash: "a3"}, UpstreamCommit: hashes[0]},
+	}
+
+	count := sources.CountCommitsSinceVersionChange(repo, "package.spec", changes)
+	assert.Equal(t, 3, count)
+}
+
+func TestCountCommitsSinceVersionChange_VersionChangeMidStream(t *testing.T) {
+	// Upstream goes 1.0 → 2.0. Two synthetic commits for 1.0, one for 2.0.
+	// Only the one after 2.0 should count.
+	repo, hashes := createRepoWithVersionCommits(t, []string{"1.0", "2.0"})
+
+	changes := []sources.FingerprintChange{
+		{CommitMetadata: sources.CommitMetadata{Hash: "a1"}, UpstreamCommit: hashes[0]},
+		{CommitMetadata: sources.CommitMetadata{Hash: "a2"}, UpstreamCommit: hashes[0]},
+		{CommitMetadata: sources.CommitMetadata{Hash: "a3"}, UpstreamCommit: hashes[1]},
+	}
+
+	count := sources.CountCommitsSinceVersionChange(repo, "package.spec", changes)
+	assert.Equal(t, 1, count)
+}
+
+func TestCountCommitsSinceVersionChange_MultipleVersionJumps(t *testing.T) {
+	// Upstream goes 1.0 → 2.0 → 3.0. Synth commits: 1 for 1.0, 1 for 2.0, 2 for 3.0.
+	// Only the 2 after 3.0 should count.
+	repo, hashes := createRepoWithVersionCommits(t, []string{"1.0", "2.0", "3.0"})
+
+	changes := []sources.FingerprintChange{
+		{CommitMetadata: sources.CommitMetadata{Hash: "a1"}, UpstreamCommit: hashes[0]},
+		{CommitMetadata: sources.CommitMetadata{Hash: "a2"}, UpstreamCommit: hashes[1]},
+		{CommitMetadata: sources.CommitMetadata{Hash: "a3"}, UpstreamCommit: hashes[2]},
+		{CommitMetadata: sources.CommitMetadata{Hash: "a4"}, UpstreamCommit: hashes[2]},
+	}
+
+	count := sources.CountCommitsSinceVersionChange(repo, "package.spec", changes)
+	assert.Equal(t, 2, count)
+}
+
+func TestCountCommitsSinceVersionChange_SameVersionMultipleUpstreams(t *testing.T) {
+	// Upstream has two commits but Version stays the same → all count (no version change).
+	repo, hashes := createRepoWithVersionCommits(t, []string{"1.0", "1.0"})
+
+	changes := []sources.FingerprintChange{
+		{CommitMetadata: sources.CommitMetadata{Hash: "a1"}, UpstreamCommit: hashes[0]},
+		{CommitMetadata: sources.CommitMetadata{Hash: "a2"}, UpstreamCommit: hashes[1]},
+		{CommitMetadata: sources.CommitMetadata{Hash: "a3"}, UpstreamCommit: hashes[1]},
+	}
+
+	count := sources.CountCommitsSinceVersionChange(repo, "package.spec", changes)
+	assert.Equal(t, 3, count)
+}
+
+func TestCountCommitsSinceVersionChange_SingleChange(t *testing.T) {
+	repo, hashes := createRepoWithVersionCommits(t, []string{"1.0"})
+
+	changes := []sources.FingerprintChange{
+		{CommitMetadata: sources.CommitMetadata{Hash: "a1"}, UpstreamCommit: hashes[0]},
+	}
+
+	count := sources.CountCommitsSinceVersionChange(repo, "package.spec", changes)
+	assert.Equal(t, 1, count)
+}
+
+func TestCountCommitsSinceVersionChange_EmptyChanges(t *testing.T) {
+	repo, _ := createRepoWithVersionCommits(t, []string{"1.0"})
+
+	count := sources.CountCommitsSinceVersionChange(repo, "package.spec", nil)
+	assert.Equal(t, 0, count)
+}
+
+func TestCountCommitsSinceVersionChange_SpecNotFound(t *testing.T) {
+	// When the spec file doesn't exist at a commit, fall back to total count.
+	repo, hashes := createRepoWithVersionCommits(t, []string{"1.0"})
+
+	changes := []sources.FingerprintChange{
+		{CommitMetadata: sources.CommitMetadata{Hash: "a1"}, UpstreamCommit: hashes[0]},
+		{CommitMetadata: sources.CommitMetadata{Hash: "a2"}, UpstreamCommit: hashes[0]},
+	}
+
+	// Use a wrong spec filename to trigger fallback.
+	count := sources.CountCommitsSinceVersionChange(repo, "nonexistent.spec", changes)
+	assert.Equal(t, 2, count)
 }

--- a/internal/app/azldev/core/sources/release_test.go
+++ b/internal/app/azldev/core/sources/release_test.go
@@ -215,6 +215,7 @@ func TestCountCommitsSinceVersionChange(t *testing.T) {
 	const (
 		nonExistentHash = -1 // valid hex format but not in repo
 		malformedHash   = -2 // invalid hash format
+		emptyHash       = -3 // empty string (local component, no upstream)
 	)
 
 	for _, testCase := range []struct {
@@ -224,17 +225,26 @@ func TestCountCommitsSinceVersionChange(t *testing.T) {
 		upstreamCommits []int
 		specFile        string // override spec filename (default: "package.spec")
 		expected        int
+		expectError     bool
 	}{
-		{"no version change", []string{"1.0"}, []int{0, 0, 0}, "", 3},
-		{"version change mid-stream", []string{"1.0", "2.0"}, []int{0, 0, 1}, "", 1},
-		{"multiple version jumps", []string{"1.0", "2.0", "3.0"}, []int{0, 1, 2, 2}, "", 2},
-		{"same version multiple upstreams", []string{"1.0", "1.0"}, []int{0, 1, 1}, "", 3},
-		{"single change", []string{"1.0"}, []int{0}, "", 1},
-		{"empty changes", []string{"1.0"}, nil, "", 0},
-		{"spec not found", []string{"1.0"}, []int{0, 0}, "nonexistent.spec", 0},
-		{"non-existent commit hash", []string{"1.0"}, []int{nonExistentHash, nonExistentHash, nonExistentHash}, "", 0},
-		{"invalid hash string", []string{"1.0"}, []int{malformedHash, malformedHash}, "", 0},
-		{"partially resolvable", []string{"1.0"}, []int{nonExistentHash, 0, 0}, "", 2},
+		{"no version change", []string{"1.0"}, []int{0, 0, 0}, "", 3, false},
+		{"version change mid-stream", []string{"1.0", "2.0"}, []int{0, 0, 1}, "", 1, false},
+		{"multiple version jumps", []string{"1.0", "2.0", "3.0"}, []int{0, 1, 2, 2}, "", 2, false},
+		{"same version multiple upstreams", []string{"1.0", "1.0"}, []int{0, 1, 1}, "", 3, false},
+		{"single change", []string{"1.0"}, []int{0}, "", 1, false},
+		{"empty changes", []string{"1.0"}, nil, "", 0, false},
+		{"spec not found", []string{"1.0"}, []int{0, 0}, "nonexistent.spec", 0, false},
+		{"non-existent commit hash", []string{"1.0"}, []int{nonExistentHash, nonExistentHash, nonExistentHash}, "", 0, false},
+		{"invalid hash string", []string{"1.0"}, []int{malformedHash, malformedHash}, "", 0, false},
+		{"partially resolvable", []string{"1.0"}, []int{nonExistentHash, 0, 0}, "", 2, false},
+		{"empty upstream (local component)", []string{"1.0"}, []int{emptyHash, emptyHash, emptyHash}, "", 3, false},
+		{"macro version errors", []string{"%{base_version}"}, []int{0, 0, 0}, "", 0, true},
+		{
+			"macro version with multiple upstreams errors",
+			[]string{"%{base_version}", "%{base_version}"},
+			[]int{0, 0, 1},
+			"", 0, true,
+		},
 	} {
 		t.Run(testCase.name, func(t *testing.T) {
 			repo, hashes := createRepoWithVersionCommits(t, testCase.versions)
@@ -256,6 +266,8 @@ func TestCountCommitsSinceVersionChange(t *testing.T) {
 					upstream = "deadbeefdeadbeefdeadbeefdeadbeefdeadbeef"
 				case idx == malformedHash:
 					upstream = "not-a-valid-hash"
+				case idx == emptyHash:
+					upstream = ""
 				}
 
 				changes = append(changes, sources.FingerprintChange{
@@ -264,8 +276,14 @@ func TestCountCommitsSinceVersionChange(t *testing.T) {
 				})
 			}
 
-			count := sources.CountCommitsSinceVersionChange(repo, specFile, changes)
-			assert.Equal(t, testCase.expected, count)
+			count, err := sources.CountCommitsSinceVersionChange(repo, specFile, changes)
+			if testCase.expectError {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), "unexpanded macro")
+			} else {
+				require.NoError(t, err)
+				assert.Equal(t, testCase.expected, count)
+			}
 		})
 	}
 }

--- a/internal/app/azldev/core/sources/sourceprep.go
+++ b/internal/app/azldev/core/sources/sourceprep.go
@@ -366,6 +366,10 @@ func openOrInitSourcesRepo(sourcesDirPath, componentName string) (*gogit.Reposit
 		return repo, nil
 	}
 
+	if !errors.Is(err, gogit.ErrRepositoryNotExists) {
+		return nil, fmt.Errorf("failed to open git repository at %#q:\n%w", sourcesDirPath, err)
+	}
+
 	slog.Info("No .git directory in sources; initializing repository",
 		"component", componentName)
 

--- a/internal/app/azldev/core/sources/sourceprep.go
+++ b/internal/app/azldev/core/sources/sourceprep.go
@@ -358,6 +358,20 @@ func initSourcesRepo(sourcesDirPath string) (*gogit.Repository, error) {
 	return repo, nil
 }
 
+// openOrInitSourcesRepo opens an existing git repository at sourcesDirPath,
+// or initializes a new one if no .git directory exists.
+func openOrInitSourcesRepo(sourcesDirPath, componentName string) (*gogit.Repository, error) {
+	repo, err := gogit.PlainOpen(sourcesDirPath)
+	if err == nil {
+		return repo, nil
+	}
+
+	slog.Info("No .git directory in sources; initializing repository",
+		"component", componentName)
+
+	return initSourcesRepo(sourcesDirPath)
+}
+
 // trySyntheticHistory attempts to create synthetic git commits on top of the
 // component's sources directory. Synthetic commits are derived from lock file
 // fingerprint changes in the project repository and interleaved into the
@@ -388,32 +402,18 @@ func (p *sourcePreparerImpl) trySyntheticHistory(
 		return nil
 	}
 
-	// Adjust the Release tag before staging changes. See [tryBumpStaticRelease]
-	// for the handling of %autorelease, static integers, and non-standard values.
-	if err := p.tryBumpStaticRelease(component, sourcesDirPath, len(changes)); err != nil {
+	// Open or initialize the dist-git repository once. It is used both for
+	// version-aware release bump computation and for recording synthetic history.
+	sourcesRepo, err := openOrInitSourcesRepo(sourcesDirPath, componentName)
+	if err != nil {
+		return err
+	}
+
+	// Adjust the Release tag before staging changes. The version-aware bump
+	// count is computed inside [tryBumpStaticRelease], only after confirming
+	// the spec uses a static release (not %autorelease or manual).
+	if err := p.tryBumpStaticRelease(component, sourcesDirPath, sourcesRepo, changes); err != nil {
 		return fmt.Errorf("failed to apply release bump:\n%w", err)
-	}
-
-	gitDirPath := filepath.Join(sourcesDirPath, ".git")
-
-	gitDirExists, err := fileutils.Exists(p.fs, gitDirPath)
-	if err != nil {
-		return fmt.Errorf("failed to check for .git directory at %#q:\n%w", gitDirPath, err)
-	}
-
-	if !gitDirExists {
-		slog.Info("No .git directory in sources; initializing repository",
-			"component", componentName)
-
-		if _, err := initSourcesRepo(sourcesDirPath); err != nil {
-			return fmt.Errorf("failed to initialize sources repository:\n%w", err)
-		}
-	}
-
-	// Open the git repository where synthetic commits will be recorded.
-	sourcesRepo, err := gogit.PlainOpen(sourcesDirPath)
-	if err != nil {
-		return fmt.Errorf("failed to open sources repository at %#q:\n%w", sourcesDirPath, err)
 	}
 
 	// Strip bogus submodule entries from the index before staging. Some upstream


### PR DESCRIPTION
Static release bumping for non-autorelease specs now resets the release counter when the upstream Version changes, matching rpmautospec behavior.

Previously, tryBumpStaticRelease counted all synthetic commits regardless of version changes, producing inflated release numbers. Now it walks fingerprint changes newest-to-oldest, reads the Version tag from the dist-git spec at each upstream commit, and only counts commits since the last version change.