### PR TITLE
feat(lockfile): add ReadAllAtCommit for batch lock file reading

### DIFF
--- a/internal/lockfile/show.go
+++ b/internal/lockfile/show.go
@@ -91,7 +91,7 @@ func cleanLockRelDir(lockRelDir string) (string, error) {
 		return "", fmt.Errorf("lockRelDir must be repo-relative, got absolute path %#q", lockRelDir)
 	}
 
-	if strings.HasPrefix(lockRelDir, "..") {
+	if lockRelDir == ".." || strings.HasPrefix(lockRelDir, "../") {
 		return "", fmt.Errorf("lockRelDir %#q escapes repository root", lockRelDir)
 	}
 

--- a/internal/lockfile/show.go
+++ b/internal/lockfile/show.go
@@ -4,10 +4,14 @@
 package lockfile
 
 import (
+	"errors"
 	"fmt"
+	gopath "path"
+	"strings"
 
 	gogit "github.com/go-git/go-git/v5"
 	"github.com/go-git/go-git/v5/plumbing"
+	"github.com/go-git/go-git/v5/plumbing/object"
 )
 
 // ShowAtCommit reads and parses a lock file at a specific commit hash
@@ -48,4 +52,123 @@ func ShowAtCommit(
 	}
 
 	return *lock, nil
+}
+
+// ReadAllAtCommit reads and parses all lock files from a directory at a specific
+// commit. Returns a map of component name → [ComponentLock]. The lockRelDir must
+// be a POSIX-style repo-relative path (e.g., "locks"). Use "" or "." for root.
+// Absolute paths and ".." escapes are rejected.
+//
+// Returns an empty map (not an error) when the lock directory does not exist in
+// the commit tree. Returns an error if any individual lock file fails to parse.
+func ReadAllAtCommit(
+	repo *gogit.Repository,
+	commitHash string,
+	lockRelDir string,
+) (map[string]ComponentLock, error) {
+	lockRelDir, err := cleanLockRelDir(lockRelDir)
+	if err != nil {
+		return nil, err
+	}
+
+	lockSubtree, err := resolveLockSubtree(repo, commitHash, lockRelDir)
+	if err != nil {
+		return nil, err
+	}
+
+	if lockSubtree == nil {
+		return make(map[string]ComponentLock), nil
+	}
+
+	return parseLockEntries(lockSubtree, lockRelDir, commitHash)
+}
+
+// cleanLockRelDir normalizes and validates a repo-relative lock directory path.
+func cleanLockRelDir(lockRelDir string) (string, error) {
+	lockRelDir = gopath.Clean(lockRelDir)
+
+	if gopath.IsAbs(lockRelDir) {
+		return "", fmt.Errorf("lockRelDir must be repo-relative, got absolute path %#q", lockRelDir)
+	}
+
+	if strings.HasPrefix(lockRelDir, "..") {
+		return "", fmt.Errorf("lockRelDir %#q escapes repository root", lockRelDir)
+	}
+
+	return lockRelDir, nil
+}
+
+// resolveLockSubtree resolves the lock directory tree at a specific commit.
+// Returns nil when the directory does not exist (not an error).
+func resolveLockSubtree(
+	repo *gogit.Repository, commitHash, lockRelDir string,
+) (*object.Tree, error) {
+	hash := plumbing.NewHash(commitHash)
+
+	commitObj, err := repo.CommitObject(hash)
+	if err != nil {
+		return nil, fmt.Errorf("failed to resolve commit %#q:\n%w", commitHash, err)
+	}
+
+	tree, err := commitObj.Tree()
+	if err != nil {
+		return nil, fmt.Errorf("failed to get tree for commit %#q:\n%w", commitHash, err)
+	}
+
+	// "." means root tree — no subtree lookup needed.
+	if lockRelDir == "" || lockRelDir == "." {
+		return tree, nil
+	}
+
+	lockSubtree, err := tree.Tree(lockRelDir)
+	if err != nil {
+		if errors.Is(err, object.ErrDirectoryNotFound) || errors.Is(err, object.ErrEntryNotFound) {
+			return nil, nil //nolint:nilnil // nil tree signals "directory absent".
+		}
+
+		return nil, fmt.Errorf("failed to read lock directory %#q at commit %#q:\n%w",
+			lockRelDir, commitHash, err)
+	}
+
+	return lockSubtree, nil
+}
+
+// parseLockEntries reads all lock files from a resolved tree.
+func parseLockEntries(
+	lockSubtree *object.Tree, lockRelDir, commitHash string,
+) (map[string]ComponentLock, error) {
+	locks := make(map[string]ComponentLock)
+
+	for _, entry := range lockSubtree.Entries {
+		if !entry.Mode.IsFile() ||
+			strings.HasPrefix(entry.Name, ".") ||
+			!strings.HasSuffix(entry.Name, lockFileExtension) {
+			continue
+		}
+
+		name := strings.TrimSuffix(entry.Name, lockFileExtension)
+		entryPath := gopath.Join(lockRelDir, entry.Name)
+
+		file, fileErr := lockSubtree.File(entry.Name)
+		if fileErr != nil {
+			return nil, fmt.Errorf("failed to read lock file %#q at commit %#q:\n%w",
+				entryPath, commitHash, fileErr)
+		}
+
+		content, contentErr := file.Contents()
+		if contentErr != nil {
+			return nil, fmt.Errorf("failed to read contents of %#q at commit %#q:\n%w",
+				entryPath, commitHash, contentErr)
+		}
+
+		lock, parseErr := Parse([]byte(content))
+		if parseErr != nil {
+			return nil, fmt.Errorf("failed to parse lock file %#q at commit %#q:\n%w",
+				entryPath, commitHash, parseErr)
+		}
+
+		locks[name] = *lock
+	}
+
+	return locks, nil
 }

--- a/internal/lockfile/show_test.go
+++ b/internal/lockfile/show_test.go
@@ -148,3 +148,127 @@ func TestShowAtCommit(t *testing.T) {
 		assert.Contains(t, err.Error(), "failed to resolve commit")
 	})
 }
+
+func TestReadAllAtCommit(t *testing.T) {
+	const lockDir = "locks"
+
+	t.Run("reads all locks", func(t *testing.T) {
+		testFS := memfs.New()
+		repo, err := gogit.Init(memory.NewStorage(), testFS)
+		require.NoError(t, err)
+
+		commitFile(t, repo, testFS, "locks/curl.lock", validLockTOML, "add curl lock")
+		commitHash := commitFile(t, repo, testFS,
+			"locks/bash.lock",
+			"version = 1\nimport-commit = \"bash111\"\nupstream-commit = \"bash222\"\ninput-fingerprint = \"bashfp\"\n",
+			"add bash lock",
+		)
+
+		locks, readErr := lockfile.ReadAllAtCommit(repo, commitHash, lockDir)
+		require.NoError(t, readErr)
+		assert.Len(t, locks, 2)
+		assert.Equal(t, "fff000", locks["curl"].InputFingerprint)
+		assert.Equal(t, "bashfp", locks["bash"].InputFingerprint)
+	})
+
+	t.Run("empty when no lock dir", func(t *testing.T) {
+		testFS := memfs.New()
+		repo, err := gogit.Init(memory.NewStorage(), testFS)
+		require.NoError(t, err)
+
+		commitHash := commitFile(t, repo, testFS, "other/file.txt", "data", "init")
+
+		locks, readErr := lockfile.ReadAllAtCommit(repo, commitHash, lockDir)
+		require.NoError(t, readErr)
+		assert.Empty(t, locks)
+	})
+
+	t.Run("skips non-lock files", func(t *testing.T) {
+		testFS := memfs.New()
+		repo, err := gogit.Init(memory.NewStorage(), testFS)
+		require.NoError(t, err)
+
+		commitFile(t, repo, testFS, "locks/curl.lock", validLockTOML, "add lock")
+		commitHash := commitFile(t, repo, testFS, "locks/README.md", "# Locks", "add readme")
+
+		locks, readErr := lockfile.ReadAllAtCommit(repo, commitHash, lockDir)
+		require.NoError(t, readErr)
+		assert.Len(t, locks, 1)
+		assert.Contains(t, locks, "curl")
+	})
+
+	t.Run("skips dot-prefixed lock files", func(t *testing.T) {
+		testFS := memfs.New()
+		repo, err := gogit.Init(memory.NewStorage(), testFS)
+		require.NoError(t, err)
+
+		commitFile(t, repo, testFS, "locks/curl.lock", validLockTOML, "add lock")
+		commitHash := commitFile(t, repo, testFS, "locks/.hidden.lock", validLockTOML, "add hidden")
+
+		locks, readErr := lockfile.ReadAllAtCommit(repo, commitHash, lockDir)
+		require.NoError(t, readErr)
+		assert.Len(t, locks, 1)
+		assert.Contains(t, locks, "curl")
+	})
+
+	t.Run("error on unparseable lock", func(t *testing.T) {
+		testFS := memfs.New()
+		repo, err := gogit.Init(memory.NewStorage(), testFS)
+		require.NoError(t, err)
+
+		commitHash := commitFile(t, repo, testFS, "locks/bad.lock", "not valid {{{", "add bad")
+
+		_, readErr := lockfile.ReadAllAtCommit(repo, commitHash, lockDir)
+		require.Error(t, readErr)
+		assert.Contains(t, readErr.Error(), "failed to parse")
+	})
+
+	t.Run("reads root-level locks with dot dir", func(t *testing.T) {
+		testFS := memfs.New()
+		repo, err := gogit.Init(memory.NewStorage(), testFS)
+		require.NoError(t, err)
+
+		commitHash := commitFile(t, repo, testFS, "curl.lock", validLockTOML, "add root lock")
+
+		locks, readErr := lockfile.ReadAllAtCommit(repo, commitHash, ".")
+		require.NoError(t, readErr)
+		assert.Len(t, locks, 1)
+		assert.Equal(t, "fff000", locks["curl"].InputFingerprint)
+	})
+
+	t.Run("normalizes ./locks to locks", func(t *testing.T) {
+		testFS := memfs.New()
+		repo, err := gogit.Init(memory.NewStorage(), testFS)
+		require.NoError(t, err)
+
+		commitHash := commitFile(t, repo, testFS, "locks/curl.lock", validLockTOML, "add lock")
+
+		locks, readErr := lockfile.ReadAllAtCommit(repo, commitHash, "./locks")
+		require.NoError(t, readErr)
+		assert.Len(t, locks, 1)
+	})
+
+	t.Run("rejects absolute path", func(t *testing.T) {
+		testFS := memfs.New()
+		repo, err := gogit.Init(memory.NewStorage(), testFS)
+		require.NoError(t, err)
+
+		commitFile(t, repo, testFS, "locks/curl.lock", validLockTOML, "add lock")
+
+		_, readErr := lockfile.ReadAllAtCommit(repo, "dummy", "/abs/locks")
+		require.Error(t, readErr)
+		assert.Contains(t, readErr.Error(), "repo-relative")
+	})
+
+	t.Run("rejects path traversal", func(t *testing.T) {
+		testFS := memfs.New()
+		repo, err := gogit.Init(memory.NewStorage(), testFS)
+		require.NoError(t, err)
+
+		commitFile(t, repo, testFS, "locks/curl.lock", validLockTOML, "add lock")
+
+		_, readErr := lockfile.ReadAllAtCommit(repo, "dummy", "../escape")
+		require.Error(t, readErr)
+		assert.Contains(t, readErr.Error(), "escapes repository root")
+	})
+}


### PR DESCRIPTION
Add ReadAllAtCommit to the lockfile package, which reads and parses all lock files from a directory at a specific git commit. Returns a map of component name to ComponentLock.

- Handles missing lock directory gracefully (empty map, not error)
- Skips non-lock files and dot-prefixed files (matches on-disk loader)
- Returns hard error on unparseable lock files

This enables efficient change detection by doing one tree walk per ref instead of N per-file lookups.