### PR TITLE
fix(component): restore git worktree support in synthetic history generation

### DIFF
--- a/internal/app/azldev/core/sources/synthistory.go
+++ b/internal/app/azldev/core/sources/synthistory.go
@@ -541,7 +541,10 @@ func openProjectRepo(
 
 	repo, err := gogit.PlainOpenWithOptions(
 		filepath.Dir(configFilePath),
-		&gogit.PlainOpenOptions{DetectDotGit: true},
+		&gogit.PlainOpenOptions{
+			DetectDotGit:          true,
+			EnableDotGitCommonDir: true,
+		},
 	)
 	if err != nil {
 		return nil, "", fmt.Errorf("failed to find project repository for config file %#q:\n%w",


### PR DESCRIPTION
PR #125 added `EnableDotGitCommonDir` to make go-git resolve the shared `.git` directory when the config file lives inside a git worktree. PR #121 later refactored `openProjectRepo` and dropped that option, regressing the fix.

This re-enables `EnableDotGitCommonDir` so affected azldev commands work again when run from a git worktree.