### PR TITLE
feat(fingerprint): add facility for upstream commit staleness detection

### DIFF
--- a/internal/fingerprint/fingerprint.go
+++ b/internal/fingerprint/fingerprint.go
@@ -173,3 +173,51 @@ func writeField(writer io.Writer, label string, value string) {
 	// via values containing newlines.
 	fmt.Fprintf(writer, "%d:%s=%d:%s\n", len(label), label, len(value), value)
 }
+
+// ResolutionInputs holds the effective inputs that determine which upstream
+// commit gets resolved. These must be the *resolved* values after inheritance
+// and fallback — not the raw component spec fields.
+type ResolutionInputs struct {
+	// Snapshot is the resolved snapshot timestamp.
+	Snapshot string
+	// DistroName is the resolved distro name.
+	DistroName string
+	// DistroVersion is the resolved distro version.
+	DistroVersion string
+	// DistGitBranch is the resolved dist-git branch (e.g., "f43").
+	DistGitBranch string
+	// DistGitBaseURI is the resolved dist-git base URI template.
+	DistGitBaseURI string
+	// UpstreamCommitPin is an explicit commit hash pin (overrides snapshot).
+	UpstreamCommitPin string
+	// UpstreamName is the upstream package name (if different from component).
+	UpstreamName string
+}
+
+// ComputeResolutionHash produces a deterministic hash of the effective inputs
+// that affect upstream commit resolution. When this hash matches the stored
+// value in a lock file, re-resolving the upstream commit can be skipped — the
+// resolution inputs haven't changed so the same commit would be produced.
+//
+// This prevents two classes of problems:
+//   - Unnecessary re-resolution when only build inputs changed (e.g., overlay edit)
+//   - Snapshot instability where upstream branches receive new commits (mass
+//     rebuilds, cherry-picks) that change what 'git rev-list --before' resolves
+//     to, even though the snapshot timestamp itself is unchanged
+//
+// Callers must resolve distro inheritance/fallbacks before calling this — the
+// hash must reflect the *actual* values used during resolution, not the raw
+// per-component config which may be empty when defaults apply.
+func ComputeResolutionHash(inputs ResolutionInputs) string {
+	hasher := sha256.New()
+
+	writeField(hasher, "snapshot", inputs.Snapshot)
+	writeField(hasher, "distro_name", inputs.DistroName)
+	writeField(hasher, "distro_version", inputs.DistroVersion)
+	writeField(hasher, "dist_git_branch", inputs.DistGitBranch)
+	writeField(hasher, "dist_git_base_uri", inputs.DistGitBaseURI)
+	writeField(hasher, "upstream_commit_pin", inputs.UpstreamCommitPin)
+	writeField(hasher, "upstream_name", inputs.UpstreamName)
+
+	return "sha256:" + hex.EncodeToString(hasher.Sum(nil))
+}

--- a/internal/fingerprint/fingerprint.go
+++ b/internal/fingerprint/fingerprint.go
@@ -174,10 +174,10 @@ func writeField(writer io.Writer, label string, value string) {
 	fmt.Fprintf(writer, "%d:%s=%d:%s\n", len(label), label, len(value), value)
 }
 
-// ResolutionInputs holds the effective inputs that determine which upstream
+// UpstreamCommitResolutionInputs holds the effective inputs that determine which upstream
 // commit gets resolved. These must be the *resolved* values after inheritance
 // and fallback — not the raw component spec fields.
-type ResolutionInputs struct {
+type UpstreamCommitResolutionInputs struct {
 	// Snapshot is the resolved snapshot timestamp.
 	Snapshot string
 	// DistroName is the resolved distro name.
@@ -208,7 +208,7 @@ type ResolutionInputs struct {
 // Callers must resolve distro inheritance/fallbacks before calling this — the
 // hash must reflect the *actual* values used during resolution, not the raw
 // per-component config which may be empty when defaults apply.
-func ComputeResolutionHash(inputs ResolutionInputs) string {
+func ComputeResolutionHash(inputs UpstreamCommitResolutionInputs) string {
 	hasher := sha256.New()
 
 	writeField(hasher, "snapshot", inputs.Snapshot)

--- a/internal/fingerprint/fingerprint_test.go
+++ b/internal/fingerprint/fingerprint_test.go
@@ -4,6 +4,7 @@
 package fingerprint_test
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/microsoft/azure-linux-dev-tools/internal/fingerprint"
@@ -672,4 +673,94 @@ func TestComputeIdentity_DifferentCheckoutPaths(t *testing.T) {
 
 	assert.Equal(t, fp1, fp2,
 		"same component in different checkout directories must produce identical fingerprints")
+}
+
+func testResolutionInputs() fingerprint.ResolutionInputs {
+	return fingerprint.ResolutionInputs{
+		Snapshot:       "2025-01-01T00:00:00Z",
+		DistroName:     "fedora",
+		DistroVersion:  "41",
+		DistGitBranch:  "f41",
+		DistGitBaseURI: "https://src.fedoraproject.org/rpms/$pkg.git",
+		UpstreamName:   "curl",
+	}
+}
+
+func TestComputeResolutionHash_SnapshotChangeAffectsHash(t *testing.T) {
+	inputs := testResolutionInputs()
+	hashBefore := fingerprint.ComputeResolutionHash(inputs)
+
+	inputs.Snapshot = "2026-06-15T00:00:00Z"
+	hashAfter := fingerprint.ComputeResolutionHash(inputs)
+
+	assert.NotEqual(t, hashBefore, hashAfter,
+		"snapshot change must change resolution hash")
+}
+
+func TestComputeResolutionHash_BuildOptionDoesNotAffectHash(t *testing.T) {
+	// Build options are not part of ResolutionInputs — they only affect
+	// InputFingerprint. Verify the hash is stable regardless.
+	inputs := testResolutionInputs()
+	hashBefore := fingerprint.ComputeResolutionHash(inputs)
+
+	// Re-compute with identical inputs (build options are external).
+	hashAfter := fingerprint.ComputeResolutionHash(inputs)
+
+	assert.Equal(t, hashBefore, hashAfter,
+		"resolution hash must not be affected by build options")
+}
+
+func TestComputeResolutionHash_Deterministic(t *testing.T) {
+	inputs := testResolutionInputs()
+
+	hashFirst := fingerprint.ComputeResolutionHash(inputs)
+	hashSecond := fingerprint.ComputeResolutionHash(inputs)
+
+	assert.Equal(t, hashFirst, hashSecond, "same inputs must produce same hash")
+	assert.True(t, strings.HasPrefix(hashFirst, "sha256:"), "hash must have sha256 prefix")
+}
+
+func TestComputeResolutionHash_PinChangeAffectsHash(t *testing.T) {
+	inputs := testResolutionInputs()
+	hashNoPin := fingerprint.ComputeResolutionHash(inputs)
+
+	inputs.UpstreamCommitPin = "abc123def456"
+	hashWithPin := fingerprint.ComputeResolutionHash(inputs)
+
+	assert.NotEqual(t, hashNoPin, hashWithPin,
+		"adding an upstream commit pin must change resolution hash")
+}
+
+func TestComputeResolutionHash_DistroVersionChangeAffectsHash(t *testing.T) {
+	inputs := testResolutionInputs()
+	hashV41 := fingerprint.ComputeResolutionHash(inputs)
+
+	inputs.DistroVersion = "42"
+	inputs.DistGitBranch = "f42"
+	hashV42 := fingerprint.ComputeResolutionHash(inputs)
+
+	assert.NotEqual(t, hashV41, hashV42,
+		"distro version change must change resolution hash")
+}
+
+func TestComputeResolutionHash_BranchChangeAffectsHash(t *testing.T) {
+	inputs := testResolutionInputs()
+	hashBefore := fingerprint.ComputeResolutionHash(inputs)
+
+	inputs.DistGitBranch = "f41-stabilization"
+	hashAfter := fingerprint.ComputeResolutionHash(inputs)
+
+	assert.NotEqual(t, hashBefore, hashAfter,
+		"dist-git branch change must change resolution hash")
+}
+
+func TestComputeResolutionHash_BaseURIChangeAffectsHash(t *testing.T) {
+	inputs := testResolutionInputs()
+	hashBefore := fingerprint.ComputeResolutionHash(inputs)
+
+	inputs.DistGitBaseURI = "https://internal-mirror.example.com/rpms/$pkg.git"
+	hashAfter := fingerprint.ComputeResolutionHash(inputs)
+
+	assert.NotEqual(t, hashBefore, hashAfter,
+		"dist-git base URI change must change resolution hash")
 }

--- a/internal/fingerprint/fingerprint_test.go
+++ b/internal/fingerprint/fingerprint_test.go
@@ -675,8 +675,8 @@ func TestComputeIdentity_DifferentCheckoutPaths(t *testing.T) {
 		"same component in different checkout directories must produce identical fingerprints")
 }
 
-func testResolutionInputs() fingerprint.ResolutionInputs {
-	return fingerprint.ResolutionInputs{
+func testUpstreamCommitResolutionInputs() fingerprint.UpstreamCommitResolutionInputs {
+	return fingerprint.UpstreamCommitResolutionInputs{
 		Snapshot:       "2025-01-01T00:00:00Z",
 		DistroName:     "fedora",
 		DistroVersion:  "41",
@@ -687,7 +687,7 @@ func testResolutionInputs() fingerprint.ResolutionInputs {
 }
 
 func TestComputeResolutionHash_SnapshotChangeAffectsHash(t *testing.T) {
-	inputs := testResolutionInputs()
+	inputs := testUpstreamCommitResolutionInputs()
 	hashBefore := fingerprint.ComputeResolutionHash(inputs)
 
 	inputs.Snapshot = "2026-06-15T00:00:00Z"
@@ -697,21 +697,19 @@ func TestComputeResolutionHash_SnapshotChangeAffectsHash(t *testing.T) {
 		"snapshot change must change resolution hash")
 }
 
-func TestComputeResolutionHash_BuildOptionDoesNotAffectHash(t *testing.T) {
-	// Build options are not part of ResolutionInputs — they only affect
-	// InputFingerprint. Verify the hash is stable regardless.
-	inputs := testResolutionInputs()
+func TestComputeResolutionHash_UpstreamNameChangeAffectsHash(t *testing.T) {
+	inputs := testUpstreamCommitResolutionInputs()
 	hashBefore := fingerprint.ComputeResolutionHash(inputs)
 
-	// Re-compute with identical inputs (build options are external).
+	inputs.UpstreamName = "wget"
 	hashAfter := fingerprint.ComputeResolutionHash(inputs)
 
-	assert.Equal(t, hashBefore, hashAfter,
-		"resolution hash must not be affected by build options")
+	assert.NotEqual(t, hashBefore, hashAfter,
+		"upstream name change must change resolution hash")
 }
 
 func TestComputeResolutionHash_Deterministic(t *testing.T) {
-	inputs := testResolutionInputs()
+	inputs := testUpstreamCommitResolutionInputs()
 
 	hashFirst := fingerprint.ComputeResolutionHash(inputs)
 	hashSecond := fingerprint.ComputeResolutionHash(inputs)
@@ -721,7 +719,7 @@ func TestComputeResolutionHash_Deterministic(t *testing.T) {
 }
 
 func TestComputeResolutionHash_PinChangeAffectsHash(t *testing.T) {
-	inputs := testResolutionInputs()
+	inputs := testUpstreamCommitResolutionInputs()
 	hashNoPin := fingerprint.ComputeResolutionHash(inputs)
 
 	inputs.UpstreamCommitPin = "abc123def456"
@@ -732,7 +730,7 @@ func TestComputeResolutionHash_PinChangeAffectsHash(t *testing.T) {
 }
 
 func TestComputeResolutionHash_DistroVersionChangeAffectsHash(t *testing.T) {
-	inputs := testResolutionInputs()
+	inputs := testUpstreamCommitResolutionInputs()
 	hashV41 := fingerprint.ComputeResolutionHash(inputs)
 
 	inputs.DistroVersion = "42"
@@ -744,7 +742,7 @@ func TestComputeResolutionHash_DistroVersionChangeAffectsHash(t *testing.T) {
 }
 
 func TestComputeResolutionHash_BranchChangeAffectsHash(t *testing.T) {
-	inputs := testResolutionInputs()
+	inputs := testUpstreamCommitResolutionInputs()
 	hashBefore := fingerprint.ComputeResolutionHash(inputs)
 
 	inputs.DistGitBranch = "f41-stabilization"
@@ -755,7 +753,7 @@ func TestComputeResolutionHash_BranchChangeAffectsHash(t *testing.T) {
 }
 
 func TestComputeResolutionHash_BaseURIChangeAffectsHash(t *testing.T) {
-	inputs := testResolutionInputs()
+	inputs := testUpstreamCommitResolutionInputs()
 	hashBefore := fingerprint.ComputeResolutionHash(inputs)
 
 	inputs.DistGitBaseURI = "https://internal-mirror.example.com/rpms/$pkg.git"


### PR DESCRIPTION
Add ComputeResolutionHash to the fingerprint package. It hashes the resolved inputs that affect upstream commit resolution: snapshot time, distro name/version, dist-git branch/URI, explicit commit pin, and upstream name.

Uses a UpstreamCommitResolutionInputs struct to ensure callers pass resolved values (after inheritance/fallback), not raw spec fields. This catches changes to dist-git branch or base URI that the raw distro reference would miss.
