### PR TITLE
feat: add explicit release calculation modes (autorelease, static)

### DIFF
--- a/docs/user/reference/config/components.md
+++ b/docs/user/reference/config/components.md
@@ -104,11 +104,25 @@ The `[components.<name>.release]` section controls how azldev manages the Releas
 
 | Field | TOML Key | Type | Required | Description |
 |-------|----------|------|----------|-------------|
-| Calculation | `calculation` | string | No | `"auto"` (default) = auto-bump; `"manual"` = skip all automatic Release manipulation |
+| Calculation | `calculation` | string | No | One of `"auto"` (default), `"autorelease"`, `"static"`, or `"manual"` |
 
-Most components use auto mode (the default) and need no release configuration. Set `calculation = "manual"` for components that manage their own release numbering, such as kernel:
+### Calculation Modes
+
+| Mode | Behavior |
+|------|----------|
+| `auto` | Auto-detects from the spec's Release tag value. If `%autorelease` is found, rpmautospec handles it. If a static integer is found, it is bumped by the synthetic commit count. |
+| `autorelease` | Explicitly declares the spec uses `%autorelease`. Skips all Release manipulation. Use this for specs with conditional `%autorelease`/`%else` fallbacks that confuse auto-detection. |
+| `static` | Explicitly declares the spec uses a static integer release. Always bumps it by the synthetic commit count. |
+| `manual` | Skips all automatic Release manipulation. Use for components that manage their own release numbering (e.g. kernel). |
+
+Most components use `auto` (the default) and need no release configuration. Examples:
 
 ```toml
+# Spec with conditional %autorelease that auto-detection gets wrong:
+[components.gvisor-tap-vsock.release]
+calculation = "autorelease"
+
+# Component that manages its own release numbering:
 [components.kernel.release]
 calculation = "manual"
 ```

--- a/docs/user/reference/config/components.md
+++ b/docs/user/reference/config/components.md
@@ -112,7 +112,7 @@ The `[components.<name>.release]` section controls how azldev manages the Releas
 |------|----------|
 | `auto` | Auto-detects from the spec's Release tag value. If `%autorelease` is found, rpmautospec handles it. If a static integer is found, it is bumped by the synthetic commit count. |
 | `autorelease` | Explicitly declares the spec uses `%autorelease`. Skips all Release manipulation. Use this for specs with conditional `%autorelease`/`%else` fallbacks that confuse auto-detection. |
-| `static` | Explicitly declares the spec uses a static integer release. Always bumps it by the synthetic commit count. |
+| `static` | Explicitly declares the spec uses a static integer release. Bumps it by the synthetic commit count only when the Release tag starts with an integer. Non-integer or other non-standard Release values (for example, `%{pkg_release}`) require `manual` or an overlay. |
 | `manual` | Skips all automatic Release manipulation. Use for components that manage their own release numbering (e.g. kernel). |
 
 Most components use `auto` (the default) and need no release configuration. Examples:

--- a/internal/app/azldev/core/sources/release.go
+++ b/internal/app/azldev/core/sources/release.go
@@ -120,10 +120,10 @@ func (p *sourcePreparerImpl) tryBumpStaticRelease(
 		return nil
 
 	case projectconfig.ReleaseCalculationStatic:
-		return p.bumpStaticRelease(component, sourcesDirPath, commitCount)
+		return p.readAndBumpRelease(component, sourcesDirPath, commitCount, true)
 
 	case projectconfig.ReleaseCalculationAuto:
-		return p.autoBumpStaticRelease(component, sourcesDirPath, commitCount)
+		return p.readAndBumpRelease(component, sourcesDirPath, commitCount, false)
 
 	default:
 		return fmt.Errorf("component %#q has unknown release calculation mode %#q",
@@ -131,12 +131,15 @@ func (p *sourcePreparerImpl) tryBumpStaticRelease(
 	}
 }
 
-// autoBumpStaticRelease auto-detects the release mode from the spec's Release tag value.
-// If the tag uses %autorelease, it's a no-op. Otherwise it attempts a static bump.
-func (p *sourcePreparerImpl) autoBumpStaticRelease(
+// readAndBumpRelease reads the Release tag from the spec and bumps its static integer.
+// When requireStaticRelease is true (explicit static mode), encountering %autorelease
+// produces an error telling the user to switch to 'release.calculation = "autorelease"'.
+// When false (auto mode), specs using %autorelease are silently skipped.
+func (p *sourcePreparerImpl) readAndBumpRelease(
 	component components.Component,
 	sourcesDirPath string,
 	commitCount int,
+	requireStaticRelease bool,
 ) error {
 	specPath, err := p.resolveSpecPath(component, sourcesDirPath)
 	if err != nil {
@@ -150,41 +153,19 @@ func (p *sourcePreparerImpl) autoBumpStaticRelease(
 	}
 
 	if ReleaseUsesAutorelease(releaseValue) {
+		if requireStaticRelease {
+			return fmt.Errorf(
+				"component %#q has 'release.calculation = \"static\"' but its Release tag "+
+					"uses %%autorelease; set 'release.calculation = \"autorelease\"' instead",
+				component.GetName())
+		}
+
 		slog.Debug("Spec uses %%autorelease; skipping static release bump",
 			"component", component.GetName())
 
 		return nil
 	}
 
-	return p.applyStaticBump(component, specPath, releaseValue, commitCount)
-}
-
-// bumpStaticRelease unconditionally bumps the static integer release.
-func (p *sourcePreparerImpl) bumpStaticRelease(
-	component components.Component,
-	sourcesDirPath string,
-	commitCount int,
-) error {
-	specPath, err := p.resolveSpecPath(component, sourcesDirPath)
-	if err != nil {
-		return err
-	}
-
-	releaseValue, err := GetReleaseTagValue(p.fs, specPath)
-	if err != nil {
-		return fmt.Errorf("failed to read Release tag for component %#q:\n%w",
-			component.GetName(), err)
-	}
-
-	return p.applyStaticBump(component, specPath, releaseValue, commitCount)
-}
-
-// applyStaticBump bumps a static integer release value and writes the result back to the spec.
-func (p *sourcePreparerImpl) applyStaticBump(
-	component components.Component,
-	specPath, releaseValue string,
-	commitCount int,
-) error {
 	newRelease, err := BumpStaticRelease(releaseValue, commitCount)
 	if err != nil {
 		return fmt.Errorf(

--- a/internal/app/azldev/core/sources/release.go
+++ b/internal/app/azldev/core/sources/release.go
@@ -91,34 +91,53 @@ func BumpStaticRelease(releaseValue string, commitCount int) (string, error) {
 	return fmt.Sprintf("%d%s", newRelease, suffix), nil
 }
 
-// tryBumpStaticRelease checks whether the component's spec uses %autorelease.
-// If not, it bumps the static Release tag by commitCount and applies the change
-// as an overlay to the spec file in-place. This ensures that components with static
-// release numbers get deterministic version bumps matching the number of synthetic
-// commits applied from the project repository.
+// tryBumpStaticRelease manages the Release tag based on the component's release
+// calculation mode. It may bump, skip, or auto-detect depending on configuration:
 //
-// When the component's release calculation is "manual", this function is a no-op.
-//
-// When the spec uses %autorelease, this function is a no-op because rpmautospec
-// already resolves the release number from git history.
-//
-// When the Release tag uses a non-standard value (not %autorelease and not a leading
-// integer, e.g. %{pkg_release}), the component must set release.calculation to
-// "manual", and likely define an explicit overlay that sets the Release tag.
-// If a non-standard Release is found and release.calculation is not "manual",
-// an error is returned.
+//   - "manual":      no-op — component manages its own release numbering.
+//   - "autorelease": no-op — rpmautospec resolves the release from git history.
+//   - "static":      always bumps the static integer release by commitCount.
+//   - "auto":        auto-detects from the spec's Release tag value; skips if
+//     %autorelease is found, otherwise bumps the static integer.
 func (p *sourcePreparerImpl) tryBumpStaticRelease(
 	component components.Component,
 	sourcesDirPath string,
 	commitCount int,
 ) error {
-	if component.GetConfig().Release.Calculation == projectconfig.ReleaseCalculationManual {
+	calc := component.GetConfig().Release.Calculation
+
+	switch calc {
+	case projectconfig.ReleaseCalculationManual:
 		slog.Debug("Component uses manual release calculation; skipping static release bump",
 			"component", component.GetName())
 
 		return nil
-	}
 
+	case projectconfig.ReleaseCalculationAutorelease:
+		slog.Debug("Component uses autorelease calculation; skipping static release bump",
+			"component", component.GetName())
+
+		return nil
+
+	case projectconfig.ReleaseCalculationStatic:
+		return p.bumpStaticRelease(component, sourcesDirPath, commitCount)
+
+	case projectconfig.ReleaseCalculationAuto:
+		return p.autoBumpStaticRelease(component, sourcesDirPath, commitCount)
+
+	default:
+		return fmt.Errorf("component %#q has unknown release calculation mode %#q",
+			component.GetName(), calc)
+	}
+}
+
+// autoBumpStaticRelease auto-detects the release mode from the spec's Release tag value.
+// If the tag uses %autorelease, it's a no-op. Otherwise it attempts a static bump.
+func (p *sourcePreparerImpl) autoBumpStaticRelease(
+	component components.Component,
+	sourcesDirPath string,
+	commitCount int,
+) error {
 	specPath, err := p.resolveSpecPath(component, sourcesDirPath)
 	if err != nil {
 		return err
@@ -137,10 +156,37 @@ func (p *sourcePreparerImpl) tryBumpStaticRelease(
 		return nil
 	}
 
+	return p.applyStaticBump(component, specPath, releaseValue, commitCount)
+}
+
+// bumpStaticRelease unconditionally bumps the static integer release.
+func (p *sourcePreparerImpl) bumpStaticRelease(
+	component components.Component,
+	sourcesDirPath string,
+	commitCount int,
+) error {
+	specPath, err := p.resolveSpecPath(component, sourcesDirPath)
+	if err != nil {
+		return err
+	}
+
+	releaseValue, err := GetReleaseTagValue(p.fs, specPath)
+	if err != nil {
+		return fmt.Errorf("failed to read Release tag for component %#q:\n%w",
+			component.GetName(), err)
+	}
+
+	return p.applyStaticBump(component, specPath, releaseValue, commitCount)
+}
+
+// applyStaticBump bumps a static integer release value and writes the result back to the spec.
+func (p *sourcePreparerImpl) applyStaticBump(
+	component components.Component,
+	specPath, releaseValue string,
+	commitCount int,
+) error {
 	newRelease, err := BumpStaticRelease(releaseValue, commitCount)
 	if err != nil {
-		// The Release tag does not start with an integer (e.g. %{pkg_release})
-		// and the user did not set release.calculation to "manual".
 		return fmt.Errorf(
 			"component %#q has a non-standard Release tag value %#q that cannot be auto-bumped; "+
 				"set 'release.calculation = \"manual\"' in the component configuration "+

--- a/internal/app/azldev/core/sources/release_internal_test.go
+++ b/internal/app/azldev/core/sources/release_internal_test.go
@@ -195,5 +195,5 @@ func TestTryBumpStaticRelease_ExplicitStaticErrorsOnAutorelease(t *testing.T) {
 
 	err := preparer.tryBumpStaticRelease(comp, filepath.Join(testSourcesDir, "test-pkg"), 3)
 	require.Error(t, err)
-	assert.Contains(t, err.Error(), "cannot be auto-bumped")
+	assert.Contains(t, err.Error(), `release.calculation = "autorelease"`)
 }

--- a/internal/app/azldev/core/sources/release_internal_test.go
+++ b/internal/app/azldev/core/sources/release_internal_test.go
@@ -138,3 +138,62 @@ func TestTryBumpStaticRelease_NonStandardSucceedsWithManual(t *testing.T) {
 	err := preparer.tryBumpStaticRelease(comp, filepath.Join(testSourcesDir, "kernel"), 3)
 	require.NoError(t, err)
 }
+
+func TestTryBumpStaticRelease_ExplicitAutoreleaseSkips(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	memFS := afero.NewMemMapFs()
+	preparer := newTestPreparer(memFS)
+
+	// Spec has a static release, but config says autorelease — should skip.
+	comp := mockComponent(ctrl, "gvisor", &projectconfig.ComponentConfig{
+		Release: projectconfig.ReleaseConfig{
+			Calculation: projectconfig.ReleaseCalculationAutorelease,
+		},
+	})
+
+	// No spec file needed — should skip before reading anything.
+	err := preparer.tryBumpStaticRelease(comp, testSourcesDir, 3)
+	require.NoError(t, err)
+}
+
+func TestTryBumpStaticRelease_ExplicitStaticBumps(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	memFS := afero.NewMemMapFs()
+	preparer := newTestPreparer(memFS)
+
+	writeTestSpec(t, memFS, "test-pkg", "1%{?dist}")
+
+	comp := mockComponent(ctrl, "test-pkg", &projectconfig.ComponentConfig{
+		Release: projectconfig.ReleaseConfig{
+			Calculation: projectconfig.ReleaseCalculationStatic,
+		},
+	})
+
+	err := preparer.tryBumpStaticRelease(comp, filepath.Join(testSourcesDir, "test-pkg"), 3)
+	require.NoError(t, err)
+
+	// Verify the spec was updated.
+	specPath := filepath.Join(testSourcesDir, "test-pkg", "test-pkg.spec")
+	content, err := fileutils.ReadFile(memFS, specPath)
+	require.NoError(t, err)
+	assert.Contains(t, string(content), "Release: 4%{?dist}")
+}
+
+func TestTryBumpStaticRelease_ExplicitStaticErrorsOnAutorelease(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	memFS := afero.NewMemMapFs()
+	preparer := newTestPreparer(memFS)
+
+	// Spec uses %autorelease, but config says static — should error.
+	writeTestSpec(t, memFS, "test-pkg", "%autorelease")
+
+	comp := mockComponent(ctrl, "test-pkg", &projectconfig.ComponentConfig{
+		Release: projectconfig.ReleaseConfig{
+			Calculation: projectconfig.ReleaseCalculationStatic,
+		},
+	})
+
+	err := preparer.tryBumpStaticRelease(comp, filepath.Join(testSourcesDir, "test-pkg"), 3)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "cannot be auto-bumped")
+}

--- a/internal/projectconfig/component.go
+++ b/internal/projectconfig/component.go
@@ -133,10 +133,21 @@ func (g ComponentGroupConfig) WithAbsolutePaths(referenceDir string) ComponentGr
 type ReleaseCalculation string
 
 const (
-	// ReleaseCalculationAuto is the default. azldev auto-bumps the Release tag based on
-	// synthetic commit history. Static integer releases are incremented; %autorelease
-	// is handled by rpmautospec.
+	// ReleaseCalculationAuto is the default. azldev auto-detects whether the spec uses
+	// %autorelease or a static integer release, and handles each accordingly.
 	ReleaseCalculationAuto ReleaseCalculation = "auto"
+
+	// ReleaseCalculationAutorelease explicitly declares that the spec uses %autorelease.
+	// azldev skips all Release tag manipulation, letting rpmautospec resolve the release
+	// number from git history. Use this for specs with conditional %autorelease/%else
+	// fallbacks that confuse auto-detection.
+	ReleaseCalculationAutorelease ReleaseCalculation = "autorelease"
+
+	// ReleaseCalculationStatic explicitly declares that the spec uses a static integer
+	// release. azldev bumps the integer by the synthetic commit count during rendering.
+	// Use this for specs with conditional Release tags where auto-detection picks the
+	// wrong branch.
+	ReleaseCalculationStatic ReleaseCalculation = "static"
 
 	// ReleaseCalculationManual skips all automatic Release tag manipulation. Use this for
 	// components that manage their own release numbering (e.g. kernel).
@@ -146,7 +157,7 @@ const (
 // ReleaseConfig holds release-related configuration for a component.
 type ReleaseConfig struct {
 	// Calculation controls how the Release tag is managed during rendering.
-	Calculation ReleaseCalculation `toml:"calculation,omitempty" json:"calculation,omitempty" validate:"omitempty,oneof=auto manual" jsonschema:"enum=auto,enum=manual,default=auto,title=Release calculation,description=Controls how the Release tag is managed during rendering. Empty or omitted means auto."`
+	Calculation ReleaseCalculation `toml:"calculation,omitempty" json:"calculation,omitempty" validate:"omitempty,oneof=auto autorelease static manual" jsonschema:"enum=auto,enum=autorelease,enum=static,enum=manual,default=auto,title=Release calculation,description=Controls how the Release tag is managed during rendering. Empty or omitted means auto."`
 }
 
 // ComponentLockData holds resolved lock file state attached to a component at

--- a/internal/projectconfig/component.go
+++ b/internal/projectconfig/component.go
@@ -143,10 +143,10 @@ const (
 	// fallbacks that confuse auto-detection.
 	ReleaseCalculationAutorelease ReleaseCalculation = "autorelease"
 
-	// ReleaseCalculationStatic explicitly declares that the spec uses a static integer
-	// release. azldev bumps the integer by the synthetic commit count during rendering.
-	// Use this for specs with conditional Release tags where auto-detection picks the
-	// wrong branch.
+	// ReleaseCalculationStatic explicitly declares that the spec uses a static
+	// release tag. azldev parses and bumps the release value during rendering.
+	// Use this for specs with conditional Release tags where auto-detection
+	// picks the wrong branch but the static release logic still works correctly.
 	ReleaseCalculationStatic ReleaseCalculation = "static"
 
 	// ReleaseCalculationManual skips all automatic Release tag manipulation. Use this for

--- a/internal/projectconfig/component_test.go
+++ b/internal/projectconfig/component_test.go
@@ -228,6 +228,16 @@ func TestReleaseCalculationValidation(t *testing.T) {
 		Calculation: projectconfig.ReleaseCalculationManual,
 	}))
 
+	// Explicit "autorelease" is valid.
+	require.NoError(t, validate.Struct(&projectconfig.ReleaseConfig{
+		Calculation: projectconfig.ReleaseCalculationAutorelease,
+	}))
+
+	// Explicit "static" is valid.
+	require.NoError(t, validate.Struct(&projectconfig.ReleaseConfig{
+		Calculation: projectconfig.ReleaseCalculationStatic,
+	}))
+
 	// Invalid value is rejected.
 	require.Error(t, validate.Struct(&projectconfig.ReleaseConfig{
 		Calculation: "manaul",

--- a/scenario/__snapshots__/TestSnapshotsContainer_config_generate-schema_stdout_1.snap
+++ b/scenario/__snapshots__/TestSnapshotsContainer_config_generate-schema_stdout_1.snap
@@ -834,6 +834,8 @@
           "type": "string",
           "enum": [
             "auto",
+            "autorelease",
+            "static",
             "manual"
           ],
           "title": "Release calculation",

--- a/scenario/__snapshots__/TestSnapshots_config_generate-schema_stdout_1.snap
+++ b/scenario/__snapshots__/TestSnapshots_config_generate-schema_stdout_1.snap
@@ -834,6 +834,8 @@
           "type": "string",
           "enum": [
             "auto",
+            "autorelease",
+            "static",
             "manual"
           ],
           "title": "Release calculation",

--- a/schemas/azldev.schema.json
+++ b/schemas/azldev.schema.json
@@ -834,6 +834,8 @@
           "type": "string",
           "enum": [
             "auto",
+            "autorelease",
+            "static",
             "manual"
           ],
           "title": "Release calculation",


### PR DESCRIPTION
Specs with conditional %autorelease/%else fallbacks confuse the auto- detection logic, causing incorrect Release tag updates. Add two new explicit modes to release.calculation config:

- "autorelease": skip all Release manipulation (rpmautospec handles it)
- "static": always bump the static integer release

Existing "auto" (default) and "manual" modes unchanged.

