### PR TITLE
workaround: Add symlinks to renders to fix URL decode issue

### DIFF
--- a/docs/user/reference/cli/azldev_component_render.md
+++ b/docs/user/reference/cli/azldev_component_render.md
@@ -20,10 +20,13 @@ Unlike prepare-sources, render skips downloading source tarballs from the
 lookaside cache — only spec files, patches, scripts, and other git-tracked
 sidecar files are included. Multiple components can be rendered at once.
 
-When rendering all components (-a), the --clean-stale flag removes rendered
-directories that no longer correspond to any current component. Stale cleanup
-is skipped when rendering individual components to avoid accidentally removing
-directories for components not included in the filter.
+When rendering all components (-a), the --clean-stale flag removes the
+letter-prefix subdirectories of the output directory before rendering.
+Only single-character subdirectories (e.g., 'a/', 'c/', 'l/' — the layout
+azldev itself produces) are removed; any other files or directories at
+the output root are preserved. An interrupted run with --clean-stale
+leaves the output directory partially populated; recover with
+'git checkout'. This flag is only valid with -a.
 
 ```
 azldev component render [flags]
@@ -49,7 +52,7 @@ azldev component render [flags]
 
 ```
   -a, --all-components                Include all components
-      --clean-stale                   remove stale rendered directories not matching any current component (only with -a)
+      --clean-stale                   remove letter-prefix subdirectories of the output directory before rendering (only with -a)
   -p, --component stringArray         Component name pattern
   -g, --component-group stringArray   Component group name
       --fail-on-error                 exit with error if any component fails to render (useful for CI)

--- a/docs/user/reference/cli/azldev_component_render.md
+++ b/docs/user/reference/cli/azldev_component_render.md
@@ -20,13 +20,12 @@ Unlike prepare-sources, render skips downloading source tarballs from the
 lookaside cache — only spec files, patches, scripts, and other git-tracked
 sidecar files are included. Multiple components can be rendered at once.
 
-When rendering all components (-a), the --clean-stale flag removes the
-letter-prefix subdirectories of the output directory before rendering.
-Only single-character subdirectories (e.g., 'a/', 'c/', 'l/' — the layout
-azldev itself produces) are removed; any other files or directories at
-the output root are preserved. An interrupted run with --clean-stale
-leaves the output directory partially populated; recover with
-'git checkout'. This flag is only valid with -a.
+When rendering all components (-a), the --clean-stale flag removes all
+contents of the output directory before rendering, leaving the directory
+itself in place. When using a custom output directory (--output-dir),
+--force is required alongside --clean-stale as a safety measure. An
+interrupted run with --clean-stale leaves the output directory partially
+populated; recover with 'git checkout'. This flag is only valid with -a.
 
 ```
 azldev component render [flags]
@@ -52,7 +51,7 @@ azldev component render [flags]
 
 ```
   -a, --all-components                Include all components
-      --clean-stale                   remove letter-prefix subdirectories of the output directory before rendering (only with -a)
+      --clean-stale                   remove contents of the output directory before rendering (only with -a; requires -f with -o)
   -p, --component stringArray         Component name pattern
   -g, --component-group stringArray   Component group name
       --fail-on-error                 exit with error if any component fails to render (useful for CI)

--- a/internal/app/azldev/cmds/component/render.go
+++ b/internal/app/azldev/cmds/component/render.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"os"
 	"path/filepath"
 	"slices"
 	"strings"
@@ -19,6 +20,7 @@ import (
 	"github.com/microsoft/azure-linux-dev-tools/internal/providers/sourceproviders"
 	"github.com/microsoft/azure-linux-dev-tools/internal/utils/fileperms"
 	"github.com/microsoft/azure-linux-dev-tools/internal/utils/fileutils"
+	"github.com/spf13/afero"
 	"github.com/spf13/cobra"
 )
 
@@ -59,10 +61,13 @@ Unlike prepare-sources, render skips downloading source tarballs from the
 lookaside cache — only spec files, patches, scripts, and other git-tracked
 sidecar files are included. Multiple components can be rendered at once.
 
-When rendering all components (-a), the --clean-stale flag removes rendered
-directories that no longer correspond to any current component. Stale cleanup
-is skipped when rendering individual components to avoid accidentally removing
-directories for components not included in the filter.`,
+When rendering all components (-a), the --clean-stale flag removes the
+letter-prefix subdirectories of the output directory before rendering.
+Only single-character subdirectories (e.g., 'a/', 'c/', 'l/' — the layout
+azldev itself produces) are removed; any other files or directories at
+the output root are preserved. An interrupted run with --clean-stale
+leaves the output directory partially populated; recover with
+'git checkout'. This flag is only valid with -a.`,
 		Example: `  # Render all components (output dir from config)
   azldev component render -a
 
@@ -99,7 +104,7 @@ directories for components not included in the filter.`,
 		"allow overwriting existing rendered component directories")
 
 	cmd.Flags().BoolVar(&options.CleanStale, "clean-stale", false,
-		"remove stale rendered directories not matching any current component (only with -a)")
+		"remove letter-prefix subdirectories of the output directory before rendering (only with -a)")
 
 	return cmd
 }
@@ -178,21 +183,39 @@ func RenderComponents(env *azldev.Env, options *RenderOptions) ([]*RenderResult,
 	results := make([]*RenderResult, len(componentList))
 
 	// ── Phase 1: Parallel source preparation ──
-	prepared := parallelPrepare(env, componentList, stagingDir, options.OutputDir, options.Force, results)
+	prepared := parallelPrepare(env, componentList, stagingDir, options.OutputDir, results)
 
 	// ── Phase 2: Batch mock processing ──
 	mockResultMap := batchMockProcess(env, mockProcessor, stagingDir, prepared)
+
+	// Wipe stale letter-prefix subdirectories of the output dir between mock
+	// processing (slow: clone + chroot) and the per-component copy in phase 3.
+	// This keeps Ctrl-C-during-mock from leaving the user with no output and
+	// nothing fresh either; if they cancel before this point the existing
+	// output is untouched. Once we reach phase 3 we're moments away from
+	// writing replacement content anyway.
+	//
+	// We only remove single-character subdirectories — the layout azldev itself
+	// produces (see RenderedSpecDir). Files and other directories at the output
+	// root are preserved, which keeps a typo'd '-o /tmp' from nuking unrelated
+	// content. This also drops sibling alias symlinks created to bridge the
+	// percent-encoded path mismatch with our build pipeline; see writeAliasSymlink.
+	if options.CleanStale {
+		if wipeErr := wipeLetterPrefixSubdirs(env.FS(), options.OutputDir); wipeErr != nil {
+			return nil, fmt.Errorf("clearing output directory %#q:\n%w", options.OutputDir, wipeErr)
+		}
+	}
 
 	// ── Phase 3: Parallel finishing ──
 	parallelFinish(env, prepared, mockResultMap, results, stagingDir,
 		options.Force)
 
-	// Clean up stale rendered directories when explicitly requested.
-	if options.CleanStale && options.ComponentFilter.IncludeAllComponents {
-		if cleanupErr := cleanupStaleRenders(env.FS(), comps, options.OutputDir); cleanupErr != nil {
-			return results, fmt.Errorf("cleaning up stale rendered output:\n%w", cleanupErr)
-		}
-	}
+	// Write RENDER_FAILED markers for any component that errored in phase 1
+	// (source preparation) or phase 3 (mock result application + copy).
+	// Centralizing this here makes it idempotent with the --clean-stale wipe
+	// (which sits between phases 2 and 3) and keeps the per-phase code free
+	// of bookkeeping.
+	writeFailureMarkers(env.FS(), results, options.Force)
 
 	// Sort results alphabetically for consistent output.
 	sortRenderResults(results)
@@ -282,7 +305,6 @@ func parallelPrepare(
 	comps []components.Component,
 	stagingDir string,
 	outputDir string,
-	allowOverwrite bool,
 	results []*RenderResult,
 ) []*preparedComponent {
 	progressEvent := env.StartEvent("Preparing component sources", "count", len(comps))
@@ -302,7 +324,7 @@ func parallelPrepare(
 		go func(idx int, comp components.Component) {
 			defer waitGroup.Done()
 
-			resultsChan <- prepWithSemaphore(workerEnv, semaphore, idx, comp, stagingDir, outputDir, allowOverwrite)
+			resultsChan <- prepWithSemaphore(workerEnv, semaphore, idx, comp, stagingDir, outputDir)
 		}(compIdx, comp)
 	}
 
@@ -337,7 +359,6 @@ func prepWithSemaphore(
 	comp components.Component,
 	stagingDir string,
 	outputDir string,
-	allowOverwrite bool,
 ) prepResult {
 	componentName := comp.GetName()
 
@@ -369,16 +390,6 @@ func prepWithSemaphore(
 	if err != nil {
 		slog.Error("Failed to prepare component sources",
 			"component", componentName, "error", err)
-
-		// Write error marker so the failure is visible in git diff.
-		if allowOverwrite {
-			if removeErr := env.FS().RemoveAll(compOutputDir); removeErr != nil {
-				slog.Debug("Failed to clean output before writing error marker",
-					"path", compOutputDir, "error", removeErr)
-			}
-		}
-
-		writeRenderErrorMarker(env.FS(), compOutputDir)
 
 		return prepResult{index: index, result: &RenderResult{
 			Component: componentName,
@@ -603,17 +614,6 @@ func finishOneComponent(
 
 		result.Status = renderStatusError
 		result.Error = err.Error()
-
-		// Clean any stale good output before writing the failure marker.
-		// Only allowed for managed (project-local) output directories.
-		if allowOverwrite {
-			if removeErr := env.FS().RemoveAll(compOutputDir); removeErr != nil {
-				slog.Debug("Failed to clean output before writing error marker",
-					"path", compOutputDir, "error", removeErr)
-			}
-		}
-
-		writeRenderErrorMarker(env.FS(), compOutputDir)
 	}
 
 	return result
@@ -673,10 +673,94 @@ func finishComponentRender(
 		return copyErr
 	}
 
+	// Best-effort: create a sibling symlink at the URL-encoded component name to
+	// bridge a path-encoding mismatch. We percent-encode component names like
+	// 'libxml++' into 'libxml%2B%2B' when building the SCM URL fragment passed to
+	// the build host (koji), but the build system then uses that fragment as a
+	// filesystem path without decoding it. The symlink lets the build host find
+	// the component under either form.
+	//
+	//nolint:godox // tracked by TODO(koji-fragment-decode) tag.
+	// TODO(koji-fragment-decode): remove once the build system decodes fragments.
+	if aliasErr := writeAliasSymlink(env.FS(), prep.compOutputDir, componentName); aliasErr != nil {
+		slog.Warn("Failed to create rendered-spec alias symlink; downstream build steps"+
+			" that consume the percent-encoded path may fail to locate this component",
+			"component", componentName, "error", aliasErr)
+	}
+
 	slog.Info("Rendered component", "component", componentName,
 		"output", prep.compOutputDir)
 
 	return nil
+}
+
+// writeAliasSymlink creates a sibling symlink alongside componentOutputDir at the
+// URL-encoded form of componentName, pointing back at the real directory with a
+// relative target.
+//
+// No-ops when no encoding is needed (plain ASCII names) or when the underlying
+// filesystem doesn't support symlinks (e.g., in-memory test FS).
+//
+// Refuses to overwrite a non-symlink at the alias path — if a real component
+// directory already lives there (the hypothetical 'gtk%2B' next to 'gtk+'
+// case), bail with an error rather than silently destroying that component's
+// rendered output. RPM names don't use '%' in practice, so this is belt-and
+// suspenders.
+func writeAliasSymlink(fileSystem opctx.FS, componentOutputDir, componentName string) error {
+	aliasName := components.RenderedSpecDirAliasName(componentName)
+	if aliasName == "" {
+		return nil
+	}
+
+	linker, ok := fileSystem.(afero.Linker)
+	if !ok {
+		slog.Debug("Filesystem doesn't support symlinks; skipping rendered-spec alias",
+			"component", componentName)
+
+		return nil
+	}
+
+	parentDir := filepath.Dir(componentOutputDir)
+	aliasPath := filepath.Join(parentDir, aliasName)
+
+	// Inspect any existing entry at the alias path. We only ever clobber a
+	// pre-existing symlink (a stale alias from a previous render); a real
+	// directory or file there means a name collision with another component
+	// and must be reported, not silently destroyed.
+	info, lstatErr := lstatIfPossible(fileSystem, aliasPath)
+	switch {
+	case lstatErr == nil && info.Mode()&os.ModeSymlink == 0:
+		return fmt.Errorf(
+			"alias path %#q is already occupied by a non-symlink entry; refusing to overwrite",
+			aliasPath)
+	case lstatErr == nil:
+		// Existing symlink — remove and replace below.
+		if removeErr := fileSystem.Remove(aliasPath); removeErr != nil {
+			return fmt.Errorf("removing existing alias symlink %#q:\n%w", aliasPath, removeErr)
+		}
+	case !errors.Is(lstatErr, os.ErrNotExist):
+		return fmt.Errorf("inspecting alias path %#q:\n%w", aliasPath, lstatErr)
+	}
+
+	// Use a relative target so the rendered tree stays portable.
+	target := filepath.Base(componentOutputDir)
+	if symErr := linker.SymlinkIfPossible(target, aliasPath); symErr != nil {
+		return fmt.Errorf("creating alias symlink %#q -> %#q:\n%w", aliasPath, target, symErr)
+	}
+
+	return nil
+}
+
+// lstatIfPossible returns the link info at path without following symlinks, if
+// the underlying filesystem supports it. Falls back to a regular Stat otherwise.
+func lstatIfPossible(fileSystem opctx.FS, path string) (os.FileInfo, error) {
+	if lstater, ok := fileSystem.(afero.Lstater); ok {
+		info, _, err := lstater.LstatIfPossible(path)
+
+		return info, err //nolint:wrapcheck // pass-through to the caller.
+	}
+
+	return fileSystem.Stat(path) //nolint:wrapcheck // pass-through to the caller.
 }
 
 // copyRenderedOutput copies the rendered files from tempDir to the component's output directory.
@@ -792,65 +876,6 @@ func findSpecFile(fs opctx.FS, dir, componentName string) (string, error) {
 	return specPath, nil
 }
 
-// cleanupStaleRenders removes rendered output directories for components that
-// no longer exist in the current configuration. Only called during full renders (-a).
-// The output directory uses letter-prefix subdirectories (e.g., SPECS/c/curl),
-// so this walks two levels: letter directories, then component directories within each.
-func cleanupStaleRenders(fs opctx.FS, currentComponents *components.ComponentSet, outputDir string) error {
-	exists, existsErr := fileutils.Exists(fs, outputDir)
-	if existsErr != nil {
-		return fmt.Errorf("checking output directory %#q:\n%w", outputDir, existsErr)
-	}
-
-	if !exists {
-		return nil
-	}
-
-	letterEntries, err := fileutils.ReadDir(fs, outputDir)
-	if err != nil {
-		return fmt.Errorf("reading output directory %#q:\n%w", outputDir, err)
-	}
-
-	// Build a set of current component names.
-	currentNames := make(map[string]bool, currentComponents.Len())
-	for _, comp := range currentComponents.Components() {
-		currentNames[comp.GetName()] = true
-	}
-
-	for _, letterEntry := range letterEntries {
-		if !letterEntry.IsDir() {
-			continue
-		}
-
-		letterDir := filepath.Join(outputDir, letterEntry.Name())
-
-		compEntries, readErr := fileutils.ReadDir(fs, letterDir)
-		if readErr != nil {
-			return fmt.Errorf("reading letter directory %#q:\n%w", letterDir, readErr)
-		}
-
-		for _, compEntry := range compEntries {
-			if !compEntry.IsDir() {
-				continue
-			}
-
-			if currentNames[compEntry.Name()] {
-				continue
-			}
-
-			stalePath := filepath.Join(letterDir, compEntry.Name())
-
-			slog.Info("Removing stale rendered output", "directory", stalePath)
-
-			if removeErr := fs.RemoveAll(stalePath); removeErr != nil {
-				return fmt.Errorf("removing stale directory %#q:\n%w", stalePath, removeErr)
-			}
-		}
-	}
-
-	return nil
-}
-
 // renderErrorMarkerFile is the name of the marker file written to a component's
 // output directory when rendering fails. This makes the failure visible in git diff
 // when the issue is later fixed (the marker file disappears, replaced by real output).
@@ -901,8 +926,8 @@ func resolveAndValidateOutputDir(env *azldev.Env, options *RenderOptions) error 
 	return validateOutputDir(options.OutputDir)
 }
 
-// validateOutputDir rejects output directory values that could cause
-// cleanupStaleRenders to delete unrelated directories.
+// validateOutputDir rejects output directory values that could cause the
+// --clean-stale wipe to delete unrelated directories.
 func validateOutputDir(outputDir string) error {
 	cleaned := filepath.Clean(outputDir)
 	if cleaned == "." || cleaned == string(filepath.Separator) ||
@@ -912,6 +937,64 @@ func validateOutputDir(outputDir string) error {
 	}
 
 	return nil
+}
+
+// wipeLetterPrefixSubdirs removes every direct child of outputDir whose name
+// is a single character — matching the canonical layout produced by
+// RenderedSpecDir (e.g., 'a/', 'c/', 'l/'). Anything else (top-level files,
+// multi-character directories) is left alone. Missing outputDir is a no-op.
+func wipeLetterPrefixSubdirs(fileSystem opctx.FS, outputDir string) error {
+	exists, existsErr := fileutils.DirExists(fileSystem, outputDir)
+	if existsErr != nil {
+		return fmt.Errorf("checking output directory %#q:\n%w", outputDir, existsErr)
+	}
+
+	if !exists {
+		return nil
+	}
+
+	entries, readErr := fileutils.ReadDir(fileSystem, outputDir)
+	if readErr != nil {
+		return fmt.Errorf("reading output directory %#q:\n%w", outputDir, readErr)
+	}
+
+	for _, entry := range entries {
+		if !entry.IsDir() || len(entry.Name()) != 1 {
+			continue
+		}
+
+		subPath := filepath.Join(outputDir, entry.Name())
+		if removeErr := fileSystem.RemoveAll(subPath); removeErr != nil {
+			return fmt.Errorf("removing %#q:\n%w", subPath, removeErr)
+		}
+	}
+
+	return nil
+}
+
+// writeFailureMarkers walks the final results slice and writes a RENDER_FAILED
+// marker into each errored component's output directory. When allowOverwrite
+// is set, any pre-existing content at the path is removed first so the marker
+// isn't surrounded by stale render output.
+//
+// Cancelled components are intentionally skipped — a Ctrl-C is not a render
+// failure, just an incomplete run, and silently planting markers under those
+// circumstances would lie in git diff.
+func writeFailureMarkers(fileSystem opctx.FS, results []*RenderResult, allowOverwrite bool) {
+	for _, result := range results {
+		if result == nil || result.Status != renderStatusError {
+			continue
+		}
+
+		if allowOverwrite {
+			if removeErr := fileSystem.RemoveAll(result.OutputDir); removeErr != nil {
+				slog.Debug("Failed to clean output before writing error marker",
+					"path", result.OutputDir, "error", removeErr)
+			}
+		}
+
+		writeRenderErrorMarker(fileSystem, result.OutputDir)
+	}
 }
 
 // createMockProcessor creates a [sources.MockProcessor] using the project's

--- a/internal/app/azldev/cmds/component/render.go
+++ b/internal/app/azldev/cmds/component/render.go
@@ -61,13 +61,12 @@ Unlike prepare-sources, render skips downloading source tarballs from the
 lookaside cache — only spec files, patches, scripts, and other git-tracked
 sidecar files are included. Multiple components can be rendered at once.
 
-When rendering all components (-a), the --clean-stale flag removes the
-letter-prefix subdirectories of the output directory before rendering.
-Only single-character subdirectories (e.g., 'a/', 'c/', 'l/' — the layout
-azldev itself produces) are removed; any other files or directories at
-the output root are preserved. An interrupted run with --clean-stale
-leaves the output directory partially populated; recover with
-'git checkout'. This flag is only valid with -a.`,
+When rendering all components (-a), the --clean-stale flag removes all
+contents of the output directory before rendering, leaving the directory
+itself in place. When using a custom output directory (--output-dir),
+--force is required alongside --clean-stale as a safety measure. An
+interrupted run with --clean-stale leaves the output directory partially
+populated; recover with 'git checkout'. This flag is only valid with -a.`,
 		Example: `  # Render all components (output dir from config)
   azldev component render -a
 
@@ -104,7 +103,7 @@ leaves the output directory partially populated; recover with
 		"allow overwriting existing rendered component directories")
 
 	cmd.Flags().BoolVar(&options.CleanStale, "clean-stale", false,
-		"remove letter-prefix subdirectories of the output directory before rendering (only with -a)")
+		"remove contents of the output directory before rendering (only with -a; requires -f with -o)")
 
 	return cmd
 }
@@ -134,8 +133,14 @@ func RenderComponents(env *azldev.Env, options *RenderOptions) ([]*RenderResult,
 		return nil, err
 	}
 
-	if options.CleanStale && !options.ComponentFilter.IncludeAllComponents {
-		return nil, errors.New("--clean-stale requires -a (render all components)")
+	if options.CleanStale {
+		if !options.ComponentFilter.IncludeAllComponents {
+			return nil, errors.New("--clean-stale requires -a (render all components)")
+		}
+
+		if options.OutputDirExplicit && !options.Force {
+			return nil, errors.New("--clean-stale with --output-dir requires --force (-f)")
+		}
 	}
 
 	resolver := components.NewResolver(env)
@@ -188,20 +193,13 @@ func RenderComponents(env *azldev.Env, options *RenderOptions) ([]*RenderResult,
 	// ── Phase 2: Batch mock processing ──
 	mockResultMap := batchMockProcess(env, mockProcessor, stagingDir, prepared)
 
-	// Wipe stale letter-prefix subdirectories of the output dir between mock
-	// processing (slow: clone + chroot) and the per-component copy in phase 3.
-	// This keeps Ctrl-C-during-mock from leaving the user with no output and
-	// nothing fresh either; if they cancel before this point the existing
-	// output is untouched. Once we reach phase 3 we're moments away from
-	// writing replacement content anyway.
-	//
-	// We only remove single-character subdirectories — the layout azldev itself
-	// produces (see RenderedSpecDir). Files and other directories at the output
-	// root are preserved, which keeps a typo'd '-o /tmp' from nuking unrelated
-	// content. This also drops sibling alias symlinks created to bridge the
-	// percent-encoded path mismatch with our build pipeline; see writeAliasSymlink.
+	// Wipe contents of the output dir between mock processing (slow: clone +
+	// chroot) and the per-component copy in phase 3. This keeps Ctrl-C-during-mock
+	// from leaving the user with no output and nothing fresh either; if they cancel
+	// before this point the existing output is untouched. Once we reach phase 3
+	// we're moments away from writing replacement content anyway.
 	if options.CleanStale {
-		if wipeErr := wipeLetterPrefixSubdirs(env.FS(), options.OutputDir); wipeErr != nil {
+		if wipeErr := wipeOutputDirContents(env.FS(), options.OutputDir); wipeErr != nil {
 			return nil, fmt.Errorf("clearing output directory %#q:\n%w", options.OutputDir, wipeErr)
 		}
 	}
@@ -939,11 +937,10 @@ func validateOutputDir(outputDir string) error {
 	return nil
 }
 
-// wipeLetterPrefixSubdirs removes every direct child of outputDir whose name
-// is a single character — matching the canonical layout produced by
-// RenderedSpecDir (e.g., 'a/', 'c/', 'l/'). Anything else (top-level files,
-// multi-character directories) is left alone. Missing outputDir is a no-op.
-func wipeLetterPrefixSubdirs(fileSystem opctx.FS, outputDir string) error {
+// wipeOutputDirContents removes every direct child of outputDir (files and
+// directories alike) but leaves the directory itself in place.
+// Missing outputDir is a no-op.
+func wipeOutputDirContents(fileSystem opctx.FS, outputDir string) error {
 	exists, existsErr := fileutils.DirExists(fileSystem, outputDir)
 	if existsErr != nil {
 		return fmt.Errorf("checking output directory %#q:\n%w", outputDir, existsErr)
@@ -959,13 +956,9 @@ func wipeLetterPrefixSubdirs(fileSystem opctx.FS, outputDir string) error {
 	}
 
 	for _, entry := range entries {
-		if !entry.IsDir() || len(entry.Name()) != 1 {
-			continue
-		}
-
-		subPath := filepath.Join(outputDir, entry.Name())
-		if removeErr := fileSystem.RemoveAll(subPath); removeErr != nil {
-			return fmt.Errorf("removing %#q:\n%w", subPath, removeErr)
+		childPath := filepath.Join(outputDir, entry.Name())
+		if removeErr := fileSystem.RemoveAll(childPath); removeErr != nil {
+			return fmt.Errorf("removing %#q:\n%w", childPath, removeErr)
 		}
 	}
 

--- a/internal/app/azldev/cmds/component/render_internal_test.go
+++ b/internal/app/azldev/cmds/component/render_internal_test.go
@@ -4,17 +4,15 @@
 package component
 
 import (
+	"os"
 	"path/filepath"
 	"testing"
 
-	"github.com/microsoft/azure-linux-dev-tools/internal/app/azldev/core/components"
-	"github.com/microsoft/azure-linux-dev-tools/internal/app/azldev/core/components/components_testutils"
 	"github.com/microsoft/azure-linux-dev-tools/internal/utils/fileperms"
 	"github.com/microsoft/azure-linux-dev-tools/internal/utils/fileutils"
 	"github.com/spf13/afero"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"go.uber.org/mock/gomock"
 )
 
 func TestFindSpecFile(t *testing.T) {
@@ -78,74 +76,6 @@ func TestWriteRenderErrorMarker(t *testing.T) {
 		exists, err := fileutils.Exists(fs, "/new/deep/path/"+renderErrorMarkerFile)
 		require.NoError(t, err)
 		assert.True(t, exists)
-	})
-}
-
-func TestCleanupStaleRenders(t *testing.T) {
-	t.Run("removes directories not in component set", func(t *testing.T) {
-		testFS := afero.NewMemMapFs()
-		ctrl := gomock.NewController(t)
-
-		// Create letter-prefixed output directories for curl, wget, and stale-pkg.
-		for _, name := range []string{"curl", "wget", "stale-pkg"} {
-			prefix := string(name[0])
-			dir := filepath.Join("/output", prefix, name)
-			require.NoError(t, fileutils.MkdirAll(testFS, dir))
-			require.NoError(t, fileutils.WriteFile(testFS,
-				filepath.Join(dir, name+".spec"),
-				[]byte("Name: "+name), fileperms.PublicFile))
-		}
-
-		// Only curl and wget are current components.
-		compSet := components.NewComponentSet()
-
-		for _, name := range []string{"curl", "wget"} {
-			mock := components_testutils.NewMockComponent(ctrl)
-			mock.EXPECT().GetName().AnyTimes().Return(name)
-			compSet.Add(mock)
-		}
-
-		err := cleanupStaleRenders(testFS, compSet, "/output")
-		require.NoError(t, err)
-
-		// curl and wget should still exist.
-		for _, name := range []string{"curl", "wget"} {
-			prefix := string(name[0])
-			exists, existsErr := fileutils.Exists(testFS, filepath.Join("/output", prefix, name))
-			require.NoError(t, existsErr)
-			assert.True(t, exists, "%s should still exist", name)
-		}
-
-		// stale-pkg should be removed.
-		exists, err := fileutils.Exists(testFS, "/output/s/stale-pkg")
-		require.NoError(t, err)
-		assert.False(t, exists, "stale-pkg should be removed")
-	})
-
-	t.Run("skips non-directory entries", func(t *testing.T) {
-		testFS := afero.NewMemMapFs()
-
-		require.NoError(t, fileutils.MkdirAll(testFS, "/output"))
-		require.NoError(t, fileutils.WriteFile(testFS, "/output/README.md", []byte("# readme"), fileperms.PublicFile))
-
-		compSet := components.NewComponentSet()
-
-		err := cleanupStaleRenders(testFS, compSet, "/output")
-		require.NoError(t, err)
-
-		// File should still exist (only directories are cleaned up).
-		exists, err := fileutils.Exists(testFS, "/output/README.md")
-		require.NoError(t, err)
-		assert.True(t, exists)
-	})
-
-	t.Run("no-op when output directory does not exist", func(t *testing.T) {
-		fs := afero.NewMemMapFs()
-
-		compSet := components.NewComponentSet()
-
-		err := cleanupStaleRenders(fs, compSet, "/nonexistent")
-		require.NoError(t, err)
 	})
 }
 
@@ -360,4 +290,285 @@ func TestFindUnexpandedMacro(t *testing.T) {
 			assert.Equal(t, tc.want, result)
 		})
 	}
+}
+
+// TestWriteAliasSymlink exercises the real (afero.OsFs) symlink path. MemMapFs
+// doesn't implement afero.Linker, so the production code paths can only be
+// covered against the OS filesystem. Each subtest gets its own t.TempDir().
+func TestWriteAliasSymlink(t *testing.T) {
+	// Helpers that perform the type assertions once (osFS is afero.OsFs which
+	// implements all three interfaces); the linter dislikes inline assertions.
+	osLstat := func(t *testing.T, fs afero.Fs, path string) os.FileInfo {
+		t.Helper()
+
+		lstater, ok := fs.(afero.Lstater)
+		require.True(t, ok, "OsFs must implement afero.Lstater")
+
+		info, _, err := lstater.LstatIfPossible(path)
+		require.NoError(t, err)
+
+		return info
+	}
+	osReadlink := func(t *testing.T, fs afero.Fs, path string) string {
+		t.Helper()
+
+		reader, ok := fs.(afero.LinkReader)
+		require.True(t, ok, "OsFs must implement afero.LinkReader")
+
+		target, err := reader.ReadlinkIfPossible(path)
+		require.NoError(t, err)
+
+		return target
+	}
+	osSymlink := func(t *testing.T, fs afero.Fs, target, linkPath string) {
+		t.Helper()
+
+		linker, ok := fs.(afero.Linker)
+		require.True(t, ok, "OsFs must implement afero.Linker")
+		require.NoError(t, linker.SymlinkIfPossible(target, linkPath))
+	}
+
+	t.Run("creates relative symlink for encoded name", func(t *testing.T) {
+		osFS := afero.NewOsFs()
+		root := t.TempDir()
+		letterDir := filepath.Join(root, "l")
+		realDir := filepath.Join(letterDir, "libxml++")
+		require.NoError(t, fileutils.MkdirAll(osFS, realDir))
+
+		err := writeAliasSymlink(osFS, realDir, "libxml++")
+		require.NoError(t, err)
+
+		aliasPath := filepath.Join(letterDir, "libxml%2B%2B")
+
+		linkInfo := osLstat(t, osFS, aliasPath)
+		assert.NotZero(t, linkInfo.Mode()&os.ModeSymlink, "alias should be a symlink")
+
+		// Relative target — must be just the basename, not absolute.
+		assert.Equal(t, "libxml++", osReadlink(t, osFS, aliasPath))
+	})
+
+	t.Run("no-op for plain ASCII name", func(t *testing.T) {
+		osFS := afero.NewOsFs()
+		root := t.TempDir()
+		letterDir := filepath.Join(root, "v")
+		realDir := filepath.Join(letterDir, "vim")
+		require.NoError(t, fileutils.MkdirAll(osFS, realDir))
+
+		err := writeAliasSymlink(osFS, realDir, "vim")
+		require.NoError(t, err)
+
+		entries, err := fileutils.ReadDir(osFS, letterDir)
+		require.NoError(t, err)
+		assert.Len(t, entries, 1, "no alias should be created for plain ASCII")
+	})
+
+	t.Run("replaces stale alias symlink", func(t *testing.T) {
+		osFS := afero.NewOsFs()
+		root := t.TempDir()
+		letterDir := filepath.Join(root, "g")
+		realDir := filepath.Join(letterDir, "gtk+")
+		require.NoError(t, fileutils.MkdirAll(osFS, realDir))
+
+		// Pre-existing stale symlink pointing somewhere wrong.
+		aliasPath := filepath.Join(letterDir, "gtk%2B")
+		osSymlink(t, osFS, "nonexistent-target", aliasPath)
+
+		err := writeAliasSymlink(osFS, realDir, "gtk+")
+		require.NoError(t, err)
+
+		assert.Equal(t, "gtk+", osReadlink(t, osFS, aliasPath), "stale symlink should be replaced")
+	})
+
+	t.Run("refuses to overwrite a non-symlink at alias path", func(t *testing.T) {
+		osFS := afero.NewOsFs()
+		root := t.TempDir()
+		letterDir := filepath.Join(root, "g")
+		realDir := filepath.Join(letterDir, "gtk+")
+		require.NoError(t, fileutils.MkdirAll(osFS, realDir))
+
+		// Hypothetical collision: a real component named 'gtk%2B' already exists
+		// at the alias path. RPM names don't use '%' in practice, but the guard
+		// must protect against it.
+		collisionDir := filepath.Join(letterDir, "gtk%2B")
+		require.NoError(t, fileutils.MkdirAll(osFS, collisionDir))
+
+		err := writeAliasSymlink(osFS, realDir, "gtk+")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "non-symlink")
+
+		// Collision dir must still exist — the guard MUST NOT have destroyed it.
+		exists, existsErr := fileutils.DirExists(osFS, collisionDir)
+		require.NoError(t, existsErr)
+		assert.True(t, exists, "non-symlink at alias path must be preserved")
+	})
+
+	t.Run("no-op on filesystem without symlink support", func(t *testing.T) {
+		// MemMapFs does NOT implement afero.Linker — function should silently no-op.
+		memFS := afero.NewMemMapFs()
+		require.NoError(t, fileutils.MkdirAll(memFS, "/SPECS/l/libxml++"))
+
+		err := writeAliasSymlink(memFS, "/SPECS/l/libxml++", "libxml++")
+		assert.NoError(t, err, "must not fail when FS doesn't support symlinks")
+	})
+}
+
+func TestWipeLetterPrefixSubdirs(t *testing.T) {
+	t.Parallel()
+
+	t.Run("missing directory is a no-op", func(t *testing.T) {
+		t.Parallel()
+
+		fs := afero.NewMemMapFs()
+		assert.NoError(t, wipeLetterPrefixSubdirs(fs, "/output"))
+	})
+
+	t.Run("empty directory is a no-op", func(t *testing.T) {
+		t.Parallel()
+
+		fs := afero.NewMemMapFs()
+		require.NoError(t, fileutils.MkdirAll(fs, "/output"))
+
+		assert.NoError(t, wipeLetterPrefixSubdirs(fs, "/output"))
+	})
+
+	t.Run("removes single-character subdirectories", func(t *testing.T) {
+		t.Parallel()
+
+		testFS := afero.NewMemMapFs()
+		for _, letter := range []string{"a", "c", "l"} {
+			require.NoError(t, fileutils.MkdirAll(testFS, filepath.Join("/output", letter, "pkg")))
+		}
+
+		require.NoError(t, wipeLetterPrefixSubdirs(testFS, "/output"))
+
+		entries, err := fileutils.ReadDir(testFS, "/output")
+		require.NoError(t, err)
+		assert.Empty(t, entries, "all letter-prefix subdirectories should be removed")
+	})
+
+	t.Run("preserves top-level files", func(t *testing.T) {
+		t.Parallel()
+
+		testFS := afero.NewMemMapFs()
+		require.NoError(t, fileutils.MkdirAll(testFS, "/output/l/libxml++"))
+		require.NoError(t, fileutils.WriteFile(testFS, "/output/README.md", []byte("keep me"), fileperms.PublicFile))
+
+		require.NoError(t, wipeLetterPrefixSubdirs(testFS, "/output"))
+
+		// File survives.
+		exists, err := fileutils.Exists(testFS, "/output/README.md")
+		require.NoError(t, err)
+		assert.True(t, exists, "top-level file must be preserved")
+
+		// Letter-prefix subdir wiped.
+		exists, err = fileutils.DirExists(testFS, "/output/l")
+		require.NoError(t, err)
+		assert.False(t, exists, "letter-prefix subdirectory must be removed")
+	})
+
+	t.Run("preserves multi-character subdirectories", func(t *testing.T) {
+		t.Parallel()
+
+		// Hypothetical typo: '-o /tmp' instead of '-o /tmp/specs'. Real-world
+		// directories at /tmp have multi-character names (.X11-unix, Documents,
+		// systemd-private-*) — the single-character filter leaves them alone.
+		testFS := afero.NewMemMapFs()
+		require.NoError(t, fileutils.MkdirAll(testFS, "/tmp/.X11-unix"))
+		require.NoError(t, fileutils.MkdirAll(testFS, "/tmp/Documents"))
+		require.NoError(t, fileutils.MkdirAll(testFS, "/tmp/systemd-private-abc"))
+
+		require.NoError(t, wipeLetterPrefixSubdirs(testFS, "/tmp"))
+
+		for _, name := range []string{".X11-unix", "Documents", "systemd-private-abc"} {
+			exists, err := fileutils.DirExists(testFS, filepath.Join("/tmp", name))
+			require.NoError(t, err)
+			assert.True(t, exists, "%s must be preserved (multi-character name)", name)
+		}
+	})
+}
+
+func TestWriteFailureMarkers(t *testing.T) {
+	t.Parallel()
+
+	t.Run("writes markers for error results", func(t *testing.T) {
+		t.Parallel()
+
+		testFS := afero.NewMemMapFs()
+		results := []*RenderResult{
+			{Component: "broken-pkg", OutputDir: "/output/b/broken-pkg", Status: renderStatusError},
+			{Component: "ok-pkg", OutputDir: "/output/o/ok-pkg", Status: renderStatusOK},
+			{Component: "cancelled-pkg", OutputDir: "/output/c/cancelled-pkg", Status: renderStatusCancelled},
+			nil, // gap from a still-pending phase-3 slot.
+		}
+
+		writeFailureMarkers(testFS, results, false)
+
+		// Error result → marker present.
+		exists, err := fileutils.Exists(testFS, "/output/b/broken-pkg/"+renderErrorMarkerFile)
+		require.NoError(t, err)
+		assert.True(t, exists, "error result should have a marker")
+
+		// Non-error results → no marker.
+		nonErrorPaths := []string{
+			"/output/o/ok-pkg/" + renderErrorMarkerFile,
+			"/output/c/cancelled-pkg/" + renderErrorMarkerFile,
+		}
+		for _, path := range nonErrorPaths {
+			exists, err := fileutils.Exists(testFS, path)
+			require.NoError(t, err)
+			assert.False(t, exists, "non-error result must not have a marker (%s)", path)
+		}
+	})
+
+	t.Run("clears stale output before marker when allowOverwrite", func(t *testing.T) {
+		t.Parallel()
+
+		// Pre-existing successful render content that should be wiped before
+		// the failure marker is dropped.
+		testFS := afero.NewMemMapFs()
+		require.NoError(t, fileutils.MkdirAll(testFS, "/output/b/broken-pkg"))
+		require.NoError(t, fileutils.WriteFile(testFS,
+			"/output/b/broken-pkg/broken-pkg.spec",
+			[]byte("Name: broken-pkg"), fileperms.PublicFile))
+
+		results := []*RenderResult{
+			{Component: "broken-pkg", OutputDir: "/output/b/broken-pkg", Status: renderStatusError},
+		}
+
+		writeFailureMarkers(testFS, results, true)
+
+		// Stale spec gone.
+		exists, err := fileutils.Exists(testFS, "/output/b/broken-pkg/broken-pkg.spec")
+		require.NoError(t, err)
+		assert.False(t, exists, "stale render output should be cleared before marker")
+
+		// Marker present.
+		exists, err = fileutils.Exists(testFS, "/output/b/broken-pkg/"+renderErrorMarkerFile)
+		require.NoError(t, err)
+		assert.True(t, exists)
+	})
+
+	t.Run("preserves stale output when allowOverwrite is false", func(t *testing.T) {
+		t.Parallel()
+
+		// Without --force, a previous successful render's content stays in
+		// place — the marker just appears alongside it. (Realistically this
+		// scenario can't happen with the current call sites, but the helper
+		// must respect its allowOverwrite contract.)
+		testFS := afero.NewMemMapFs()
+		require.NoError(t, fileutils.MkdirAll(testFS, "/output/b/broken-pkg"))
+		require.NoError(t, fileutils.WriteFile(testFS,
+			"/output/b/broken-pkg/broken-pkg.spec",
+			[]byte("Name: broken-pkg"), fileperms.PublicFile))
+
+		results := []*RenderResult{
+			{Component: "broken-pkg", OutputDir: "/output/b/broken-pkg", Status: renderStatusError},
+		}
+
+		writeFailureMarkers(testFS, results, false)
+
+		exists, err := fileutils.Exists(testFS, "/output/b/broken-pkg/broken-pkg.spec")
+		require.NoError(t, err)
+		assert.True(t, exists, "spec should be preserved when overwrite is not allowed")
+	})
 }

--- a/internal/app/azldev/cmds/component/render_internal_test.go
+++ b/internal/app/azldev/cmds/component/render_internal_test.go
@@ -412,14 +412,14 @@ func TestWriteAliasSymlink(t *testing.T) {
 	})
 }
 
-func TestWipeLetterPrefixSubdirs(t *testing.T) {
+func TestWipeOutputDirContents(t *testing.T) {
 	t.Parallel()
 
 	t.Run("missing directory is a no-op", func(t *testing.T) {
 		t.Parallel()
 
 		fs := afero.NewMemMapFs()
-		assert.NoError(t, wipeLetterPrefixSubdirs(fs, "/output"))
+		assert.NoError(t, wipeOutputDirContents(fs, "/output"))
 	})
 
 	t.Run("empty directory is a no-op", func(t *testing.T) {
@@ -428,10 +428,10 @@ func TestWipeLetterPrefixSubdirs(t *testing.T) {
 		fs := afero.NewMemMapFs()
 		require.NoError(t, fileutils.MkdirAll(fs, "/output"))
 
-		assert.NoError(t, wipeLetterPrefixSubdirs(fs, "/output"))
+		assert.NoError(t, wipeOutputDirContents(fs, "/output"))
 	})
 
-	t.Run("removes single-character subdirectories", func(t *testing.T) {
+	t.Run("removes all children but keeps directory", func(t *testing.T) {
 		t.Parallel()
 
 		testFS := afero.NewMemMapFs()
@@ -439,51 +439,20 @@ func TestWipeLetterPrefixSubdirs(t *testing.T) {
 			require.NoError(t, fileutils.MkdirAll(testFS, filepath.Join("/output", letter, "pkg")))
 		}
 
-		require.NoError(t, wipeLetterPrefixSubdirs(testFS, "/output"))
+		require.NoError(t, fileutils.WriteFile(testFS, "/output/README.md", []byte("keep me"), fileperms.PublicFile))
+		require.NoError(t, fileutils.MkdirAll(testFS, "/output/multi-char-dir"))
 
+		require.NoError(t, wipeOutputDirContents(testFS, "/output"))
+
+		// Directory itself still exists.
+		exists, err := fileutils.DirExists(testFS, "/output")
+		require.NoError(t, err)
+		assert.True(t, exists, "output directory itself must be preserved")
+
+		// All children removed.
 		entries, err := fileutils.ReadDir(testFS, "/output")
 		require.NoError(t, err)
-		assert.Empty(t, entries, "all letter-prefix subdirectories should be removed")
-	})
-
-	t.Run("preserves top-level files", func(t *testing.T) {
-		t.Parallel()
-
-		testFS := afero.NewMemMapFs()
-		require.NoError(t, fileutils.MkdirAll(testFS, "/output/l/libxml++"))
-		require.NoError(t, fileutils.WriteFile(testFS, "/output/README.md", []byte("keep me"), fileperms.PublicFile))
-
-		require.NoError(t, wipeLetterPrefixSubdirs(testFS, "/output"))
-
-		// File survives.
-		exists, err := fileutils.Exists(testFS, "/output/README.md")
-		require.NoError(t, err)
-		assert.True(t, exists, "top-level file must be preserved")
-
-		// Letter-prefix subdir wiped.
-		exists, err = fileutils.DirExists(testFS, "/output/l")
-		require.NoError(t, err)
-		assert.False(t, exists, "letter-prefix subdirectory must be removed")
-	})
-
-	t.Run("preserves multi-character subdirectories", func(t *testing.T) {
-		t.Parallel()
-
-		// Hypothetical typo: '-o /tmp' instead of '-o /tmp/specs'. Real-world
-		// directories at /tmp have multi-character names (.X11-unix, Documents,
-		// systemd-private-*) — the single-character filter leaves them alone.
-		testFS := afero.NewMemMapFs()
-		require.NoError(t, fileutils.MkdirAll(testFS, "/tmp/.X11-unix"))
-		require.NoError(t, fileutils.MkdirAll(testFS, "/tmp/Documents"))
-		require.NoError(t, fileutils.MkdirAll(testFS, "/tmp/systemd-private-abc"))
-
-		require.NoError(t, wipeLetterPrefixSubdirs(testFS, "/tmp"))
-
-		for _, name := range []string{".X11-unix", "Documents", "systemd-private-abc"} {
-			exists, err := fileutils.DirExists(testFS, filepath.Join("/tmp", name))
-			require.NoError(t, err)
-			assert.True(t, exists, "%s must be preserved (multi-character name)", name)
-		}
+		assert.Empty(t, entries, "all contents should be removed")
 	})
 }
 

--- a/internal/app/azldev/cmds/component/render_test.go
+++ b/internal/app/azldev/cmds/component/render_test.go
@@ -84,3 +84,16 @@ func TestRenderCmd_CleanStaleRequiresAll(t *testing.T) {
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "--clean-stale requires -a")
 }
+
+func TestRenderCmd_CleanStaleCustomOutDirRequiresForce(t *testing.T) {
+	testEnv := testutils.NewTestEnv(t)
+
+	cmd := componentcmds.NewRenderCmd()
+	cmd.SetArgs([]string{"-a", "-o", "SPECS", "--clean-stale"})
+
+	err := cmd.ExecuteContext(testEnv.Env)
+
+	// --clean-stale with -o but without -f should fail.
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "--clean-stale with --output-dir requires --force")
+}

--- a/internal/app/azldev/core/components/renderedspecdir.go
+++ b/internal/app/azldev/core/components/renderedspecdir.go
@@ -5,6 +5,7 @@ package components
 
 import (
 	"fmt"
+	"net/url"
 	"path/filepath"
 	"strings"
 
@@ -29,4 +30,30 @@ func RenderedSpecDir(renderedSpecsDir, componentName string) (string, error) {
 	prefix := strings.ToLower(componentName[:1])
 
 	return filepath.Join(renderedSpecsDir, prefix, componentName), nil
+}
+
+// RenderedSpecDirAliasName returns the URL-encoded form of componentName intended
+// for use as a sibling alias (typically a symlink) alongside the real rendered
+// directory. This is a temporary compatibility shim — see the workaround block
+// in `RenderComponents` for the full rationale and TODO link. It is NOT part of
+// the canonical rendered-spec directory contract and should be removed once the
+// downstream build system decodes SCM URL fragments correctly.
+//
+// Encoder choice: [url.QueryEscape] is used deliberately, in conscious divergence
+// from the [url.PathEscape] convention elsewhere in this codebase (e.g.
+// fedorasource). Of the two stdlib encoders, only QueryEscape escapes '+' as
+// '%2B', and '+' is the only RPM-name character that triggers the downstream
+// path mismatch we need to bridge (PathEscape would emit a literal '+', the
+// alias name would equal the real name, and no symlink would be written).
+// Component names with '%' literal are assumed not to occur (RPM convention);
+// no real-world packages exercise this case.
+//
+// Returns "" when no alias is needed (the encoded form equals componentName).
+func RenderedSpecDirAliasName(componentName string) string {
+	encoded := url.QueryEscape(componentName)
+	if encoded == componentName {
+		return ""
+	}
+
+	return encoded
 }

--- a/internal/app/azldev/core/components/renderedspecdir_test.go
+++ b/internal/app/azldev/core/components/renderedspecdir_test.go
@@ -73,3 +73,26 @@ func TestRenderedSpecDir(t *testing.T) {
 		assert.Error(t, err)
 	})
 }
+
+func TestRenderedSpecDirAliasName(t *testing.T) {
+	t.Run("EmptyForPlainAsciiName", func(t *testing.T) {
+		assert.Empty(t, components.RenderedSpecDirAliasName("vim"))
+	})
+
+	t.Run("EmptyForDashAndUnderscore", func(t *testing.T) {
+		assert.Empty(t, components.RenderedSpecDirAliasName("my-component_v2"))
+	})
+
+	t.Run("EmptyForDotInName", func(t *testing.T) {
+		// '.' is a safe filesystem char and not URL-encoded.
+		assert.Empty(t, components.RenderedSpecDirAliasName("foo.bar"))
+	})
+
+	t.Run("EncodesPlusCharacters", func(t *testing.T) {
+		assert.Equal(t, "libxml%2B%2B", components.RenderedSpecDirAliasName("libxml++"))
+	})
+
+	t.Run("EncodesSinglePlus", func(t *testing.T) {
+		assert.Equal(t, "gtk%2B", components.RenderedSpecDirAliasName("gtk+"))
+	})
+}


### PR DESCRIPTION
<!--
PR Title must follow Conventional Commits format. Available types:

- feat: A new feature
- fix: A bug fix
- docs: Documentation only changes
- style: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
- refactor: A code change that neither fixes a bug nor adds a feature
- perf: A code change that improves performance
- test: Adding missing tests or correcting existing tests
- build: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
- ci: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
- chore: Other changes that don't modify src or test files
- revert: Reverts a previous commit

Reference: https://www.conventionalcommits.org/en/v1.0.0/
-->
