### PR TITLE
feat(update): add freshness-based skip optimization to component update

### DIFF
--- a/docs/user/reference/cli/azldev_component_update.md
+++ b/docs/user/reference/cli/azldev_component_update.md
@@ -50,6 +50,7 @@ azldev component update [flags]
       --bump                          increment the manual-rebuild counter to trigger a new release
   -p, --component stringArray         Component name pattern
   -g, --component-group stringArray   Component group name
+      --force-recalculate             disable optimizations that skip work for unchanged components
   -h, --help                          help for update
       --skip-lock-validation          skip lock file consistency checks (default true)
   -s, --spec-path stringArray         Spec path

--- a/docs/user/reference/cli/azldev_component_update.md
+++ b/docs/user/reference/cli/azldev_component_update.md
@@ -50,7 +50,7 @@ azldev component update [flags]
       --bump                          increment the manual-rebuild counter to trigger a new release
   -p, --component stringArray         Component name pattern
   -g, --component-group stringArray   Component group name
-      --force-recalculate             disable optimizations that skip work for unchanged components
+      --force-recalculate             force re-resolution of all components, ignoring freshness checks that would skip unchanged components. Use when upstream state may have changed independently of the snapshot time and the new commit is preferred
   -h, --help                          help for update
       --skip-lock-validation          skip lock file consistency checks (default true)
   -s, --spec-path stringArray         Spec path

--- a/internal/app/azldev/cmds/component/update.go
+++ b/internal/app/azldev/cmds/component/update.go
@@ -26,6 +26,10 @@ type UpdateComponentOptions struct {
 	// Bump increments the manual-rebuild counter on matched components'
 	// lock files. Used for mass-rebuild scenarios.
 	Bump bool
+	// ForceRecalculate disables freshness optimizations that skip
+	// re-resolution for unchanged components. When set, all components
+	// are re-resolved regardless of their freshness status.
+	ForceRecalculate bool
 }
 
 func updateOnAppInit(_ *azldev.App, parentCmd *cobra.Command) {
@@ -83,6 +87,8 @@ toolchain bug, static library update). Orphan pruning is skipped under --bump.`,
 
 	cmd.Flags().BoolVar(&options.Bump, "bump", false,
 		"increment the manual-rebuild counter to trigger a new release")
+	cmd.Flags().BoolVar(&options.ForceRecalculate, "force-recalculate", false,
+		"disable optimizations that skip work for unchanged components")
 
 	return cmd
 }
@@ -116,6 +122,11 @@ func UpdateComponents(env *azldev.Env, options *UpdateComponentOptions) ([]Updat
 	// Suppress staleness warnings — we're about to refresh the locks ourselves,
 	// so warning the user to "run component update" would be self-referential noise.
 	resolver.SuppressLockWarnings = true
+	// Enable freshness checking so the resolver computes FreshnessStatus for
+	// each component. This lets resolveSourceIdentitiesParallel skip
+	// re-resolution for components whose resolution inputs haven't changed.
+	// Disabled when --force-recalculate is set.
+	resolver.CheckFreshness = !options.ForceRecalculate
 
 	resolved, err := resolver.FindComponents(&options.ComponentFilter)
 	if err != nil {
@@ -217,7 +228,7 @@ func saveComponentLocks(env *azldev.Env, store *lockfile.Store, results []Update
 	}()
 
 	for idx := range results {
-		if results[idx].Error != "" || results[idx].Skipped {
+		if results[idx].Error != "" || results[idx].Skipped || results[idx].config == nil {
 			continue
 		}
 
@@ -287,15 +298,27 @@ func updateComponentLock(env *azldev.Env, store *lockfile.Store, result *UpdateR
 	}
 
 	// Mark as changed if fingerprint differs (catches config/overlay edits
-	// even when the upstream commit is unchanged).
+	// even when the upstream commit is unchanged). This is the user-visible
+	// "changed" flag — it drives render/build decisions.
 	if lock.InputFingerprint != identity.Fingerprint {
 		result.Changed = true
 	}
 
 	lock.InputFingerprint = identity.Fingerprint
 
-	// Only write if something actually changed.
-	if !result.Changed {
+	// Update resolution input hash (snapshot, distro ref, branch, pin).
+	resInputs, resErr := buildUpstreamCommitResolutionInputs(env, result.config)
+	if resErr != nil {
+		return false, fmt.Errorf("building resolution inputs for %#q:\n%w", result.Component, resErr)
+	}
+
+	resHash := fingerprint.ComputeResolutionHash(resInputs)
+	resHashChanged := lock.ResolutionInputHash != resHash
+	lock.ResolutionInputHash = resHash
+
+	// Write if either hash changed. ResolutionInputHash updates are silent
+	// (don't set Changed) since they don't affect build outputs.
+	if !result.Changed && !resHashChanged {
 		return false, nil
 	}
 
@@ -462,7 +485,7 @@ func checkUpdateErrors(results []UpdateResult) error {
 // logUpdateSummary logs the final update summary. Called after saveComponentLocks
 // so that Changed counts reflect fingerprint-only diffs.
 func logUpdateSummary(results []UpdateResult) {
-	var changed, skipped int
+	var changed, skipped, upToDate int
 
 	for idx := range results {
 		switch {
@@ -470,16 +493,21 @@ func logUpdateSummary(results []UpdateResult) {
 			skipped++
 		case results[idx].Changed:
 			changed++
+		default:
+			upToDate++
 		}
 	}
 
 	slog.Info("Update complete",
 		"total", len(results),
 		"changed", changed,
+		"upToDate", upToDate,
 		"skipped", skipped)
 }
 
 // filterDisplayResults returns changed and skipped results for table display.
+// Up-to-date components (not Changed, not Skipped) are excluded — they
+// represent the common "nothing to do" case and would dominate the output.
 func filterDisplayResults(results []UpdateResult) []UpdateResult {
 	var tableResults []UpdateResult
 
@@ -511,6 +539,41 @@ func resolveSourceIdentitiesParallel(
 	for idx, comp := range comps {
 		results[idx].Component = comp.GetName()
 
+		locked := comp.GetConfig().Locked
+
+		// Three-way freshness check (when lock data is available).
+		// Only applies to upstream components — local components resolve via
+		// filesystem hashing (cheap, no network), so skipping gains little
+		// and their empty UpstreamCommit can't serve as source identity.
+		//
+		// 1. FreshnessCurrent → nothing changed, skip entirely (no re-resolution).
+		// 2. FreshnessStale + resolution fresh → only build inputs changed
+		//    (e.g., overlay edit). Reuse locked commit, but enter save path
+		//    to update the fingerprint.
+		// 3. FreshnessStale + resolution stale → resolution inputs changed
+		//    (e.g., snapshot bump). Must re-resolve upstream.
+		isUpstream := comp.GetConfig().Spec.SourceType == projectconfig.SpecSourceTypeUpstream
+
+		if isUpstream && locked != nil && locked.Freshness == projectconfig.FreshnessCurrent {
+			// Case 1: fully up-to-date — skip.
+			results[idx].UpstreamCommit = locked.UpstreamCommit
+			results[idx].sourceIdentity = comp.GetConfig().EffectiveUpstreamCommit()
+
+			continue
+		}
+
+		if isUpstream && locked != nil && locked.Freshness == projectconfig.FreshnessStale &&
+			!locked.ResolutionStale {
+			// Case 2: build inputs changed but resolution inputs unchanged.
+			// Reuse the locked commit — re-resolving would yield the same hash.
+			results[idx].UpstreamCommit = locked.UpstreamCommit
+			results[idx].sourceIdentity = comp.GetConfig().EffectiveUpstreamCommit()
+			results[idx].config = comp.GetConfig()
+
+			continue
+		}
+
+		// Case 3: resolution stale, unknown, or no lock — must re-resolve.
 		waitGroup.Add(1)
 
 		go func() {
@@ -636,4 +699,36 @@ func resolveReleaseVer(env *azldev.Env, config *projectconfig.ComponentConfig) (
 	}
 
 	return distroVer.ReleaseVer, nil
+}
+
+// buildUpstreamCommitResolutionInputs resolves the effective distro for a component and
+// builds [fingerprint.UpstreamCommitResolutionInputs] for resolution hash computation.
+// Uses the resolved (inherited) config values — not raw spec fields — so
+// that default-distro and distro-version-level snapshots are captured.
+func buildUpstreamCommitResolutionInputs(
+	env *azldev.Env, config *projectconfig.ComponentConfig,
+) (fingerprint.UpstreamCommitResolutionInputs, error) {
+	ref := config.Spec.UpstreamDistro
+	if ref.Name == "" {
+		ref = env.Config().Project.DefaultDistro
+	}
+
+	distroDef, distroVer, err := env.ResolveDistroRef(ref)
+	if err != nil {
+		return fingerprint.UpstreamCommitResolutionInputs{},
+			fmt.Errorf("resolving distro ref %#q:\n%w", ref.Name, err)
+	}
+
+	return fingerprint.UpstreamCommitResolutionInputs{
+		// Use resolved config's snapshot — not ref.Snapshot — because the
+		// snapshot may come from distro-version-level default-component-config
+		// inheritance, which is merged into config.Spec before we get here.
+		Snapshot:          config.Spec.UpstreamDistro.Snapshot,
+		DistroName:        ref.Name,
+		DistroVersion:     ref.Version,
+		DistGitBranch:     distroVer.DistGitBranch,
+		DistGitBaseURI:    distroDef.DistGitBaseURI,
+		UpstreamCommitPin: config.Spec.UpstreamCommit,
+		UpstreamName:      config.Spec.UpstreamName,
+	}, nil
 }

--- a/internal/app/azldev/cmds/component/update.go
+++ b/internal/app/azldev/cmds/component/update.go
@@ -88,7 +88,10 @@ toolchain bug, static library update). Orphan pruning is skipped under --bump.`,
 	cmd.Flags().BoolVar(&options.Bump, "bump", false,
 		"increment the manual-rebuild counter to trigger a new release")
 	cmd.Flags().BoolVar(&options.ForceRecalculate, "force-recalculate", false,
-		"disable optimizations that skip work for unchanged components")
+		"force re-resolution of all components, ignoring freshness checks that "+
+			"would skip unchanged components. Use when upstream state may have "+
+			"changed independently of the snapshot time and the new commit is "+
+			"preferred")
 
 	return cmd
 }
@@ -113,6 +116,12 @@ type UpdateResult struct {
 	// for local components this is a content hash of the spec directory.
 	// Used as SourceIdentity input for fingerprint computation.
 	sourceIdentity string `json:"-" table:"-"`
+
+	// upToDate is set by the freshness check (Case 1) when both the input
+	// fingerprint and resolution hash match the lock. Components marked
+	// upToDate are skipped by [saveComponentLocks] — no re-fingerprinting
+	// or lock rewrite is needed.
+	upToDate bool `json:"-" table:"-"`
 }
 
 // UpdateComponents resolves source identities for all selected components and
@@ -228,7 +237,7 @@ func saveComponentLocks(env *azldev.Env, store *lockfile.Store, results []Update
 	}()
 
 	for idx := range results {
-		if results[idx].Error != "" || results[idx].Skipped || results[idx].config == nil {
+		if results[idx].Error != "" || results[idx].Skipped || results[idx].upToDate {
 			continue
 		}
 
@@ -306,15 +315,8 @@ func updateComponentLock(env *azldev.Env, store *lockfile.Store, result *UpdateR
 
 	lock.InputFingerprint = identity.Fingerprint
 
-	// Update resolution input hash (snapshot, distro ref, branch, pin).
-	resInputs, resErr := buildUpstreamCommitResolutionInputs(env, result.config)
-	if resErr != nil {
-		return false, fmt.Errorf("building resolution inputs for %#q:\n%w", result.Component, resErr)
-	}
-
-	resHash := fingerprint.ComputeResolutionHash(resInputs)
-	resHashChanged := lock.ResolutionInputHash != resHash
-	lock.ResolutionInputHash = resHash
+	// Update resolution input hash for upstream components.
+	resHashChanged := updateResolutionHash(env, result.config, lock)
 
 	// Write if either hash changed. ResolutionInputHash updates are silent
 	// (don't set Changed) since they don't affect build outputs.
@@ -327,6 +329,31 @@ func updateComponentLock(env *azldev.Env, store *lockfile.Store, result *UpdateR
 	}
 
 	return true, nil
+}
+
+// updateResolutionHash computes and stores the resolution input hash for
+// upstream components. Returns true if the hash changed. Local components
+// don't use upstream resolution, so the hash is left empty for them.
+func updateResolutionHash(
+	env *azldev.Env, config *projectconfig.ComponentConfig, lock *lockfile.ComponentLock,
+) bool {
+	if config.Spec.SourceType != projectconfig.SpecSourceTypeUpstream {
+		return false
+	}
+
+	resInputs, resErr := components.BuildUpstreamCommitResolutionInputs(env, config)
+	if resErr != nil {
+		slog.Debug("Cannot compute resolution hash",
+			"component", config.Name, "error", resErr)
+
+		return false
+	}
+
+	resHash := fingerprint.ComputeResolutionHash(resInputs)
+	changed := lock.ResolutionInputHash != resHash
+	lock.ResolutionInputHash = resHash
+
+	return changed
 }
 
 // bumpComponents re-fingerprints each matched component's lock file with an
@@ -558,15 +585,17 @@ func resolveSourceIdentitiesParallel(
 			// Case 1: fully up-to-date — skip.
 			results[idx].UpstreamCommit = locked.UpstreamCommit
 			results[idx].sourceIdentity = comp.GetConfig().EffectiveUpstreamCommit()
+			results[idx].upToDate = true
 
 			continue
 		}
 
 		if isUpstream && locked != nil && locked.Freshness == projectconfig.FreshnessStale &&
-			!locked.ResolutionStale {
+			!locked.ResolutionStale && locked.UpstreamCommit != "" {
 			// Case 2: build inputs changed but resolution inputs unchanged.
 			// Reuse the locked commit — re-resolving would yield the same hash.
 			results[idx].UpstreamCommit = locked.UpstreamCommit
+			results[idx].PreviousCommit = locked.UpstreamCommit
 			results[idx].sourceIdentity = comp.GetConfig().EffectiveUpstreamCommit()
 			results[idx].config = comp.GetConfig()
 
@@ -699,36 +728,4 @@ func resolveReleaseVer(env *azldev.Env, config *projectconfig.ComponentConfig) (
 	}
 
 	return distroVer.ReleaseVer, nil
-}
-
-// buildUpstreamCommitResolutionInputs resolves the effective distro for a component and
-// builds [fingerprint.UpstreamCommitResolutionInputs] for resolution hash computation.
-// Uses the resolved (inherited) config values — not raw spec fields — so
-// that default-distro and distro-version-level snapshots are captured.
-func buildUpstreamCommitResolutionInputs(
-	env *azldev.Env, config *projectconfig.ComponentConfig,
-) (fingerprint.UpstreamCommitResolutionInputs, error) {
-	ref := config.Spec.UpstreamDistro
-	if ref.Name == "" {
-		ref = env.Config().Project.DefaultDistro
-	}
-
-	distroDef, distroVer, err := env.ResolveDistroRef(ref)
-	if err != nil {
-		return fingerprint.UpstreamCommitResolutionInputs{},
-			fmt.Errorf("resolving distro ref %#q:\n%w", ref.Name, err)
-	}
-
-	return fingerprint.UpstreamCommitResolutionInputs{
-		// Use resolved config's snapshot — not ref.Snapshot — because the
-		// snapshot may come from distro-version-level default-component-config
-		// inheritance, which is merged into config.Spec before we get here.
-		Snapshot:          config.Spec.UpstreamDistro.Snapshot,
-		DistroName:        ref.Name,
-		DistroVersion:     ref.Version,
-		DistGitBranch:     distroVer.DistGitBranch,
-		DistGitBaseURI:    distroDef.DistGitBaseURI,
-		UpstreamCommitPin: config.Spec.UpstreamCommit,
-		UpstreamName:      config.Spec.UpstreamName,
-	}, nil
 }

--- a/internal/app/azldev/cmds/component/update_freshness_test.go
+++ b/internal/app/azldev/cmds/component/update_freshness_test.go
@@ -1,0 +1,407 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+package component_test
+
+import (
+	"os/exec"
+	"strings"
+	"sync/atomic"
+	"testing"
+
+	componentcmds "github.com/microsoft/azure-linux-dev-tools/internal/app/azldev/cmds/component"
+	"github.com/microsoft/azure-linux-dev-tools/internal/app/azldev/core/components"
+	"github.com/microsoft/azure-linux-dev-tools/internal/app/azldev/core/testutils"
+	"github.com/microsoft/azure-linux-dev-tools/internal/lockfile"
+	"github.com/microsoft/azure-linux-dev-tools/internal/projectconfig"
+	"github.com/microsoft/azure-linux-dev-tools/internal/utils/fileutils"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const testComponentName = "curl"
+
+// setupMockGitWithCounter configures mock git that tracks all git command invocations.
+// Returns a pointer to the atomic counter so tests can assert network usage.
+// Any git command (clone, rev-list, rev-parse) counts as "network" since the
+// Fedora source provider needs network access for all of them.
+func setupMockGitWithCounter(env *testutils.TestEnv, commitHash string) *atomic.Int32 {
+	var gitCalls atomic.Int32
+
+	env.CmdFactory.RegisterCommandInSearchPath("git")
+
+	env.CmdFactory.RunHandler = func(cmd *exec.Cmd) error {
+		gitCalls.Add(1)
+
+		args := cmd.Args
+
+		for _, arg := range args {
+			if arg == "clone" {
+				destDir := args[len(args)-1]
+				_ = fileutils.MkdirAll(env.TestFS, destDir)
+
+				return nil
+			}
+
+			if arg == "checkout" {
+				return nil
+			}
+		}
+
+		return nil
+	}
+
+	env.CmdFactory.RunAndGetOutputHandler = func(cmd *exec.Cmd) (string, error) {
+		gitCalls.Add(1)
+
+		if strings.Contains(strings.Join(cmd.Args, " "), "rev-parse") {
+			return commitHash, nil
+		}
+
+		if strings.Contains(strings.Join(cmd.Args, " "), "rev-list") {
+			return commitHash, nil
+		}
+
+		return "", nil
+	}
+
+	return &gitCalls
+}
+
+// allComponentsFilter returns a filter for all components with lock validation skipped.
+func allComponentsFilter() *componentcmds.UpdateComponentOptions {
+	return &componentcmds.UpdateComponentOptions{
+		ComponentFilter: components.ComponentFilter{IncludeAllComponents: true},
+	}
+}
+
+// initialUpdate runs the first update to establish lock files. Returns the
+// initial fingerprint and resolution hash for the named component.
+func initialUpdate(
+	t *testing.T, env *testutils.TestEnv,
+) (fingerprint, resHash string) {
+	t.Helper()
+
+	require.NoError(t, fileutils.MkdirAll(env.TestFS, testLockDir))
+
+	results, err := componentcmds.UpdateComponents(env.Env, allComponentsFilter())
+	require.NoError(t, err)
+	require.NotEmpty(t, results, "initial update should produce results")
+
+	store := lockfile.NewStore(env.TestFS, testLockDir)
+
+	lock, lockErr := store.Get(testComponentName)
+	require.NoError(t, lockErr)
+	require.NotEmpty(t, lock.InputFingerprint, "initial lock should have fingerprint")
+	require.NotEmpty(t, lock.ResolutionInputHash, "initial lock should have resolution hash")
+
+	return lock.InputFingerprint, lock.ResolutionInputHash
+}
+
+// TestFreshness_NothingChanged_SkipsNetwork verifies Case 1: when nothing
+// changed between updates, no git clones happen and the lock is untouched.
+func TestFreshness_NothingChanged_SkipsNetwork(t *testing.T) {
+	env := testutils.NewTestEnv(t)
+
+	const commit = "aabbccdd11223344"
+
+	gitCalls := setupMockGitWithCounter(env, commit)
+	addUpstreamComponent(env, testComponentName)
+	setDistroSnapshot(env, "2025-01-01T00:00:00Z")
+
+	fpBefore, resHashBefore := initialUpdate(t, env)
+
+	// Reset clone counter after initial update.
+	initialClones := gitCalls.Load()
+	require.Positive(t, initialClones, "initial update must do at least one clone")
+
+	gitCalls.Store(0)
+
+	// Second update — nothing changed.
+	results, err := componentcmds.UpdateComponents(env.Env, allComponentsFilter())
+	require.NoError(t, err)
+
+	// No git clones should have happened.
+	assert.Equal(t, int32(0), gitCalls.Load(),
+		"no git calls expected when nothing changed")
+
+	// No results in display (up-to-date filtered out).
+	for _, r := range results {
+		if r.Component == testComponentName {
+			assert.False(t, r.Changed, "curl should not be changed")
+			assert.False(t, r.Skipped, "curl should not be skipped")
+		}
+	}
+
+	// Lock file should be identical.
+	store := lockfile.NewStore(env.TestFS, testLockDir)
+
+	lock, lockErr := store.Get("curl")
+	require.NoError(t, lockErr)
+	assert.Equal(t, fpBefore, lock.InputFingerprint, "fingerprint should be unchanged")
+	assert.Equal(t, resHashBefore, lock.ResolutionInputHash, "resolution hash should be unchanged")
+	assert.Equal(t, commit, lock.UpstreamCommit, "commit should be unchanged")
+}
+
+// setDistroSnapshot updates the test distro version's default-component-config
+// snapshot. This mirrors how real projects set snapshots in distro.toml.
+func setDistroSnapshot(env *testutils.TestEnv, snapshot string) {
+	distro := env.Config.Distros["test-distro"]
+
+	version := distro.Versions["1.0"]
+	version.DefaultComponentConfig.Spec.UpstreamDistro.Snapshot = snapshot
+	distro.Versions["1.0"] = version
+
+	env.Config.Distros["test-distro"] = distro
+}
+
+// TestFreshness_SnapshotChanged_SameCommit_UsesNetwork verifies Case 2: when
+// the snapshot changes but the resolved commit is the same, the system
+// re-resolves (network), updates the resolution hash, but the fingerprint
+// stays the same (commit unchanged → build output unchanged).
+func TestFreshness_SnapshotChanged_SameCommit_UsesNetwork(t *testing.T) {
+	env := testutils.NewTestEnv(t)
+
+	const commit = "aabbccdd11223344"
+
+	gitCalls := setupMockGitWithCounter(env, commit)
+	addUpstreamComponent(env, testComponentName)
+	setDistroSnapshot(env, "2025-01-01T00:00:00Z")
+
+	fpBefore, resHashBefore := initialUpdate(t, env)
+
+	gitCalls.Store(0)
+
+	// Bump snapshot at the distro level — resolution inputs change.
+	setDistroSnapshot(env, "2026-06-15T00:00:00Z")
+
+	// Second update — should re-resolve (network).
+	results, err := componentcmds.UpdateComponents(env.Env, allComponentsFilter())
+	require.NoError(t, err)
+
+	assert.Positive(t, gitCalls.Load(),
+		"git calls expected when snapshot changed")
+
+	// Fingerprint should be UNCHANGED (same commit, snapshot excluded from fingerprint).
+	store := lockfile.NewStore(env.TestFS, testLockDir)
+
+	lock, lockErr := store.Get("curl")
+	require.NoError(t, lockErr)
+	assert.Equal(t, fpBefore, lock.InputFingerprint,
+		"fingerprint should be unchanged (same commit, snapshot excluded)")
+	assert.Equal(t, commit, lock.UpstreamCommit,
+		"commit should be the same (mock returns same hash)")
+
+	// Resolution hash should be CHANGED (snapshot is a resolution input).
+	assert.NotEqual(t, resHashBefore, lock.ResolutionInputHash,
+		"resolution hash should change after snapshot bump")
+
+	// Component should NOT be in display results as "changed" (fingerprint same).
+	for _, r := range results {
+		if r.Component == testComponentName {
+			assert.False(t, r.Changed,
+				"curl should not be marked changed (fingerprint unchanged)")
+		}
+	}
+}
+
+// TestFreshness_OverlayChanged_SkipsNetwork verifies Case 3: when only build
+// inputs change (overlay edit) but resolution inputs are unchanged, the system
+// reuses the locked commit (no network) and updates the fingerprint.
+func TestFreshness_OverlayChanged_SkipsNetwork(t *testing.T) {
+	env := testutils.NewTestEnv(t)
+
+	const commit = "aabbccdd11223344"
+
+	gitCalls := setupMockGitWithCounter(env, commit)
+	addUpstreamComponent(env, testComponentName)
+	setDistroSnapshot(env, "2025-01-01T00:00:00Z")
+
+	fpBefore, resHashBefore := initialUpdate(t, env)
+
+	gitCalls.Store(0)
+
+	// Add a build option — changes fingerprint but not resolution inputs.
+	modifiedConfig := env.Config.Components["curl"]
+	modifiedConfig.Build.With = []string{"ssl"}
+	env.Config.Components["curl"] = modifiedConfig
+
+	// Second update — should NOT re-resolve.
+	results, err := componentcmds.UpdateComponents(env.Env, allComponentsFilter())
+	require.NoError(t, err)
+
+	assert.Equal(t, int32(0), gitCalls.Load(),
+		"no git calls expected when only build inputs changed")
+
+	// Fingerprint should be CHANGED (build input added).
+	store := lockfile.NewStore(env.TestFS, testLockDir)
+
+	lock, lockErr := store.Get("curl")
+	require.NoError(t, lockErr)
+	assert.NotEqual(t, fpBefore, lock.InputFingerprint,
+		"fingerprint should change after build input change")
+	assert.Equal(t, commit, lock.UpstreamCommit,
+		"commit should be unchanged (reused from lock)")
+
+	// Resolution hash should be UNCHANGED.
+	assert.Equal(t, resHashBefore, lock.ResolutionInputHash,
+		"resolution hash should be unchanged (no resolution input changed)")
+
+	// Component SHOULD be in display results as "changed".
+	foundChanged := false
+
+	for _, r := range results {
+		if r.Component == testComponentName && r.Changed {
+			foundChanged = true
+		}
+	}
+
+	assert.True(t, foundChanged,
+		"curl should appear as changed in results (fingerprint differs)")
+}
+
+// TestFreshness_SnapshotChanged_DifferentCommit verifies Case 4: when
+// snapshot changes AND the resolved commit is different, both the
+// resolution hash and fingerprint should change.
+func TestFreshness_SnapshotChanged_DifferentCommit(t *testing.T) {
+	env := testutils.NewTestEnv(t)
+
+	const (
+		initialCommit = "aabbccdd11223344"
+		newCommit     = "eeff00112233aabb"
+	)
+
+	gitCalls := setupMockGitWithCounter(env, initialCommit)
+	addUpstreamComponent(env, testComponentName)
+	setDistroSnapshot(env, "2025-01-01T00:00:00Z")
+
+	fpBefore, resHashBefore := initialUpdate(t, env)
+
+	gitCalls.Store(0)
+
+	// Bump snapshot AND change the commit the mock returns.
+	gitCalls = setupMockGitWithCounter(env, newCommit)
+	setDistroSnapshot(env, "2026-06-15T00:00:00Z")
+
+	results, err := componentcmds.UpdateComponents(env.Env, allComponentsFilter())
+	require.NoError(t, err)
+
+	assert.Positive(t, gitCalls.Load(),
+		"git calls expected when snapshot changed")
+
+	store := lockfile.NewStore(env.TestFS, testLockDir)
+
+	lock, lockErr := store.Get("curl")
+	require.NoError(t, lockErr)
+
+	// Everything should change.
+	assert.Equal(t, newCommit, lock.UpstreamCommit,
+		"commit should be the new one")
+	assert.NotEqual(t, fpBefore, lock.InputFingerprint,
+		"fingerprint should change (different commit)")
+	assert.NotEqual(t, resHashBefore, lock.ResolutionInputHash,
+		"resolution hash should change (snapshot bumped)")
+
+	// Component should be marked changed.
+	foundChanged := false
+
+	for _, r := range results {
+		if r.Component == testComponentName && r.Changed {
+			foundChanged = true
+		}
+	}
+
+	assert.True(t, foundChanged,
+		"curl should appear as changed (new commit → new fingerprint)")
+}
+
+// addLocalComponent registers a local component with a spec file on the test FS.
+func addLocalComponent(env *testutils.TestEnv, name string) {
+	specPath := "/project/specs/" + name + "/" + name + ".spec"
+
+	_ = fileutils.WriteFile(env.TestFS, specPath, []byte("Name: "+name+"\n"), 0o644)
+
+	env.Config.Components[name] = projectconfig.ComponentConfig{
+		Name: name,
+		Spec: projectconfig.SpecSource{
+			SourceType: projectconfig.SpecSourceTypeLocal,
+			Path:       specPath,
+		},
+	}
+}
+
+// TestFreshness_LocalComponent_ReUpdateSucceeds verifies that local components
+// work correctly with the freshness optimization. Local components have no
+// upstream commit — their source identity is a content hash of the spec dir.
+// The freshness path must not try to reuse a locked commit for these.
+// Regression: local components can inherit a snapshot from the distro's
+// default-component-config, which bypasses the HEAD-tracking check and
+// causes the freshness optimizer to try reusing an empty UpstreamCommit
+// as source identity.
+func TestFreshness_LocalComponent_ReUpdateSucceeds(t *testing.T) {
+	env := testutils.NewTestEnv(t)
+
+	setupMockGitWithCounter(env, "doesnt-matter")
+	addLocalComponent(env, "local-pkg")
+
+	// Set a snapshot — this is the key trigger. Local components inherit
+	// the snapshot from the distro's default-component-config. Without this,
+	// the HEAD-tracking check would fire and always re-resolve, masking the bug.
+	setDistroSnapshot(env, "2025-01-01T00:00:00Z")
+
+	require.NoError(t, fileutils.MkdirAll(env.TestFS, testLockDir))
+
+	// Initial update — creates the lock file.
+	results, err := componentcmds.UpdateComponents(env.Env, allComponentsFilter())
+	require.NoError(t, err)
+	require.NotEmpty(t, results)
+
+	store := lockfile.NewStore(env.TestFS, testLockDir)
+
+	lock, lockErr := store.Get("local-pkg")
+	require.NoError(t, lockErr)
+	assert.NotEmpty(t, lock.InputFingerprint, "initial lock should have fingerprint")
+	assert.Empty(t, lock.UpstreamCommit, "local component has no upstream commit")
+
+	// Second update — should succeed, not error with "source identity required".
+	results2, err2 := componentcmds.UpdateComponents(env.Env, allComponentsFilter())
+	require.NoError(t, err2, "re-update of local component must not fail")
+
+	// Local component should not appear as changed (nothing changed).
+	for _, r := range results2 {
+		if r.Component == "local-pkg" {
+			assert.False(t, r.Changed, "unchanged local component should not be marked changed")
+		}
+	}
+}
+
+// TestFreshness_LocalComponent_LegacyLock_ReUpdateSucceeds reproduces the exact
+// failure path: a local component with an inherited snapshot and a legacy lock
+// file (has InputFingerprint but no ResolutionInputHash). The legacy migration
+// path sets ResolutionStale=false to trigger Case 2 (reuse commit, backfill
+// hash), but Case 2 fails for local components because UpstreamCommit is empty
+// and ComputeIdentity requires a non-empty source identity.
+func TestFreshness_LocalComponent_LegacyLock_ReUpdateSucceeds(t *testing.T) {
+	env := testutils.NewTestEnv(t)
+
+	setupMockGitWithCounter(env, "doesnt-matter")
+	addLocalComponent(env, "local-pkg")
+	setDistroSnapshot(env, "2025-01-01T00:00:00Z")
+
+	require.NoError(t, fileutils.MkdirAll(env.TestFS, testLockDir))
+
+	// Write a legacy lock directly — has InputFingerprint but no
+	// ResolutionInputHash, simulating a lock created before the freshness
+	// feature existed. Must use WriteLock before any UpdateComponents call
+	// so the store cache isn't contaminated with a full lock.
+	legacyLock := lockfile.New()
+	legacyLock.InputFingerprint = "sha256:placeholder-will-differ"
+	env.WriteLock(t, "local-pkg", legacyLock)
+
+	// Update with legacy lock — must not error with
+	// "source identity is required for component with source type local".
+	_, err := componentcmds.UpdateComponents(env.Env, allComponentsFilter())
+	require.NoError(t, err,
+		"update of local component with legacy lock must not fail "+
+			"(was: 'source identity is required for component with source type local')")
+}

--- a/internal/app/azldev/cmds/component/update_freshness_test.go
+++ b/internal/app/azldev/cmds/component/update_freshness_test.go
@@ -23,8 +23,13 @@ const testComponentName = "curl"
 
 // setupMockGitWithCounter configures mock git that tracks all git command invocations.
 // Returns a pointer to the atomic counter so tests can assert network usage.
-// Any git command (clone, rev-list, rev-parse) counts as "network" since the
-// Fedora source provider needs network access for all of them.
+//
+// The counter treats every git invocation (clone, rev-list, rev-parse, etc.)
+// as a single signal because the Fedora source provider chains multiple git
+// commands per resolution (clone → rev-list/rev-parse). Tests reset the
+// counter between updates and assert zero vs. positive — not exact counts —
+// so the signal is robust against internal provider changes that add or
+// reorder git calls.
 func setupMockGitWithCounter(env *testutils.TestEnv, commitHash string) *atomic.Int32 {
 	var gitCalls atomic.Int32
 
@@ -404,4 +409,107 @@ func TestFreshness_LocalComponent_LegacyLock_ReUpdateSucceeds(t *testing.T) {
 	require.NoError(t, err,
 		"update of local component with legacy lock must not fail "+
 			"(was: 'source identity is required for component with source type local')")
+}
+
+// TestFreshness_ForceRecalculate_BypassesFreshness verifies that
+// --force-recalculate causes all components to be re-resolved even when
+// their freshness status says they're current.
+func TestFreshness_ForceRecalculate_BypassesFreshness(t *testing.T) {
+	env := testutils.NewTestEnv(t)
+
+	const commit = "aabbccdd11223344"
+
+	gitCalls := setupMockGitWithCounter(env, commit)
+	addUpstreamComponent(env, testComponentName)
+	setDistroSnapshot(env, "2025-01-01T00:00:00Z")
+
+	_, _ = initialUpdate(t, env)
+
+	gitCalls.Store(0)
+
+	// Second update with --force-recalculate — should re-resolve even
+	// though nothing changed.
+	opts := allComponentsFilter()
+	opts.ForceRecalculate = true
+
+	_, err := componentcmds.UpdateComponents(env.Env, opts)
+	require.NoError(t, err)
+
+	assert.Positive(t, gitCalls.Load(),
+		"--force-recalculate must bypass freshness and trigger re-resolution")
+}
+
+// TestFreshness_HeadTracking_AlwaysReResolves verifies that upstream
+// components with no snapshot and no pin (HEAD-tracking) always re-resolve.
+// The freshness optimization assumes "same inputs → same commit," which
+// doesn't hold for HEAD-tracking components since upstream pushes change
+// the result without any config edit.
+func TestFreshness_HeadTracking_AlwaysReResolves(t *testing.T) {
+	env := testutils.NewTestEnv(t)
+
+	const commit = "aabbccdd11223344"
+
+	gitCalls := setupMockGitWithCounter(env, commit)
+	addUpstreamComponent(env, testComponentName)
+
+	// Explicitly clear snapshot — HEAD-tracking means no snapshot, no pin.
+	setDistroSnapshot(env, "")
+
+	require.NoError(t, fileutils.MkdirAll(env.TestFS, testLockDir))
+
+	// Initial update.
+	_, err := componentcmds.UpdateComponents(env.Env, allComponentsFilter())
+	require.NoError(t, err)
+
+	gitCalls.Store(0)
+
+	// Second update — nothing changed in config, but HEAD-tracking
+	// components must always re-resolve.
+	_, err = componentcmds.UpdateComponents(env.Env, allComponentsFilter())
+	require.NoError(t, err)
+
+	assert.Positive(t, gitCalls.Load(),
+		"HEAD-tracking component (no snapshot/pin) must always re-resolve")
+}
+
+// TestFreshness_UpstreamLegacyLock_ReResolves verifies that upstream
+// components with a legacy lock file (InputFingerprint set but no
+// ResolutionInputHash) trigger a full re-resolution to backfill the hash.
+// Without this, legacy locks would be permanently treated as "current"
+// because the empty-hash comparison was skipped.
+func TestFreshness_UpstreamLegacyLock_ReResolves(t *testing.T) {
+	env := testutils.NewTestEnv(t)
+
+	const commit = "aabbccdd11223344"
+
+	gitCalls := setupMockGitWithCounter(env, commit)
+	addUpstreamComponent(env, testComponentName)
+	setDistroSnapshot(env, "2025-01-01T00:00:00Z")
+
+	require.NoError(t, fileutils.MkdirAll(env.TestFS, testLockDir))
+
+	// Write a legacy lock — has fingerprint + commit but no resolution hash.
+	legacyLock := lockfile.New()
+	legacyLock.InputFingerprint = "sha256:legacy-placeholder"
+	legacyLock.UpstreamCommit = commit
+	env.WriteLock(t, testComponentName, legacyLock)
+
+	gitCalls.Store(0)
+
+	// Update with legacy lock — must re-resolve to backfill resolution hash.
+	_, err := componentcmds.UpdateComponents(env.Env, allComponentsFilter())
+	require.NoError(t, err)
+
+	assert.Positive(t, gitCalls.Load(),
+		"upstream component with legacy lock (no resolution hash) must re-resolve")
+
+	// Verify resolution hash was backfilled.
+	store := lockfile.NewStore(env.TestFS, testLockDir)
+
+	lock, lockErr := store.Get(testComponentName)
+	require.NoError(t, lockErr)
+	assert.NotEmpty(t, lock.ResolutionInputHash,
+		"resolution hash should be populated after re-resolution")
+	assert.Equal(t, commit, lock.UpstreamCommit,
+		"commit should be unchanged (mock returns same hash)")
 }

--- a/internal/app/azldev/cmds/component/update_internal_test.go
+++ b/internal/app/azldev/cmds/component/update_internal_test.go
@@ -171,21 +171,21 @@ func TestSaveComponentLocks_SkipsErrorAndSkipped(t *testing.T) {
 	assert.False(t, exists2)
 }
 
-func TestSaveComponentLocks_SkipsNilConfig(t *testing.T) {
+func TestSaveComponentLocks_SkipsUpToDate(t *testing.T) {
 	env := testutils.NewTestEnv(t)
 	store := newTestStore(t, env)
 
-	// nil config means the component was skipped by freshness check —
+	// upToDate means the component was skipped by freshness check (Case 1) —
 	// saveComponentLocks should silently skip it, not error.
 	results := []UpdateResult{
-		{Component: "skipped-fresh", UpstreamCommit: "abc", config: nil},
+		{Component: "skipped-fresh", UpstreamCommit: "abc", upToDate: true},
 	}
 
 	err := saveComponentLocks(env.Env, store, results)
 	require.NoError(t, err)
 
 	exists, _ := store.Exists("skipped-fresh")
-	assert.False(t, exists, "nil-config component should not get a lock file")
+	assert.False(t, exists, "upToDate component should not get a lock file")
 }
 
 func TestSaveComponentLocks_PreservesManualBump(t *testing.T) {

--- a/internal/app/azldev/cmds/component/update_internal_test.go
+++ b/internal/app/azldev/cmds/component/update_internal_test.go
@@ -171,17 +171,21 @@ func TestSaveComponentLocks_SkipsErrorAndSkipped(t *testing.T) {
 	assert.False(t, exists2)
 }
 
-func TestSaveComponentLocks_ErrorOnNilConfig(t *testing.T) {
+func TestSaveComponentLocks_SkipsNilConfig(t *testing.T) {
 	env := testutils.NewTestEnv(t)
 	store := newTestStore(t, env)
 
+	// nil config means the component was skipped by freshness check —
+	// saveComponentLocks should silently skip it, not error.
 	results := []UpdateResult{
-		{Component: "bad", UpstreamCommit: "abc", Changed: true, config: nil},
+		{Component: "skipped-fresh", UpstreamCommit: "abc", config: nil},
 	}
 
 	err := saveComponentLocks(env.Env, store, results)
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "no resolved config")
+	require.NoError(t, err)
+
+	exists, _ := store.Exists("skipped-fresh")
+	assert.False(t, exists, "nil-config component should not get a lock file")
 }
 
 func TestSaveComponentLocks_PreservesManualBump(t *testing.T) {

--- a/internal/app/azldev/core/components/resolver.go
+++ b/internal/app/azldev/core/components/resolver.go
@@ -585,13 +585,20 @@ func (r *Resolver) computeFreshnessStatus(config *projectconfig.ComponentConfig)
 		return
 	}
 
+	// Freshness optimization only applies to upstream components. Local
+	// components resolve via filesystem hashing (cheap), and their empty
+	// UpstreamCommit can't serve as source identity for fingerprint checks.
+	if config.Spec.SourceType != projectconfig.SpecSourceTypeUpstream {
+		return
+	}
+
 	// Need at least one stored hash to compare against.
 	if config.Locked.InputFingerprint == "" && config.Locked.ResolutionInputHash == "" {
 		return
 	}
 
 	// Check resolution inputs (cheap, no I/O beyond distro resolution).
-	resInputs, resolveErr := r.buildUpstreamCommitResolutionInputs(config)
+	resInputs, resolveErr := BuildUpstreamCommitResolutionInputs(r.env, config)
 	if resolveErr != nil {
 		slog.Debug("Cannot compute resolution hash (distro resolve failed)",
 			"component", config.Name, "error", resolveErr)
@@ -619,13 +626,14 @@ func (r *Resolver) computeFreshnessStatus(config *projectconfig.ComponentConfig)
 
 	switch {
 	case config.Locked.ResolutionInputHash == "":
-		// Legacy lock — ResolutionInputHash was not populated. Force one
-		// re-resolution to backfill the field. Use ResolutionStale=false
-		// so Case 2 fires (reuse commit, update hashes) rather than
-		// Case 3 (full re-resolve), since the commit is likely still valid.
+		// Legacy lock — ResolutionInputHash was not populated. Force full
+		// re-resolution to ensure the commit matches current resolution
+		// inputs. The old commit may have been resolved under different
+		// snapshot/distro settings.
+		config.Locked.ResolutionStale = true
 		config.Locked.Freshness = projectconfig.FreshnessStale
 
-		slog.Debug("Legacy lock missing resolution hash; will backfill",
+		slog.Debug("Legacy lock missing resolution hash; will re-resolve",
 			"component", config.Name)
 
 		return
@@ -711,19 +719,20 @@ func (r *Resolver) resolveReleaseVer(config *projectconfig.ComponentConfig) (str
 	return distroVer.ReleaseVer, nil
 }
 
-// buildUpstreamCommitResolutionInputs resolves the effective distro and builds the
-// [fingerprint.UpstreamCommitResolutionInputs] struct for resolution hash computation.
-// Uses the resolved (inherited) config values — not raw spec fields — so
-// that default-distro and distro-version-level snapshots are captured.
-func (r *Resolver) buildUpstreamCommitResolutionInputs(
-	config *projectconfig.ComponentConfig,
+// BuildUpstreamCommitResolutionInputs resolves the effective distro for a
+// component and builds [fingerprint.UpstreamCommitResolutionInputs] for
+// resolution hash computation. Uses the resolved (inherited) config values —
+// not raw spec fields — so that default-distro and distro-version-level
+// snapshots are captured.
+func BuildUpstreamCommitResolutionInputs(
+	env *azldev.Env, config *projectconfig.ComponentConfig,
 ) (fingerprint.UpstreamCommitResolutionInputs, error) {
 	ref := config.Spec.UpstreamDistro
 	if ref.Name == "" {
-		ref = r.env.Config().Project.DefaultDistro
+		ref = env.Config().Project.DefaultDistro
 	}
 
-	distroDef, distroVer, err := r.env.ResolveDistroRef(ref)
+	distroDef, distroVer, err := env.ResolveDistroRef(ref)
 	if err != nil {
 		return fingerprint.UpstreamCommitResolutionInputs{}, fmt.Errorf("resolving distro ref %#q:\n%w", ref.Name, err)
 	}

--- a/internal/app/azldev/core/components/resolver.go
+++ b/internal/app/azldev/core/components/resolver.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/bmatcuk/doublestar/v4"
 	"github.com/microsoft/azure-linux-dev-tools/internal/app/azldev"
+	"github.com/microsoft/azure-linux-dev-tools/internal/fingerprint"
 	"github.com/microsoft/azure-linux-dev-tools/internal/projectconfig"
 	"github.com/microsoft/azure-linux-dev-tools/internal/utils/fileutils"
 )
@@ -30,6 +31,17 @@ type Resolver struct {
 	// themselves (e.g., 'component update') to avoid noise telling the user
 	// to do what they're already doing.
 	SuppressLockWarnings bool
+	// CheckFreshness enables fingerprint-based freshness computation during
+	// component resolution. When true, each component's
+	// [projectconfig.ComponentLockData.Freshness] is set based on comparing
+	// stored hashes to recomputed ones. When false (default), freshness
+	// remains [projectconfig.FreshnessUnknown].
+	//
+	// Off by default because most commands (build, render, prepare-sources)
+	// consume locked state as-is and don't need to know whether it's stale.
+	// Only 'component update' enables this — it uses the freshness status to
+	// decide which components need re-resolution and which can be skipped.
+	CheckFreshness bool
 }
 
 // NewResolver constructs a new [Resolver] for the given environment.
@@ -542,13 +554,192 @@ func (r *Resolver) populateFromLock(config *projectconfig.ComponentConfig) {
 	}
 
 	config.Locked = &projectconfig.ComponentLockData{
-		UpstreamCommit:   lock.UpstreamCommit,
-		ImportCommit:     lock.ImportCommit,
-		ManualBump:       lock.ManualBump,
-		InputFingerprint: lock.InputFingerprint,
+		UpstreamCommit:      lock.UpstreamCommit,
+		ImportCommit:        lock.ImportCommit,
+		ManualBump:          lock.ManualBump,
+		InputFingerprint:    lock.InputFingerprint,
+		ResolutionInputHash: lock.ResolutionInputHash,
 	}
 
-	slog.Debug("Populated lock data", "component", config.Name, "commit", lock.UpstreamCommit)
+	if r.CheckFreshness {
+		r.computeFreshnessStatus(config)
+	}
+
+	slog.Debug("Populated lock data", "component", config.Name,
+		"commit", lock.UpstreamCommit, "freshness", config.Locked.Freshness)
+}
+
+// computeFreshnessStatus compares current config state to stored lock data.
+// A component is [projectconfig.FreshnessCurrent] only when both:
+//   - InputFingerprint matches (build inputs unchanged)
+//   - ResolutionInputHash matches (resolution inputs like snapshot unchanged)
+//
+// If either differs, the component is [projectconfig.FreshnessStale].
+// [projectconfig.ComponentLockData.ResolutionStale] is set separately so
+// callers can distinguish "need re-resolution" from "reuse locked commit."
+//
+// Left as [projectconfig.FreshnessUnknown] when comparison isn't possible
+// (missing stored hash, distro error, etc.).
+func (r *Resolver) computeFreshnessStatus(config *projectconfig.ComponentConfig) {
+	if config.Locked == nil {
+		return
+	}
+
+	// Need at least one stored hash to compare against.
+	if config.Locked.InputFingerprint == "" && config.Locked.ResolutionInputHash == "" {
+		return
+	}
+
+	// Check resolution inputs (cheap, no I/O beyond distro resolution).
+	resInputs, resolveErr := r.buildUpstreamCommitResolutionInputs(config)
+	if resolveErr != nil {
+		slog.Debug("Cannot compute resolution hash (distro resolve failed)",
+			"component", config.Name, "error", resolveErr)
+
+		return
+	}
+
+	resolutionHash := fingerprint.ComputeResolutionHash(resInputs)
+
+	// HEAD-tracking components (no snapshot, no pin) resolve to whatever
+	// the remote branch HEAD is at call time. This is inherently
+	// non-deterministic — the same resolution inputs produce different
+	// commits when upstream pushes new code. The freshness optimization
+	// assumes "same inputs → same commit," which doesn't hold here.
+	// Always mark these as stale so they re-resolve every run.
+	if resInputs.Snapshot == "" && resInputs.UpstreamCommitPin == "" {
+		config.Locked.ResolutionStale = true
+		config.Locked.Freshness = projectconfig.FreshnessStale
+
+		slog.Debug("Component tracks HEAD (no snapshot/pin); always re-resolves",
+			"component", config.Name)
+
+		return
+	}
+
+	switch {
+	case config.Locked.ResolutionInputHash == "":
+		// Legacy lock — ResolutionInputHash was not populated. Force one
+		// re-resolution to backfill the field. Use ResolutionStale=false
+		// so Case 2 fires (reuse commit, update hashes) rather than
+		// Case 3 (full re-resolve), since the commit is likely still valid.
+		config.Locked.Freshness = projectconfig.FreshnessStale
+
+		slog.Debug("Legacy lock missing resolution hash; will backfill",
+			"component", config.Name)
+
+		return
+
+	case config.Locked.ResolutionInputHash != resolutionHash:
+		config.Locked.ResolutionStale = true
+		config.Locked.Freshness = projectconfig.FreshnessStale
+
+		slog.Debug("Component is stale (resolution inputs changed)",
+			"component", config.Name,
+			"stored", config.Locked.ResolutionInputHash,
+			"computed", resolutionHash)
+
+		// Skip fingerprint check — resolution is stale, so we'll
+		// re-resolve regardless. Fingerprint recomputed after resolve.
+		return
+	}
+
+	// Check input fingerprint (requires distro for release ver + overlay I/O).
+	r.checkFingerprintFreshness(config)
+}
+
+// checkFingerprintFreshness compares the recomputed input fingerprint against
+// the stored value. Sets [projectconfig.FreshnessCurrent] when the fingerprint
+// matches (and resolution is also fresh), or [projectconfig.FreshnessStale]
+// when it differs.
+func (r *Resolver) checkFingerprintFreshness(config *projectconfig.ComponentConfig) {
+	if config.Locked.InputFingerprint == "" {
+		return
+	}
+
+	releaseVer, distroErr := r.resolveReleaseVer(config)
+	if distroErr != nil {
+		slog.Debug("Cannot compute freshness (distro resolve failed)",
+			"component", config.Name, "error", distroErr)
+
+		return
+	}
+
+	identity, fpErr := fingerprint.ComputeIdentity(
+		r.env.FS(),
+		*config,
+		releaseVer,
+		fingerprint.IdentityOptions{
+			ManualBump:     config.Locked.ManualBump,
+			SourceIdentity: config.Locked.UpstreamCommit,
+		},
+	)
+	if fpErr != nil {
+		slog.Debug("Cannot compute freshness",
+			"component", config.Name, "error", fpErr)
+
+		return
+	}
+
+	if identity.Fingerprint == config.Locked.InputFingerprint {
+		// Fingerprint matches. If resolution was also fresh, mark Current.
+		if !config.Locked.ResolutionStale {
+			config.Locked.Freshness = projectconfig.FreshnessCurrent
+		}
+	} else {
+		config.Locked.Freshness = projectconfig.FreshnessStale
+
+		slog.Debug("Component is stale (build inputs changed)",
+			"component", config.Name,
+			"stored", config.Locked.InputFingerprint,
+			"computed", identity.Fingerprint)
+	}
+}
+
+// resolveReleaseVer resolves the per-component distro release version.
+func (r *Resolver) resolveReleaseVer(config *projectconfig.ComponentConfig) (string, error) {
+	ref := config.Spec.UpstreamDistro
+	if ref.Name == "" {
+		ref = r.env.Config().Project.DefaultDistro
+	}
+
+	_, distroVer, err := r.env.ResolveDistroRef(ref)
+	if err != nil {
+		return "", fmt.Errorf("resolving distro ref %#q:\n%w", ref.Name, err)
+	}
+
+	return distroVer.ReleaseVer, nil
+}
+
+// buildUpstreamCommitResolutionInputs resolves the effective distro and builds the
+// [fingerprint.UpstreamCommitResolutionInputs] struct for resolution hash computation.
+// Uses the resolved (inherited) config values — not raw spec fields — so
+// that default-distro and distro-version-level snapshots are captured.
+func (r *Resolver) buildUpstreamCommitResolutionInputs(
+	config *projectconfig.ComponentConfig,
+) (fingerprint.UpstreamCommitResolutionInputs, error) {
+	ref := config.Spec.UpstreamDistro
+	if ref.Name == "" {
+		ref = r.env.Config().Project.DefaultDistro
+	}
+
+	distroDef, distroVer, err := r.env.ResolveDistroRef(ref)
+	if err != nil {
+		return fingerprint.UpstreamCommitResolutionInputs{}, fmt.Errorf("resolving distro ref %#q:\n%w", ref.Name, err)
+	}
+
+	return fingerprint.UpstreamCommitResolutionInputs{
+		// Use resolved config's snapshot — not ref.Snapshot — because the
+		// snapshot may come from distro-version-level default-component-config
+		// inheritance, which is merged into config.Spec before we get here.
+		Snapshot:          config.Spec.UpstreamDistro.Snapshot,
+		DistroName:        ref.Name,
+		DistroVersion:     ref.Version,
+		DistGitBranch:     distroVer.DistGitBranch,
+		DistGitBaseURI:    distroDef.DistGitBaseURI,
+		UpstreamCommitPin: config.Spec.UpstreamCommit,
+		UpstreamName:      config.Spec.UpstreamName,
+	}, nil
 }
 
 // warnOnLockDrift emits a staleness warning for each component in the resolved

--- a/internal/lockfile/lockfile.go
+++ b/internal/lockfile/lockfile.go
@@ -55,16 +55,13 @@ type ComponentLock struct {
 
 	// ResolutionInputHash is a hash of the config inputs that affect upstream
 	// commit resolution (snapshot timestamp, distro reference, explicit pin).
-	// Used for offline staleness detection: if the current config's resolution
-	// inputs produce a different hash than what's stored, the lock may be stale
-	// and `component update` will need to re-resolve the upstream commit via
-	// network.
+	// Used for staleness detection: if the current config's resolution inputs
+	// produce a different hash than what's stored, the locked upstream commit
+	// may no longer be correct and 'component update' will re-resolve it.
 	//
-	// This enables a fast offline check without re-resolving upstream commits:
-	//   - Hash matches → resolution inputs unchanged, lock is probably fresh
-	//   - Hash differs → resolution inputs changed, run update to re-resolve
-	//
-	// Not yet populated in v1 — reserved for future use.
+	// This enables a fast check without re-resolving upstream commits:
+	//   - Hash matches → resolution inputs unchanged, reuse locked commit
+	//   - Hash differs → resolution inputs changed, re-resolve required
 	ResolutionInputHash string `toml:"resolution-input-hash,omitempty"`
 }
 

--- a/internal/projectconfig/component.go
+++ b/internal/projectconfig/component.go
@@ -160,6 +160,38 @@ type ReleaseConfig struct {
 	Calculation ReleaseCalculation `toml:"calculation,omitempty" json:"calculation,omitempty" validate:"omitempty,oneof=auto autorelease static manual" jsonschema:"enum=auto,enum=autorelease,enum=static,enum=manual,default=auto,title=Release calculation,description=Controls how the Release tag is managed during rendering. Empty or omitted means auto."`
 }
 
+// FreshnessStatus indicates whether a component's current config matches
+// its locked state. Computed at resolve time when freshness checking is
+// enabled; [FreshnessUnknown] otherwise.
+type FreshnessStatus int
+
+const (
+	// FreshnessUnknown means freshness was not computed (no lock, no stored
+	// fingerprint, or freshness checking not requested).
+	FreshnessUnknown FreshnessStatus = iota
+	// FreshnessCurrent means both the input fingerprint and resolution hash
+	// match the lock — the component is fully up-to-date.
+	FreshnessCurrent
+	// FreshnessStale means the recomputed fingerprint or resolution hash
+	// differs from the lock — config, overlays, snapshot, or other inputs
+	// changed since the last update.
+	FreshnessStale
+)
+
+// String returns a human-readable label for the freshness status.
+func (f FreshnessStatus) String() string {
+	switch f {
+	case FreshnessUnknown:
+		return "unknown"
+	case FreshnessCurrent:
+		return "current"
+	case FreshnessStale:
+		return "stale"
+	default:
+		return "unknown"
+	}
+}
+
 // ComponentLockData holds resolved lock file state attached to a component at
 // resolve time. This separates user intent (config fields) from resolved reality
 // (lock data). Populated by the component resolver from the lock store; nil when
@@ -178,7 +210,21 @@ type ComponentLockData struct {
 	// ManualBump is the extra rebuild counter.
 	ManualBump int `json:"manualBump,omitempty"`
 	// InputFingerprint is the stored fingerprint from the last update.
+	// Covers build inputs (config, overlays, commit, manual bump, release ver)
+	// but excludes resolution inputs like snapshot timestamp.
 	InputFingerprint string `json:"inputFingerprint,omitempty"`
+	// ResolutionInputHash is the stored hash of resolution inputs (snapshot,
+	// distro ref, pin, upstream name). Used to determine if the locked commit
+	// needs re-resolution.
+	ResolutionInputHash string `json:"resolutionInputHash,omitempty"`
+	// Freshness indicates whether the component's config matches its lock.
+	// Runtime-only — computed by the resolver when freshness checking is enabled.
+	Freshness FreshnessStatus `json:"-"`
+	// ResolutionStale indicates whether resolution inputs specifically changed,
+	// as opposed to build-only inputs. When true, re-resolution is needed.
+	// When false but Freshness is Stale, only build inputs changed and the
+	// locked commit can be reused.
+	ResolutionStale bool `json:"-"`
 }
 
 // Defines a component.


### PR DESCRIPTION
Add a three-way freshness check that avoids unnecessary upstream re-resolution during component update:

1. FreshnessCurrent: skip entirely (no re-resolution, no lock write)
2. FreshnessStale + resolution fresh: reuse locked commit, update fingerprint only (no re-resolution needed)
3. FreshnessStale + resolution stale: full re-resolution required

Infrastructure:
- FreshnessStatus enum + ResolutionStale on ComponentLockData
- computeFreshnessStatus on resolver (opt-in via CheckFreshness)
- buildResolutionInputs uses resolved distro values
- Legacy lock migration: empty ResolutionInputHash forces backfill
- HEAD-tracking (no snapshot/pin) always re-resolves
- Local components bypass optimization (no upstream commit to reuse)

CLI:
- --force-recalculate flag to bypass freshness optimizations
- upToDate counter in update summary

Tests:
- 5 integration tests through full UpdateComponents pipeline
- Atomic git-call counter verifies re-resolution behavior
- Legacy lock + local component regression test