### PR TITLE
refactor: invert --with-git to --without-git for comp build and prepare-sources

### DIFF
--- a/docs/user/reference/cli/azldev_component_build.md
+++ b/docs/user/reference/cli/azldev_component_build.md
@@ -60,7 +60,7 @@ azldev component build [flags]
       --skip-lock-validation             skip lock file consistency checks (default true)
   -s, --spec-path stringArray            Spec path
       --srpm-only                        Build SRPM (source RPM) *only*
-      --with-git                         Create a dist-git repository with synthetic commit history (requires a project git repository)
+      --without-git                      Skip creating a dist-git repository with synthetic commit history
 ```
 
 ### Options inherited from parent commands

--- a/docs/user/reference/cli/azldev_component_prepare-sources.md
+++ b/docs/user/reference/cli/azldev_component_prepare-sources.md
@@ -42,7 +42,7 @@ azldev component prepare-sources [flags]
       --skip-lock-validation          skip lock file consistency checks (default true)
       --skip-overlays                 skip applying overlays to prepared sources
   -s, --spec-path stringArray         Spec path
-      --with-git                      Create a dist-git repository with synthetic commit history (requires a project git repository)
+      --without-git                   Disable dist-git repository creation (enabled by default)
 ```
 
 ### Options inherited from parent commands

--- a/internal/app/azldev/cmds/component/build.go
+++ b/internal/app/azldev/cmds/component/build.go
@@ -29,7 +29,7 @@ type ComponentBuildOptions struct {
 
 	ContinueOnError   bool
 	NoCheck           bool
-	WithGitRepo       bool
+	WithoutGitRepo    bool
 	SourcePackageOnly bool
 	BuildEnvPolicy    BuildEnvPreservePolicy
 
@@ -131,8 +131,8 @@ builds can consume.`,
 	cmd.Flags().BoolVarP(&options.ContinueOnError, "continue-on-error", "k", false,
 		"Continue building when some components fail")
 	cmd.Flags().BoolVar(&options.NoCheck, "no-check", false, "Skip package %check tests")
-	cmd.Flags().BoolVar(&options.WithGitRepo, "with-git", false,
-		"Create a dist-git repository with synthetic commit history (requires a project git repository)")
+	cmd.Flags().BoolVar(&options.WithoutGitRepo, "without-git", false,
+		"Skip creating a dist-git repository with synthetic commit history")
 	cmd.Flags().BoolVar(&options.SourcePackageOnly, "srpm-only", false, "Build SRPM (source RPM) *only*")
 	cmd.Flags().Var(&options.BuildEnvPolicy, "preserve-buildenv",
 		fmt.Sprintf("Preserve build environment {%s, %s, %s}",
@@ -252,7 +252,7 @@ func BuildComponent(
 	}, &err)
 
 	var preparerOpts []sources.PreparerOption
-	if options.WithGitRepo {
+	if !options.WithoutGitRepo {
 		preparerOpts = append(preparerOpts, sources.WithGitRepo(env, env.LockReader()))
 	}
 

--- a/internal/app/azldev/cmds/component/build_test.go
+++ b/internal/app/azldev/cmds/component/build_test.go
@@ -23,6 +23,15 @@ func TestNewBuildCommand(t *testing.T) {
 		assert.Equal(t, "build", cmd.Use)
 		assert.NotNil(t, cmd.RunE)
 	}
+
+	withoutGitFlag := cmd.Flags().Lookup("without-git")
+	require.NotNil(t, withoutGitFlag, "--without-git flag should be registered")
+	assert.Equal(t, "false", withoutGitFlag.DefValue, "dist-git flow should be enabled by default")
+	assert.Contains(t, withoutGitFlag.Usage, "dist-git")
+
+	// Legacy --with-git flag must NOT exist.
+	withGitFlag := cmd.Flags().Lookup("with-git")
+	assert.Nil(t, withGitFlag, "--with-git flag must not be registered")
 }
 
 func TestNewBuildCommand_MockConfigOptFlag(t *testing.T) {

--- a/internal/app/azldev/cmds/component/preparesources.go
+++ b/internal/app/azldev/cmds/component/preparesources.go
@@ -19,11 +19,11 @@ import (
 type PrepareSourcesOptions struct {
 	ComponentFilter components.ComponentFilter
 
-	OutputDir     string
-	SkipOverlays  bool
-	WithGitRepo   bool
-	Force         bool
-	AllowNoHashes bool
+	OutputDir      string
+	SkipOverlays   bool
+	WithoutGitRepo bool
+	Force          bool
+	AllowNoHashes  bool
 }
 
 func prepareOnAppInit(_ *azldev.App, sourceCmd *cobra.Command) {
@@ -68,8 +68,8 @@ Only one component may be selected at a time.`,
 	_ = cmd.MarkFlagDirname("output-dir")
 
 	cmd.Flags().BoolVar(&options.SkipOverlays, "skip-overlays", false, "skip applying overlays to prepared sources")
-	cmd.Flags().BoolVar(&options.WithGitRepo, "with-git", false,
-		"Create a dist-git repository with synthetic commit history (requires a project git repository)")
+	cmd.Flags().BoolVar(&options.WithoutGitRepo, "without-git", false,
+		"Disable dist-git repository creation (enabled by default)")
 	cmd.Flags().BoolVar(&options.Force, "force", false, "delete and recreate the output directory if it already exists")
 	cmd.Flags().BoolVar(&options.AllowNoHashes, "allow-no-hashes", false,
 		"compute missing hashes by downloading source files from their origin")
@@ -121,13 +121,13 @@ func PrepareComponentSources(env *azldev.Env, options *PrepareSourcesOptions) er
 		return err
 	}
 
-	if options.SkipOverlays && options.WithGitRepo {
-		slog.Warn("--with-git has no effect when --skip-overlays is set; " +
+	if options.SkipOverlays && !options.WithoutGitRepo {
+		slog.Warn("dist-git flow has no effect when '--skip-overlays' is set; " +
 			"synthetic history requires overlays to be applied")
 	}
 
 	var preparerOpts []sources.PreparerOption
-	if options.WithGitRepo {
+	if !options.WithoutGitRepo && !options.SkipOverlays {
 		preparerOpts = append(preparerOpts, sources.WithGitRepo(env, env.LockReader()))
 	}
 

--- a/internal/app/azldev/cmds/component/preparesources_test.go
+++ b/internal/app/azldev/cmds/component/preparesources_test.go
@@ -28,6 +28,15 @@ func TestNewPrepareSourcesCmd(t *testing.T) {
 	require.NotNil(t, allowNoHashesFlag, "--allow-no-hashes flag should be registered")
 	assert.Equal(t, "false", allowNoHashesFlag.DefValue)
 	assert.Contains(t, allowNoHashesFlag.Usage, "compute missing hashes")
+
+	withoutGitFlag := cmd.Flags().Lookup("without-git")
+	require.NotNil(t, withoutGitFlag, "--without-git flag should be registered")
+	assert.Equal(t, "false", withoutGitFlag.DefValue, "dist-git flow should be enabled by default")
+	assert.Contains(t, withoutGitFlag.Usage, "dist-git")
+
+	// Legacy --with-git flag must NOT exist.
+	withGitFlag := cmd.Flags().Lookup("with-git")
+	assert.Nil(t, withGitFlag, "--with-git flag must not be registered")
 }
 
 func TestPrepareSourcesCmd_NoMatch(t *testing.T) {

--- a/scenario/component_build_test.go
+++ b/scenario/component_build_test.go
@@ -34,6 +34,7 @@ func TestBuildingLocalComponent(t *testing.T) {
 	project := projecttest.NewDynamicTestProject(
 		projecttest.AddSpec(spec),
 		projecttest.UseTestDefaultConfigs(),
+		projecttest.WithGitRepo(),
 	)
 
 	// Run the build with test default configs copied into the container.
@@ -76,6 +77,7 @@ func TestBuildingLocalComponentFromCheckedInFiles(t *testing.T) {
 	// Include test default configs to get distro and mock configurations.
 	project := projecttest.NewTemplatedTestProject(t, "testdata/simple",
 		projecttest.TemplatedUseTestDefaultConfigs(),
+		projecttest.TemplatedWithGitRepo(),
 	)
 
 	// Run the build with test default configs copied into the container.
@@ -121,6 +123,7 @@ func TestBuildingUpstreamComponent(t *testing.T) {
 	project := projecttest.NewDynamicTestProject(
 		projecttest.AddComponent(&projectconfig.ComponentConfig{Name: testComponentName}),
 		projecttest.UseTestDefaultConfigs(),
+		projecttest.WithGitRepo(),
 	)
 
 	// Run the build with test default configs copied into the container.

--- a/scenario/internal/projecttest/templatetestproject.go
+++ b/scenario/internal/projecttest/templatetestproject.go
@@ -23,6 +23,7 @@ type TemplatedTestProjectOption func(*templatedTestProject)
 type templatedTestProject struct {
 	templateDir           string
 	useTestDefaultConfigs bool
+	initGitRepo           bool
 }
 
 // TemplatedUseTestDefaultConfigs configures the templated project to include the test default configs.
@@ -32,6 +33,15 @@ type templatedTestProject struct {
 func TemplatedUseTestDefaultConfigs() TemplatedTestProjectOption {
 	return func(p *templatedTestProject) {
 		p.useTestDefaultConfigs = true
+	}
+}
+
+// TemplatedWithGitRepo initializes the project directory as a git repository with an
+// initial commit containing all project files. Required for commands that use synthetic
+// history (e.g., [component build], [component render]).
+func TemplatedWithGitRepo() TemplatedTestProjectOption {
+	return func(p *templatedTestProject) {
+		p.initGitRepo = true
 	}
 }
 
@@ -96,6 +106,11 @@ func (p *templatedTestProject) Serialize(t *testing.T, projectDir string) {
 
 		require.NoError(t, afero.WriteFile(osFS, configFilePath, modifiedBytes, fileperms.PublicFile),
 			"failed to write config file with test default configs")
+	}
+
+	// Initialize a git repo if requested.
+	if p.initGitRepo {
+		initProjectGitRepo(t, projectDir)
 	}
 }
 


### PR DESCRIPTION
azldev component build and azldev component prepare-sources defaulted to the legacy source prep flow, while azldev component render always used the dist-git flow with synthetic commit history. This inverts the default so all three commands are consistent.

Changes
preparesources.go / build.go: WithGitRepo bool → WithoutGitRepo bool; flag renamed --with-git → --without-git (default false = dist-git on by default). Condition logic inverted accordingly.
Warning message updated: fires when --skip-overlays is set and --without-git is not (i.e., git flow is enabled but will have no effect).
Tests (preparesources_test.go, build_test.go): assert --without-git is registered with default false; assert legacy --with-git does not exist.
CLI docs regenerated via mage docs.
Before / After
```
# Before: opt-in to dist-git flow
azldev component build -p curl --with-git

# After: dist-git is the default; opt out if needed
azldev component build -p curl
azldev component build -p curl --without-git  # legacy/no-git behavior
```