### PR TITLE
fix(spec/edit): count unnumbered Patch: tags in GetHighestPatchTagNumber

### DIFF
--- a/internal/rpm/spec/edit.go
+++ b/internal/rpm/spec/edit.go
@@ -718,8 +718,8 @@ func (s *Spec) removePatchlistEntriesMatching(pattern string) (int, error) {
 // GetHighestPatchTagNumber scans the spec for all PatchN tags (where N is a decimal number)
 // across all packages and returns the highest N found. Unnumbered "Patch:" tags (no numeric
 // suffix) are treated as auto-numbered starting from 0, consistent with RPM's behavior.
-// Returns -1 if no patch tags exist at all. Tags with non-numeric suffixes (e.g., macro-based
-// names like Patch%{n}) are silently skipped.
+// Returns -1 if no numbered PatchN tags and no unnumbered "Patch:" tags are found. Tags with
+// non-numeric suffixes (e.g., macro-based names like Patch%{n}) are silently skipped.
 func (s *Spec) GetHighestPatchTagNumber() (int, error) {
 	highest := -1
 	unnumberedCount := 0

--- a/internal/rpm/spec/edit.go
+++ b/internal/rpm/spec/edit.go
@@ -716,20 +716,31 @@ func (s *Spec) removePatchlistEntriesMatching(pattern string) (int, error) {
 }
 
 // GetHighestPatchTagNumber scans the spec for all PatchN tags (where N is a decimal number)
-// across all packages and returns the highest N found. Returns -1 if no numeric patch tags
-// exist. Tags with non-numeric suffixes (e.g., macro-based names like Patch%{n}) are silently
-// skipped.
+// across all packages and returns the highest N found. Unnumbered "Patch:" tags (no numeric
+// suffix) are treated as auto-numbered starting from 0, consistent with RPM's behavior.
+// Returns -1 if no patch tags exist at all. Tags with non-numeric suffixes (e.g., macro-based
+// names like Patch%{n}) are silently skipped.
 func (s *Spec) GetHighestPatchTagNumber() (int, error) {
 	highest := -1
+	unnumberedCount := 0
 
 	err := s.VisitTags(func(tagLine *TagLine, _ *Context) error {
 		num, isPatchTag := ParsePatchTagNumber(tagLine.Tag)
 		if isPatchTag && num > highest {
 			highest = num
+		} else if strings.EqualFold(tagLine.Tag, "patch") {
+			// Bare "Patch:" with no numeric suffix — RPM auto-numbers these
+			// sequentially starting from 0.
+			unnumberedCount++
 		}
 
 		return nil
 	})
+
+	// Unnumbered patches occupy slots 0..unnumberedCount-1.
+	if unnumberedCount > 0 && (unnumberedCount-1) > highest {
+		highest = unnumberedCount - 1
+	}
 
 	return highest, err
 }

--- a/internal/rpm/spec/edit_test.go
+++ b/internal/rpm/spec/edit_test.go
@@ -1184,6 +1184,21 @@ func TestGetHighestPatchTagNumber(t *testing.T) {
 			input:    "Name: test\nPatch0: main.patch\n\n%package devel\nPatch5: devel.patch\n",
 			expected: 5,
 		},
+		{
+			name:     "unnumbered patch tags counted as auto-numbered from 0",
+			input:    "Name: test\nPatch: fix1.patch\nPatch: fix2.patch\n",
+			expected: 1,
+		},
+		{
+			name:     "unnumbered and numbered patch tags mixed",
+			input:    "Name: test\nPatch: fix1.patch\nPatch: fix2.patch\nPatch5: fix5.patch\n",
+			expected: 5,
+		},
+		{
+			name:     "single unnumbered patch tag",
+			input:    "Name: test\nPatch: fix.patch\n",
+			expected: 0,
+		},
 	}
 
 	for _, testCase := range tests {


### PR DESCRIPTION
RPM auto-numbers bare "Patch:" tags (no numeric suffix) sequentially starting from 0. GetHighestPatchTagNumber only scanned for explicit PatchN tags and returned -1 when only unnumbered patches existed, causing AddPatchEntry to assign Patch0 — which collides with RPM's internal numbering.

Count unnumbered Patch: tags as occupying slots 0..N-1 so the next assigned number avoids collisions.

Example: a spec with two unnumbered "Patch:" lines now returns 1 (not -1), so the next patch-add overlay gets Patch2.

<!--
PR Title must follow Conventional Commits format. Available types:

- feat: A new feature
- fix: A bug fix
- docs: Documentation only changes
- style: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
- refactor: A code change that neither fixes a bug nor adds a feature
- perf: A code change that improves performance
- test: Adding missing tests or correcting existing tests
- build: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
- ci: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
- chore: Other changes that don't modify src or test files
- revert: Reverts a previous commit

Reference: https://www.conventionalcommits.org/en/v1.0.0/
-->
