### PR TITLE
feat: Add root user check escape hatch with env var

### DIFF
--- a/internal/app/azldev/app.go
+++ b/internal/app/azldev/app.go
@@ -119,7 +119,8 @@ lives), or use -C to point to one.`,
 		PersistentPreRunE: func(command *cobra.Command, _ []string) error {
 			slog.Debug("Command annotations", "annotations", command.Annotations)
 
-			if _, ok := command.Annotations[CommandAnnotationRootOK]; !ok && os.Geteuid() == 0 {
+			if _, ok := command.Annotations[CommandAnnotationRootOK]; !ok && os.Geteuid() == 0 &&
+				app.osEnvFactory.OSEnv().Getenv("AZLDEV_DISABLE_ROOT_SECURITY") != "1" {
 				return errors.New("this command may not be run as root")
 			}
 

--- a/internal/app/azldev/app.go
+++ b/internal/app/azldev/app.go
@@ -120,7 +120,7 @@ lives), or use -C to point to one.`,
 			slog.Debug("Command annotations", "annotations", command.Annotations)
 
 			if _, ok := command.Annotations[CommandAnnotationRootOK]; !ok && os.Geteuid() == 0 &&
-				app.osEnvFactory.OSEnv().Getenv("AZLDEV_DISABLE_ROOT_SECURITY") != "1" {
+				app.osEnvFactory.OSEnv().Getenv("AZLDEV_ALLOW_ROOT") != "1" {
 				return errors.New("this command may not be run as root")
 			}
 


### PR DESCRIPTION
Some pipelines run as root, allow an escape hatch for those situations.