### PR TITLE
feat(pkg): split list 'group' column into 'packageGroups' and 'componentGroups'

### DIFF
--- a/docs/user/how-to/inspect-package-config.md
+++ b/docs/user/how-to/inspect-package-config.md
@@ -46,7 +46,7 @@ Example output:
 |--------|----------|
 | **Package** | Binary or source package name (RPM `Name` tag) |
 | **Type** | `rpm` for binary packages, `srpm` for source packages (set when using `--rpm-file`) |
-| **Group** | Package-group whose `packages` list contains this package, if any |
+| **Group** | Package-group whose `packages` list contains this package. Falls back to the resolved component's component-group(s) (sorted, comma-joined) when there is no package-group match, or for SRPM rows. |
 | **Component** | Component that has an explicit `packages.<name>` override for this package, if any |
 | **Publish Channel** | Effective publish channel after all config layers are applied |
 

--- a/docs/user/how-to/inspect-package-config.md
+++ b/docs/user/how-to/inspect-package-config.md
@@ -30,14 +30,14 @@ azldev package list -a
 Example output:
 
 ```
-╭──────────────────┬──────┬────────────────┬───────────┬─────────────────╮
-│ PACKAGE          │ TYPE │ GROUP          │ COMPONENT │ PUBLISH CHANNEL │
-├──────────────────┼──────┼────────────────┼───────────┼─────────────────┤
-│ curl-debugsource │ rpm  │ debug-packages │           │ rpm-debug       │
-│ libcurl          │ rpm  │ base-packages  │           │ rpm-base        │
-│ libcurl-devel    │ rpm  │ devel-packages │ curl      │ rpm-base        │
-│ wget2-wget       │ rpm  │                │ wget2     │ rpm-base        │
-╰──────────────────┴──────┴────────────────┴───────────┴─────────────────╯
+╭──────────────────┬──────┬───────────────────┬─────────────────────┬───────────┬─────────────────╮
+│ PACKAGE          │ TYPE │ PACKAGE GROUPS    │ COMPONENT GROUPS    │ COMPONENT │ PUBLISH CHANNEL │
+├──────────────────┼──────┼───────────────────┼─────────────────────┼───────────┼─────────────────┤
+│ curl-debugsource │ rpm  │ [debug-packages]  │ []                  │           │ rpm-debug       │
+│ libcurl          │ rpm  │ [base-packages]   │ [base-published]    │           │ rpm-base        │
+│ libcurl-devel    │ rpm  │ [devel-packages]  │ [base-published]    │ curl      │ rpm-base        │
+│ wget2-wget       │ rpm  │ []                │ [base-published]    │ wget2     │ rpm-base        │
+╰──────────────────┴──────┴───────────────────┴─────────────────────┴───────────┴─────────────────╯
 ```
 
 ### Column meanings
@@ -46,7 +46,8 @@ Example output:
 |--------|----------|
 | **Package** | Binary or source package name (RPM `Name` tag) |
 | **Type** | `rpm` for binary packages, `srpm` for source packages (set when using `--rpm-file`) |
-| **Group** | Package-group whose `packages` list contains this package. Falls back to the resolved component's component-group(s) (sorted, comma-joined) when there is no package-group match, or for SRPM rows. |
+| **Package Groups** | Sorted list of package-groups whose `packages` list contains this package. Always empty for SRPM rows. |
+| **Component Groups** | Sorted list of component-groups the resolved component belongs to. |
 | **Component** | Component that has an explicit `packages.<name>` override for this package, if any |
 | **Publish Channel** | Effective publish channel after all config layers are applied |
 
@@ -102,13 +103,18 @@ azldev package list -a -q -O json
   {
     "packageName": "libcurl",
     "type": "rpm",
-    "group": "base-packages",
+    "packageGroups": ["base-packages"],
+    "componentGroups": ["base-published"],
     "component": "",
     "publishChannel": "rpm-base"
   },
   ...
 ]
 ```
+
+Both `packageGroups` and `componentGroups` are always emitted as JSON arrays — packages
+with no membership receive an empty array `[]`, never `null` — so consumers can iterate
+the fields without first null-checking them.
 
 For an RPM source map file:
 

--- a/docs/user/reference/cli/azldev_package_list.md
+++ b/docs/user/reference/cli/azldev_package_list.md
@@ -28,6 +28,11 @@ Resolution order (lowest to highest priority):
   4. Package-group default-package-config
   5. Component packages.<name> override
 
+The 'group' column shows the package-group whose 'packages' list contains the package.
+If the package is not in any package-group (or it is an SRPM, which never has package-group
+membership), the column falls back to the component-group(s) the resolved component belongs to,
+comma-joined and sorted. It is empty when no attribution can be determined.
+
 ```
 azldev package list [package-name...] [flags]
 ```

--- a/docs/user/reference/cli/azldev_package_list.md
+++ b/docs/user/reference/cli/azldev_package_list.md
@@ -28,10 +28,10 @@ Resolution order (lowest to highest priority):
   4. Package-group default-package-config
   5. Component packages.<name> override
 
-The 'group' column shows the package-group whose 'packages' list contains the package.
-If the package is not in any package-group (or it is an SRPM, which never has package-group
-membership), the column falls back to the component-group(s) the resolved component belongs to,
-comma-joined and sorted. It is empty when no attribution can be determined.
+Each result has two independent group lists. 'packageGroups' is every package-group whose
+'packages' list contains the package (always empty for SRPM rows). 'componentGroups' is
+every component-group the resolved component belongs to. Both lists are sorted alphabetically
+and are emitted as empty arrays (never null) when there are no memberships.
 
 ```
 azldev package list [package-name...] [flags]

--- a/internal/app/azldev/cmds/pkg/list.go
+++ b/internal/app/azldev/cmds/pkg/list.go
@@ -74,10 +74,10 @@ Resolution order (lowest to highest priority):
   4. Package-group default-package-config
   5. Component packages.<name> override
 
-The 'group' column shows the package-group whose 'packages' list contains the package.
-If the package is not in any package-group (or it is an SRPM, which never has package-group
-membership), the column falls back to the component-group(s) the resolved component belongs to,
-comma-joined and sorted. It is empty when no attribution can be determined.`,
+Each result has two independent group lists. 'packageGroups' is every package-group whose
+'packages' list contains the package (always empty for SRPM rows). 'componentGroups' is
+every component-group the resolved component belongs to. Both lists are sorted alphabetically
+and are emitted as empty arrays (never null) when there are no memberships.`,
 		Example: `  # List all explicitly-configured packages
   azldev package list -a
 
@@ -138,13 +138,16 @@ type PackageListResult struct {
 	// packages. Always [PackageTypeRPM] for '-a' and '-p' lookups; either value for '--rpm-file'.
 	Type string `json:"type" table:"Type"`
 
-	// Group is the group this package is attributed to. For binary packages it is the
-	// package-group whose 'packages' list contains the package; if the package is not in
-	// any package-group it falls back to the comma-joined names of the component-groups
-	// the resolved component belongs to. For source packages (SRPMs), only the
-	// component-group fallback applies (SRPMs have no package-group membership in the
-	// config model). Empty if no attribution can be determined.
-	Group string `json:"group" table:"Group"`
+	// PackageGroups lists every package-group whose 'packages' list contains this package,
+	// sorted alphabetically for deterministic output. Always serialized as an empty JSON
+	// array (never null) when there are no memberships. SRPMs have no package-group
+	// membership in the config model and therefore always have an empty list here.
+	PackageGroups []string `json:"packageGroups" table:"Package Groups"`
+
+	// ComponentGroups lists every component-group the package's resolved component belongs
+	// to, sorted alphabetically for deterministic output. Always serialized as an empty
+	// JSON array (never null) when there are no memberships.
+	ComponentGroups []string `json:"componentGroups" table:"Component Groups"`
 
 	// Component is the resolved component name for this package.
 	// When using '-a' or '-p', it is the component with an explicit [projectconfig.ComponentConfig.Packages]
@@ -202,11 +205,11 @@ func buildComponentPackageIndex(components map[string]projectconfig.ComponentCon
 func listPackagesFromRPMFile(
 	env *azldev.Env,
 	options *ListPackageOptions,
-	groupOf map[string]string,
-	compGroupLabelOf map[string]string,
+	pkgGroupOf map[string][]string,
+	compGroupsOf map[string][]string,
 	proj *projectconfig.ProjectConfig,
 ) ([]PackageListResult, error) {
-	results, err := resolveFromRPMFile(env.FS(), options.RPMFile, groupOf, compGroupLabelOf, proj)
+	results, err := resolveFromRPMFile(env.FS(), options.RPMFile, pkgGroupOf, compGroupsOf, proj)
 	if err != nil {
 		return nil, err
 	}
@@ -245,25 +248,21 @@ func listPackagesFromRPMFile(
 func ListPackages(env *azldev.Env, options *ListPackageOptions) ([]PackageListResult, error) {
 	proj := env.Config()
 
-	// Build an index: pkgName → groupName for packages in any package-group.
-	// Used by '-a', '--rpm-file', and '-p' modes for group attribution and channel resolution.
-	groupOf := make(map[string]string)
+	// Build an index: pkgName → sorted list of package-group names that contain it.
+	// Used by '-a', '--rpm-file', and '-p' modes for the [PackageListResult.PackageGroups]
+	// list on each result. Valid project configuration allows at most one package-group
+	// membership per package; the slice form is kept for deterministic output.
+	pkgGroupOf := buildPackageGroupIndex(proj)
 
-	for groupName, group := range proj.PackageGroups {
-		for _, pkg := range group.Packages {
-			groupOf[pkg] = groupName
-		}
-	}
-
-	// Precompute a deterministic component-group label per component so the
-	// per-package fallback path is a cheap map lookup instead of an allocate-sort-join
-	// on every call. See [buildComponentGroupLabels].
-	compGroupLabelOf := buildComponentGroupLabels(proj)
+	// Precompute a deterministic, sorted list of component-group memberships per component
+	// so the per-result [PackageListResult.ComponentGroups] population is a cheap map
+	// lookup instead of an allocate-sort on every call. See [buildComponentGroupIndex].
+	compGroupsOf := buildComponentGroupIndex(proj)
 
 	results := make([]PackageListResult, 0)
 
 	if options.RPMFile != "" {
-		return listPackagesFromRPMFile(env, options, groupOf, compGroupLabelOf, proj)
+		return listPackagesFromRPMFile(env, options, pkgGroupOf, compGroupsOf, proj)
 	}
 
 	// Build an index: pkgName → componentName for packages with explicit component overrides.
@@ -277,7 +276,7 @@ func ListPackages(env *azldev.Env, options *ListPackageOptions) ([]PackageListRe
 	toResolve := make(map[string]struct{})
 
 	if options.All {
-		for pkg := range groupOf {
+		for pkg := range pkgGroupOf {
 			toResolve[pkg] = struct{}{}
 		}
 
@@ -297,7 +296,7 @@ func ListPackages(env *azldev.Env, options *ListPackageOptions) ([]PackageListRe
 	}
 
 	for pkgName := range toResolve {
-		result, err := resolvePackageListResult(pkgName, compOf, groupOf, compGroupLabelOf, proj)
+		result, err := resolvePackageListResult(pkgName, compOf, pkgGroupOf, compGroupsOf, proj)
 		if err != nil {
 			return nil, err
 		}
@@ -309,7 +308,7 @@ func ListPackages(env *azldev.Env, options *ListPackageOptions) ([]PackageListRe
 		slog.Warn("'--synthesize-debug-packages' is a transitional flag and may change or be removed " +
 			"once first-class debug-package configuration is supported.")
 
-		results, err = synthesizeDebugPackages(results, groupOf, compGroupLabelOf, proj)
+		results, err = synthesizeDebugPackages(results, pkgGroupOf, compGroupsOf, proj)
 		if err != nil {
 			return nil, err
 		}
@@ -328,8 +327,8 @@ func ListPackages(env *azldev.Env, options *ListPackageOptions) ([]PackageListRe
 func resolvePackageListResult(
 	pkgName string,
 	compOf map[string]string,
-	groupOf map[string]string,
-	compGroupLabelOf map[string]string,
+	pkgGroupOf map[string][]string,
+	compGroupsOf map[string][]string,
 	proj *projectconfig.ProjectConfig,
 ) (PackageListResult, error) {
 	compName := resolveComponentName(pkgName, compOf, proj)
@@ -355,35 +354,48 @@ func resolvePackageListResult(
 		return PackageListResult{}, fmt.Errorf("failed to resolve publish channel for package %#q:\n%w", pkgName, err)
 	}
 
-	group := groupOf[pkgName]
-	if group == "" {
-		group = compGroupLabelOf[compName]
-	}
-
 	return PackageListResult{
-		PackageName: pkgName,
-		Type:        PackageTypeRPM,
-		Group:       group,
-		Component:   compName,
-		Channel:     channel,
+		PackageName:     pkgName,
+		Type:            PackageTypeRPM,
+		PackageGroups:   nonNilStrings(pkgGroupOf[pkgName]),
+		ComponentGroups: nonNilStrings(compGroupsOf[compName]),
+		Component:       compName,
+		Channel:         channel,
 	}, nil
 }
 
-// buildComponentGroupLabels precomputes a deterministic, comma-joined label of the
-// component-groups each component belongs to. The label is the sorted, comma-joined
-// list of component-group names from [projectconfig.ProjectConfig.GroupsByComponent].
-// The returned map is keyed by component name and is intended to be built once per
-// command invocation so the per-package [PackageListResult.Group] fallback is a
-// cheap map lookup instead of an allocate-sort-join on every call.
+// buildPackageGroupIndex builds a deterministic index from package name to the sorted list
+// of package-group names whose 'packages' list contains it. Valid project configs assign
+// a package to at most one package-group, but this helper returns a slice because
+// [PackageListResult.PackageGroups] is represented as a list. Packages with no
+// package-group membership are omitted (a missing key reads as a nil slice, which is the
+// desired empty-list behavior).
+func buildPackageGroupIndex(proj *projectconfig.ProjectConfig) map[string][]string {
+	pkgGroupOf := make(map[string][]string)
+
+	for groupName, group := range proj.PackageGroups {
+		for _, pkg := range group.Packages {
+			pkgGroupOf[pkg] = append(pkgGroupOf[pkg], groupName)
+		}
+	}
+
+	for pkg := range pkgGroupOf {
+		sort.Strings(pkgGroupOf[pkg])
+	}
+
+	return pkgGroupOf
+}
+
+// buildComponentGroupIndex precomputes a sorted list of component-group memberships per
+// component, derived from [projectconfig.ProjectConfig.GroupsByComponent]. The returned
+// map is keyed by component name and is intended to be built once per command invocation
+// so the per-result [PackageListResult.ComponentGroups] population is a cheap map
+// lookup instead of an allocate-sort on every call.
 //
-// Components with no component-group memberships are omitted (a missing key reads as
-// the zero value "", which matches the desired behavior).
-//
-// Note: the separator is a plain comma; component-group names that themselves contain a
-// comma would render ambiguously. There is no convention in the project today that
-// disallows commas in group names, but they are not expected in practice.
-func buildComponentGroupLabels(proj *projectconfig.ProjectConfig) map[string]string {
-	labels := make(map[string]string, len(proj.GroupsByComponent))
+// Components with no component-group memberships are omitted (a missing key reads as a
+// nil slice, which matches the desired empty-list behavior).
+func buildComponentGroupIndex(proj *projectconfig.ProjectConfig) map[string][]string {
+	index := make(map[string][]string, len(proj.GroupsByComponent))
 
 	for compName, groups := range proj.GroupsByComponent {
 		if len(groups) == 0 {
@@ -392,10 +404,10 @@ func buildComponentGroupLabels(proj *projectconfig.ProjectConfig) map[string]str
 
 		sorted := append([]string(nil), groups...)
 		sort.Strings(sorted)
-		labels[compName] = strings.Join(sorted, ",")
+		index[compName] = sorted
 	}
 
-	return labels
+	return index
 }
 
 // resolveComponentName returns the component name for a binary package. It first
@@ -445,7 +457,7 @@ func resolveComponentConfig(compName string, proj *projectconfig.ProjectConfig) 
 // project default → component group → component.
 func resolveSourcePackageListResult(
 	srpmName string,
-	compGroupLabelOf map[string]string,
+	compGroupsOf map[string][]string,
 	proj *projectconfig.ProjectConfig,
 ) (PackageListResult, error) {
 	// The SRPM name is the component name by definition.
@@ -466,11 +478,13 @@ func resolveSourcePackageListResult(
 	return PackageListResult{
 		PackageName: srpmName,
 		Type:        PackageTypeSRPM,
-		// SRPMs have no package-group membership in the config model, so attribute them
-		// to their component's component-group(s) instead.
-		Group:     compGroupLabelOf[compName],
-		Component: compName,
-		Channel:   resolved.Publish.SRPMChannel,
+		// SRPMs have no package-group membership in the config model, so [PackageGroups]
+		// is always empty; only the component-group memberships of the SRPM's component
+		// are reported.
+		PackageGroups:   nonNilStrings(nil),
+		ComponentGroups: nonNilStrings(compGroupsOf[compName]),
+		Component:       compName,
+		Channel:         resolved.Publish.SRPMChannel,
 	}, nil
 }
 
@@ -482,8 +496,8 @@ func resolveSourcePackageListResult(
 func resolveFromRPMFile(
 	fs opctx.FS,
 	path string,
-	groupOf map[string]string,
-	compGroupLabelOf map[string]string,
+	pkgGroupOf map[string][]string,
+	compGroupsOf map[string][]string,
 	proj *projectconfig.ProjectConfig,
 ) ([]PackageListResult, error) {
 	srpmMap, rpmCompOf, err := loadRPMFile(fs, path)
@@ -494,7 +508,7 @@ func resolveFromRPMFile(
 	results := make([]PackageListResult, 0, len(srpmMap))
 
 	for srpmName, rpmNames := range srpmMap {
-		srpmResult, resolveErr := resolveSourcePackageListResult(srpmName, compGroupLabelOf, proj)
+		srpmResult, resolveErr := resolveSourcePackageListResult(srpmName, compGroupsOf, proj)
 		if resolveErr != nil {
 			return nil, resolveErr
 		}
@@ -502,7 +516,7 @@ func resolveFromRPMFile(
 		results = append(results, srpmResult)
 
 		for _, rpmName := range rpmNames {
-			rpmResult, resolveErr := resolvePackageListResult(rpmName, rpmCompOf, groupOf, compGroupLabelOf, proj)
+			rpmResult, resolveErr := resolvePackageListResult(rpmName, rpmCompOf, pkgGroupOf, compGroupsOf, proj)
 			if resolveErr != nil {
 				return nil, resolveErr
 			}
@@ -599,8 +613,10 @@ func loadRPMFile(fs opctx.FS, path string) (srpmMap map[string][]string, rpmComp
 // publish channel resolved through the normal component → project default chain).
 //
 // Group attribution mirrors [resolvePackageListResult]: '-debuginfo' entries inherit the
-// originating package's Group; '-debugsource' entries use the component-group baseline,
-// overridden by an explicit '<comp>-debugsource' package-group membership when present.
+// originating package's [PackageListResult.PackageGroups] and
+// [PackageListResult.ComponentGroups]; '-debugsource' entries report any explicit
+// '<comp>-debugsource' package-group memberships alongside the component-group baseline
+// derived from the owning component.
 //
 // Note: '-debugsource' entries are emitted for every component in the project regardless of
 // which packages were requested via '-p'. Components own packages via [ComponentConfig.Packages],
@@ -613,8 +629,8 @@ func loadRPMFile(fs opctx.FS, path string) (srpmMap map[string][]string, rpmComp
 // '-debugsource' do not get a doubled suffix synthesized.
 func synthesizeDebugPackages(
 	results []PackageListResult,
-	groupOf map[string]string,
-	compGroupLabelOf map[string]string,
+	pkgGroupOf map[string][]string,
+	compGroupsOf map[string][]string,
 	proj *projectconfig.ProjectConfig,
 ) ([]PackageListResult, error) {
 	existing := make(map[string]struct{}, len(results))
@@ -638,11 +654,12 @@ func synthesizeDebugPackages(
 
 		existing[name] = struct{}{}
 		debugInfoEntries = append(debugInfoEntries, PackageListResult{
-			PackageName: name,
-			Type:        PackageTypeRPM,
-			Group:       result.Group,
-			Component:   result.Component,
-			Channel:     debugChannelName(result.Channel),
+			PackageName:     name,
+			Type:            PackageTypeRPM,
+			PackageGroups:   result.PackageGroups,
+			ComponentGroups: result.ComponentGroups,
+			Component:       result.Component,
+			Channel:         debugChannelName(result.Channel),
 		})
 	}
 
@@ -671,20 +688,13 @@ func synthesizeDebugPackages(
 			return nil, fmt.Errorf("failed to resolve config for synthesized package %#q:\n%w", name, err)
 		}
 
-		// Apply the same package-group-overrides-component-group precedence used for
-		// regular RPMs: an explicit '<comp>-debugsource' package-group membership wins
-		// over the component-group baseline.
-		group := compGroupLabelOf[compName]
-		if pg, ok := groupOf[name]; ok {
-			group = pg
-		}
-
 		results = append(results, PackageListResult{
-			PackageName: name,
-			Type:        PackageTypeRPM,
-			Group:       group,
-			Component:   compName,
-			Channel:     debugChannelName(pkgConfig.Publish.EffectiveRPMChannel()),
+			PackageName:     name,
+			Type:            PackageTypeRPM,
+			PackageGroups:   nonNilStrings(pkgGroupOf[name]),
+			ComponentGroups: nonNilStrings(compGroupsOf[compName]),
+			Component:       compName,
+			Channel:         debugChannelName(pkgConfig.Publish.EffectiveRPMChannel()),
 		})
 	}
 
@@ -707,4 +717,19 @@ func debugChannelName(channel string) string {
 // so the caller can avoid synthesizing doubled-suffix names like 'foo-debuginfo-debuginfo'.
 func isDebugPackageName(name string) bool {
 	return strings.HasSuffix(name, "-debuginfo") || strings.HasSuffix(name, "-debugsource")
+}
+
+// nonNilStrings returns s unchanged when it is non-nil, otherwise an empty (non-nil)
+// []string{}. Used at [PackageListResult] construction sites to guarantee that
+// [PackageListResult.PackageGroups] and [PackageListResult.ComponentGroups] always
+// serialize as a JSON empty array '[]' instead of 'null'.
+//
+// The returned slice aliases its input; treat it as read-only. Appending to a returned
+// slice may corrupt the caller's index map.
+func nonNilStrings(s []string) []string {
+	if s == nil {
+		return []string{}
+	}
+
+	return s
 }

--- a/internal/app/azldev/cmds/pkg/list.go
+++ b/internal/app/azldev/cmds/pkg/list.go
@@ -72,7 +72,12 @@ Resolution order (lowest to highest priority):
   2. Component-group default-component-config publish settings
   3. Component publish settings
   4. Package-group default-package-config
-  5. Component packages.<name> override`,
+  5. Component packages.<name> override
+
+The 'group' column shows the package-group whose 'packages' list contains the package.
+If the package is not in any package-group (or it is an SRPM, which never has package-group
+membership), the column falls back to the component-group(s) the resolved component belongs to,
+comma-joined and sorted. It is empty when no attribution can be determined.`,
 		Example: `  # List all explicitly-configured packages
   azldev package list -a
 
@@ -133,7 +138,12 @@ type PackageListResult struct {
 	// packages. Always [PackageTypeRPM] for '-a' and '-p' lookups; either value for '--rpm-file'.
 	Type string `json:"type" table:"Type"`
 
-	// Group is the package-group this package belongs to, or empty if it is not in any group.
+	// Group is the group this package is attributed to. For binary packages it is the
+	// package-group whose 'packages' list contains the package; if the package is not in
+	// any package-group it falls back to the comma-joined names of the component-groups
+	// the resolved component belongs to. For source packages (SRPMs), only the
+	// component-group fallback applies (SRPMs have no package-group membership in the
+	// config model). Empty if no attribution can be determined.
 	Group string `json:"group" table:"Group"`
 
 	// Component is the resolved component name for this package.
@@ -193,9 +203,10 @@ func listPackagesFromRPMFile(
 	env *azldev.Env,
 	options *ListPackageOptions,
 	groupOf map[string]string,
+	compGroupLabelOf map[string]string,
 	proj *projectconfig.ProjectConfig,
 ) ([]PackageListResult, error) {
-	results, err := resolveFromRPMFile(env.FS(), options.RPMFile, groupOf, proj)
+	results, err := resolveFromRPMFile(env.FS(), options.RPMFile, groupOf, compGroupLabelOf, proj)
 	if err != nil {
 		return nil, err
 	}
@@ -244,10 +255,15 @@ func ListPackages(env *azldev.Env, options *ListPackageOptions) ([]PackageListRe
 		}
 	}
 
+	// Precompute a deterministic component-group label per component so the
+	// per-package fallback path is a cheap map lookup instead of an allocate-sort-join
+	// on every call. See [buildComponentGroupLabels].
+	compGroupLabelOf := buildComponentGroupLabels(proj)
+
 	results := make([]PackageListResult, 0)
 
 	if options.RPMFile != "" {
-		return listPackagesFromRPMFile(env, options, groupOf, proj)
+		return listPackagesFromRPMFile(env, options, groupOf, compGroupLabelOf, proj)
 	}
 
 	// Build an index: pkgName → componentName for packages with explicit component overrides.
@@ -281,7 +297,7 @@ func ListPackages(env *azldev.Env, options *ListPackageOptions) ([]PackageListRe
 	}
 
 	for pkgName := range toResolve {
-		result, err := resolvePackageListResult(pkgName, compOf, groupOf, proj)
+		result, err := resolvePackageListResult(pkgName, compOf, groupOf, compGroupLabelOf, proj)
 		if err != nil {
 			return nil, err
 		}
@@ -293,7 +309,7 @@ func ListPackages(env *azldev.Env, options *ListPackageOptions) ([]PackageListRe
 		slog.Warn("'--synthesize-debug-packages' is a transitional flag and may change or be removed " +
 			"once first-class debug-package configuration is supported.")
 
-		results, err = synthesizeDebugPackages(results, proj)
+		results, err = synthesizeDebugPackages(results, groupOf, compGroupLabelOf, proj)
 		if err != nil {
 			return nil, err
 		}
@@ -313,6 +329,7 @@ func resolvePackageListResult(
 	pkgName string,
 	compOf map[string]string,
 	groupOf map[string]string,
+	compGroupLabelOf map[string]string,
 	proj *projectconfig.ProjectConfig,
 ) (PackageListResult, error) {
 	compName := resolveComponentName(pkgName, compOf, proj)
@@ -338,13 +355,47 @@ func resolvePackageListResult(
 		return PackageListResult{}, fmt.Errorf("failed to resolve publish channel for package %#q:\n%w", pkgName, err)
 	}
 
+	group := groupOf[pkgName]
+	if group == "" {
+		group = compGroupLabelOf[compName]
+	}
+
 	return PackageListResult{
 		PackageName: pkgName,
 		Type:        PackageTypeRPM,
-		Group:       groupOf[pkgName],
+		Group:       group,
 		Component:   compName,
 		Channel:     channel,
 	}, nil
+}
+
+// buildComponentGroupLabels precomputes a deterministic, comma-joined label of the
+// component-groups each component belongs to. The label is the sorted, comma-joined
+// list of component-group names from [projectconfig.ProjectConfig.GroupsByComponent].
+// The returned map is keyed by component name and is intended to be built once per
+// command invocation so the per-package [PackageListResult.Group] fallback is a
+// cheap map lookup instead of an allocate-sort-join on every call.
+//
+// Components with no component-group memberships are omitted (a missing key reads as
+// the zero value "", which matches the desired behavior).
+//
+// Note: the separator is a plain comma; component-group names that themselves contain a
+// comma would render ambiguously. There is no convention in the project today that
+// disallows commas in group names, but they are not expected in practice.
+func buildComponentGroupLabels(proj *projectconfig.ProjectConfig) map[string]string {
+	labels := make(map[string]string, len(proj.GroupsByComponent))
+
+	for compName, groups := range proj.GroupsByComponent {
+		if len(groups) == 0 {
+			continue
+		}
+
+		sorted := append([]string(nil), groups...)
+		sort.Strings(sorted)
+		labels[compName] = strings.Join(sorted, ",")
+	}
+
+	return labels
 }
 
 // resolveComponentName returns the component name for a binary package. It first
@@ -394,6 +445,7 @@ func resolveComponentConfig(compName string, proj *projectconfig.ProjectConfig) 
 // project default → component group → component.
 func resolveSourcePackageListResult(
 	srpmName string,
+	compGroupLabelOf map[string]string,
 	proj *projectconfig.ProjectConfig,
 ) (PackageListResult, error) {
 	// The SRPM name is the component name by definition.
@@ -414,9 +466,11 @@ func resolveSourcePackageListResult(
 	return PackageListResult{
 		PackageName: srpmName,
 		Type:        PackageTypeSRPM,
-		Group:       "", // SRPMs have no package-group membership in the config model
-		Component:   compName,
-		Channel:     resolved.Publish.SRPMChannel,
+		// SRPMs have no package-group membership in the config model, so attribute them
+		// to their component's component-group(s) instead.
+		Group:     compGroupLabelOf[compName],
+		Component: compName,
+		Channel:   resolved.Publish.SRPMChannel,
 	}, nil
 }
 
@@ -429,6 +483,7 @@ func resolveFromRPMFile(
 	fs opctx.FS,
 	path string,
 	groupOf map[string]string,
+	compGroupLabelOf map[string]string,
 	proj *projectconfig.ProjectConfig,
 ) ([]PackageListResult, error) {
 	srpmMap, rpmCompOf, err := loadRPMFile(fs, path)
@@ -439,7 +494,7 @@ func resolveFromRPMFile(
 	results := make([]PackageListResult, 0, len(srpmMap))
 
 	for srpmName, rpmNames := range srpmMap {
-		srpmResult, resolveErr := resolveSourcePackageListResult(srpmName, proj)
+		srpmResult, resolveErr := resolveSourcePackageListResult(srpmName, compGroupLabelOf, proj)
 		if resolveErr != nil {
 			return nil, resolveErr
 		}
@@ -447,7 +502,7 @@ func resolveFromRPMFile(
 		results = append(results, srpmResult)
 
 		for _, rpmName := range rpmNames {
-			rpmResult, resolveErr := resolvePackageListResult(rpmName, rpmCompOf, groupOf, proj)
+			rpmResult, resolveErr := resolvePackageListResult(rpmName, rpmCompOf, groupOf, compGroupLabelOf, proj)
 			if resolveErr != nil {
 				return nil, resolveErr
 			}
@@ -543,6 +598,10 @@ func loadRPMFile(fs opctx.FS, path string) (srpmMap map[string][]string, rpmComp
 // "" or "none") and '-debugsource' packages (one per component in the project, with the
 // publish channel resolved through the normal component → project default chain).
 //
+// Group attribution mirrors [resolvePackageListResult]: '-debuginfo' entries inherit the
+// originating package's Group; '-debugsource' entries use the component-group baseline,
+// overridden by an explicit '<comp>-debugsource' package-group membership when present.
+//
 // Note: '-debugsource' entries are emitted for every component in the project regardless of
 // which packages were requested via '-p'. Components own packages via [ComponentConfig.Packages],
 // but most listed packages come from package groups with no component association — so scoping
@@ -553,7 +612,10 @@ func loadRPMFile(fs opctx.FS, path string) (srpmMap map[string][]string, rpmComp
 // real configuration always wins. Source packages whose names already end in '-debuginfo' or
 // '-debugsource' do not get a doubled suffix synthesized.
 func synthesizeDebugPackages(
-	results []PackageListResult, proj *projectconfig.ProjectConfig,
+	results []PackageListResult,
+	groupOf map[string]string,
+	compGroupLabelOf map[string]string,
+	proj *projectconfig.ProjectConfig,
 ) ([]PackageListResult, error) {
 	existing := make(map[string]struct{}, len(results))
 	for _, result := range results {
@@ -609,9 +671,18 @@ func synthesizeDebugPackages(
 			return nil, fmt.Errorf("failed to resolve config for synthesized package %#q:\n%w", name, err)
 		}
 
+		// Apply the same package-group-overrides-component-group precedence used for
+		// regular RPMs: an explicit '<comp>-debugsource' package-group membership wins
+		// over the component-group baseline.
+		group := compGroupLabelOf[compName]
+		if pg, ok := groupOf[name]; ok {
+			group = pg
+		}
+
 		results = append(results, PackageListResult{
 			PackageName: name,
 			Type:        PackageTypeRPM,
+			Group:       group,
 			Component:   compName,
 			Channel:     debugChannelName(pkgConfig.Publish.EffectiveRPMChannel()),
 		})

--- a/internal/app/azldev/cmds/pkg/list_test.go
+++ b/internal/app/azldev/cmds/pkg/list_test.go
@@ -562,3 +562,130 @@ func TestListPackages_RPMFile_Validation(t *testing.T) {
 		})
 	}
 }
+
+// TestListPackages_GroupFallsBackToComponentGroup verifies that when a binary package
+// is not in any package-group, the Group field falls back to the component-group(s) of
+// the resolved component. Multiple component-group memberships are sorted and
+// comma-joined for deterministic output.
+func TestListPackages_GroupFallsBackToComponentGroup(t *testing.T) {
+	testEnv := testutils.NewTestEnv(t)
+
+	testEnv.Config.ComponentGroups["base-published"] = projectconfig.ComponentGroupConfig{
+		Components: []string{"jq"},
+	}
+	testEnv.Config.ComponentGroups["alpha"] = projectconfig.ComponentGroupConfig{
+		Components: []string{"jq"},
+	}
+
+	// Loader normally builds GroupsByComponent; tests that mutate ComponentGroups
+	// directly must keep the reverse index aligned. Insert in non-sorted order to
+	// confirm componentGroupLabel sorts before joining.
+	testEnv.Config.GroupsByComponent["jq"] = []string{"base-published", "alpha"}
+
+	results, err := pkgcmds.ListPackages(testEnv.Env, &pkgcmds.ListPackageOptions{PackageNames: []string{"jq"}})
+
+	require.NoError(t, err)
+	require.Len(t, results, 1)
+	assert.Equal(t, "jq", results[0].PackageName)
+	assert.Equal(t, "alpha,base-published", results[0].Group,
+		"Group should fall back to sorted, comma-joined component-group names")
+}
+
+// TestListPackages_GroupPackageGroupWinsOverComponentGroup verifies that an explicit
+// package-group attribution still wins over the component-group fallback.
+func TestListPackages_GroupPackageGroupWinsOverComponentGroup(t *testing.T) {
+	testEnv := testutils.NewTestEnv(t)
+
+	testEnv.Config.PackageGroups = map[string]projectconfig.PackageGroupConfig{
+		"devel-packages": {Packages: []string{"jq"}},
+	}
+	testEnv.Config.ComponentGroups["base-published"] = projectconfig.ComponentGroupConfig{
+		Components: []string{"jq"},
+	}
+	testEnv.Config.GroupsByComponent["jq"] = []string{"base-published"}
+
+	results, err := pkgcmds.ListPackages(testEnv.Env, &pkgcmds.ListPackageOptions{PackageNames: []string{"jq"}})
+
+	require.NoError(t, err)
+	require.Len(t, results, 1)
+	assert.Equal(t, "devel-packages", results[0].Group,
+		"package-group attribution must win over the component-group fallback")
+}
+
+// TestListPackages_RPMFile_GroupFromComponentGroup verifies that --rpm-file rows
+// (both SRPM and binary RPM) get their Group from the resolved component's
+// component-group(s) when no package-group contains them.
+func TestListPackages_RPMFile_GroupFromComponentGroup(t *testing.T) {
+	testEnv := testutils.NewTestEnv(t)
+
+	testEnv.Config.Components["curl"] = projectconfig.ComponentConfig{Name: "curl"}
+	testEnv.Config.ComponentGroups["base-published"] = projectconfig.ComponentGroupConfig{
+		Components: []string{"curl"},
+	}
+	testEnv.Config.GroupsByComponent["curl"] = []string{"base-published"}
+
+	const srpmMapPath = "/test-srpm-map.json"
+
+	entries := []map[string]string{
+		{"packageName": "curl", "sourcePackageName": "curl"},
+		{"packageName": "curl-devel", "sourcePackageName": "curl"},
+	}
+
+	data, jsonErr := json.Marshal(entries)
+	require.NoError(t, jsonErr)
+	require.NoError(t, fileutils.WriteFile(testEnv.TestFS, srpmMapPath, data, fileperms.PublicFile))
+
+	results, err := pkgcmds.ListPackages(testEnv.Env, &pkgcmds.ListPackageOptions{RPMFile: srpmMapPath})
+	require.NoError(t, err)
+
+	byKey := make(map[string]pkgcmds.PackageListResult, len(results))
+	for _, r := range results {
+		byKey[r.PackageName+"#"+r.Type] = r
+	}
+
+	srpm := byKey["curl#"+pkgcmds.PackageTypeSRPM]
+	assert.Equal(t, "base-published", srpm.Group,
+		"SRPM Group should fall back to its component's component-group")
+
+	rpm := byKey["curl-devel#"+pkgcmds.PackageTypeRPM]
+	assert.Equal(t, "base-published", rpm.Group,
+		"binary RPM Group should fall back to its component's component-group when no package-group matches")
+}
+
+// TestListPackages_SynthesizeDebugPackages_DebugsourcePackageGroupOverridesComponentGroup verifies
+// that a synthesized '-debugsource' entry uses the package-group attribution when its name is
+// listed in a package-group, overriding the component-group baseline. This mirrors the
+// resolution used by [resolvePackageListResult] for regular RPMs.
+func TestListPackages_SynthesizeDebugPackages_DebugsourcePackageGroupOverridesComponentGroup(t *testing.T) {
+	testEnv := testutils.NewTestEnv(t)
+
+	testEnv.Config.Components["curl"] = projectconfig.ComponentConfig{Name: "curl"}
+
+	// Component-group provides the baseline attribution.
+	testEnv.Config.ComponentGroups["base-published"] = projectconfig.ComponentGroupConfig{
+		Components: []string{"curl"},
+	}
+	testEnv.Config.GroupsByComponent["curl"] = []string{"base-published"}
+
+	// Package-group explicitly lists 'curl-debugsource' — this should win over the
+	// component-group baseline for the synthesized entry.
+	testEnv.Config.PackageGroups = map[string]projectconfig.PackageGroupConfig{
+		"debug-packages": {Packages: []string{"curl-debugsource"}},
+	}
+
+	results, err := pkgcmds.ListPackages(testEnv.Env, &pkgcmds.ListPackageOptions{
+		PackageNames:            []string{"curl"},
+		SynthesizeDebugPackages: true,
+	})
+
+	require.NoError(t, err)
+
+	byName := make(map[string]pkgcmds.PackageListResult, len(results))
+	for _, result := range results {
+		byName[result.PackageName] = result
+	}
+
+	require.Contains(t, byName, "curl-debugsource")
+	assert.Equal(t, "debug-packages", byName["curl-debugsource"].Group,
+		"synthesized -debugsource Group should be overridden by an explicit package-group membership")
+}

--- a/internal/app/azldev/cmds/pkg/list_test.go
+++ b/internal/app/azldev/cmds/pkg/list_test.go
@@ -65,12 +65,13 @@ func TestListPackages_FromPackageGroup(t *testing.T) {
 
 	// Results are sorted by package name.
 	assert.Equal(t, "curl-devel", results[0].PackageName)
-	assert.Equal(t, "devel-packages", results[0].Group)
+	assert.Equal(t, []string{"devel-packages"}, results[0].PackageGroups)
+	assert.Empty(t, results[0].ComponentGroups)
 	assert.Empty(t, results[0].Component)
 	assert.Equal(t, "devel", results[0].Channel)
 
 	assert.Equal(t, "wget2-devel", results[1].PackageName)
-	assert.Equal(t, "devel-packages", results[1].Group)
+	assert.Equal(t, []string{"devel-packages"}, results[1].PackageGroups)
 	assert.Equal(t, "devel", results[1].Channel)
 }
 
@@ -90,7 +91,8 @@ func TestListPackages_FromComponentPackageOverride(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, results, 1)
 	assert.Equal(t, "curl-minimal", results[0].PackageName)
-	assert.Empty(t, results[0].Group)
+	assert.Empty(t, results[0].PackageGroups)
+	assert.Empty(t, results[0].ComponentGroups)
 	assert.Equal(t, "curl", results[0].Component)
 	assert.Equal(t, "none", results[0].Channel)
 }
@@ -119,7 +121,7 @@ func TestListPackages_ComponentOverrideWinsOverGroup(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, results, 1)
 	assert.Equal(t, "curl-devel", results[0].PackageName)
-	assert.Equal(t, "base-packages", results[0].Group)
+	assert.Equal(t, []string{"base-packages"}, results[0].PackageGroups)
 	assert.Equal(t, "curl", results[0].Component)
 	// Component override (none) wins over group (base).
 	assert.Equal(t, "none", results[0].Channel)
@@ -161,7 +163,7 @@ func TestListPackages_ByName_InExplicitConfig(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, results, 1)
 	assert.Equal(t, "curl-devel", results[0].PackageName)
-	assert.Equal(t, "devel-packages", results[0].Group)
+	assert.Equal(t, []string{"devel-packages"}, results[0].PackageGroups)
 	assert.Empty(t, results[0].Component)
 	assert.Equal(t, "devel", results[0].Channel)
 }
@@ -180,9 +182,29 @@ func TestListPackages_ByName_NotInExplicitConfig(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, results, 1)
 	assert.Equal(t, "unknown-pkg", results[0].PackageName)
-	assert.Empty(t, results[0].Group)
+	assert.Empty(t, results[0].PackageGroups)
+	assert.Empty(t, results[0].ComponentGroups)
 	assert.Empty(t, results[0].Component)
 	assert.Equal(t, "default-channel", results[0].Channel)
+}
+
+// TestListPackages_EmptyGroupsMarshalAsJSONArray verifies that a result with no group
+// memberships serializes 'packageGroups' and 'componentGroups' as empty JSON arrays
+// ('[]') rather than 'null', so consumers can iterate the fields without null-checking.
+func TestListPackages_EmptyGroupsMarshalAsJSONArray(t *testing.T) {
+	testEnv := testutils.NewTestEnv(t)
+
+	results, err := pkgcmds.ListPackages(testEnv.Env, &pkgcmds.ListPackageOptions{PackageNames: []string{"unknown-pkg"}})
+
+	require.NoError(t, err)
+	require.Len(t, results, 1)
+	require.NotNil(t, results[0].PackageGroups, "PackageGroups must be a non-nil slice")
+	require.NotNil(t, results[0].ComponentGroups, "ComponentGroups must be a non-nil slice")
+
+	data, marshalErr := json.Marshal(results[0])
+	require.NoError(t, marshalErr)
+	assert.Contains(t, string(data), `"packageGroups":[]`)
+	assert.Contains(t, string(data), `"componentGroups":[]`)
 }
 
 func TestListPackages_ByName_MultipleNames(t *testing.T) {
@@ -258,14 +280,15 @@ func TestListPackages_SynthesizeDebugPackages(t *testing.T) {
 	// '-debuginfo' synthesized for each reported package on the parallel debug channel.
 	require.Contains(t, byName, "curl-devel-debuginfo")
 	assert.Equal(t, "devel-debuginfo", byName["curl-devel-debuginfo"].Channel)
-	assert.Equal(t, "devel-packages", byName["curl-devel-debuginfo"].Group)
+	assert.Equal(t, []string{"devel-packages"}, byName["curl-devel-debuginfo"].PackageGroups)
 
 	// '-debugsource' synthesized for each component, with its channel resolved through the
 	// component → project default chain and suffixed onto the parallel debug channel.
 	require.Contains(t, byName, "curl-debugsource")
 	assert.Equal(t, "default-channel-debuginfo", byName["curl-debugsource"].Channel)
 	assert.Equal(t, "curl", byName["curl-debugsource"].Component)
-	assert.Empty(t, byName["curl-debugsource"].Group)
+	assert.Empty(t, byName["curl-debugsource"].PackageGroups)
+	assert.Empty(t, byName["curl-debugsource"].ComponentGroups)
 
 	require.Contains(t, byName, "wget-debugsource")
 	assert.Equal(t, "default-channel-debuginfo", byName["wget-debugsource"].Channel)
@@ -563,11 +586,11 @@ func TestListPackages_RPMFile_Validation(t *testing.T) {
 	}
 }
 
-// TestListPackages_GroupFallsBackToComponentGroup verifies that when a binary package
-// is not in any package-group, the Group field falls back to the component-group(s) of
-// the resolved component. Multiple component-group memberships are sorted and
-// comma-joined for deterministic output.
-func TestListPackages_GroupFallsBackToComponentGroup(t *testing.T) {
+// TestListPackages_ComponentGroupsReportedSorted verifies that the
+// [PackageListResult.ComponentGroups] field reports every component-group the
+// resolved component belongs to, sorted alphabetically, even when the package
+// itself is not listed in any package-group.
+func TestListPackages_ComponentGroupsReportedSorted(t *testing.T) {
 	testEnv := testutils.NewTestEnv(t)
 
 	testEnv.Config.ComponentGroups["base-published"] = projectconfig.ComponentGroupConfig{
@@ -579,7 +602,7 @@ func TestListPackages_GroupFallsBackToComponentGroup(t *testing.T) {
 
 	// Loader normally builds GroupsByComponent; tests that mutate ComponentGroups
 	// directly must keep the reverse index aligned. Insert in non-sorted order to
-	// confirm componentGroupLabel sorts before joining.
+	// confirm the per-result list is sorted alphabetically.
 	testEnv.Config.GroupsByComponent["jq"] = []string{"base-published", "alpha"}
 
 	results, err := pkgcmds.ListPackages(testEnv.Env, &pkgcmds.ListPackageOptions{PackageNames: []string{"jq"}})
@@ -587,13 +610,16 @@ func TestListPackages_GroupFallsBackToComponentGroup(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, results, 1)
 	assert.Equal(t, "jq", results[0].PackageName)
-	assert.Equal(t, "alpha,base-published", results[0].Group,
-		"Group should fall back to sorted, comma-joined component-group names")
+	assert.Empty(t, results[0].PackageGroups,
+		"PackageGroups should be empty when the package is not in any package-group")
+	assert.Equal(t, []string{"alpha", "base-published"}, results[0].ComponentGroups,
+		"ComponentGroups should be the sorted list of component-group memberships")
 }
 
-// TestListPackages_GroupPackageGroupWinsOverComponentGroup verifies that an explicit
-// package-group attribution still wins over the component-group fallback.
-func TestListPackages_GroupPackageGroupWinsOverComponentGroup(t *testing.T) {
+// TestListPackages_PackageGroupAndComponentGroupCoexist verifies that
+// package-group and component-group memberships are reported independently in the
+// [PackageListResult] rather than one overriding the other.
+func TestListPackages_PackageGroupAndComponentGroupCoexist(t *testing.T) {
 	testEnv := testutils.NewTestEnv(t)
 
 	testEnv.Config.PackageGroups = map[string]projectconfig.PackageGroupConfig{
@@ -608,14 +634,17 @@ func TestListPackages_GroupPackageGroupWinsOverComponentGroup(t *testing.T) {
 
 	require.NoError(t, err)
 	require.Len(t, results, 1)
-	assert.Equal(t, "devel-packages", results[0].Group,
-		"package-group attribution must win over the component-group fallback")
+	assert.Equal(t, []string{"devel-packages"}, results[0].PackageGroups,
+		"PackageGroups should report the package-group membership")
+	assert.Equal(t, []string{"base-published"}, results[0].ComponentGroups,
+		"ComponentGroups should report the component-group membership independently")
 }
 
-// TestListPackages_RPMFile_GroupFromComponentGroup verifies that --rpm-file rows
-// (both SRPM and binary RPM) get their Group from the resolved component's
-// component-group(s) when no package-group contains them.
-func TestListPackages_RPMFile_GroupFromComponentGroup(t *testing.T) {
+// TestListPackages_RPMFile_ComponentGroupsReported verifies that --rpm-file rows
+// (both SRPM and binary RPM) report their resolved component's component-group
+// memberships in [PackageListResult.ComponentGroups]. SRPM rows always have an
+// empty [PackageListResult.PackageGroups] list.
+func TestListPackages_RPMFile_ComponentGroupsReported(t *testing.T) {
 	testEnv := testutils.NewTestEnv(t)
 
 	testEnv.Config.Components["curl"] = projectconfig.ComponentConfig{Name: "curl"}
@@ -644,19 +673,24 @@ func TestListPackages_RPMFile_GroupFromComponentGroup(t *testing.T) {
 	}
 
 	srpm := byKey["curl#"+pkgcmds.PackageTypeSRPM]
-	assert.Equal(t, "base-published", srpm.Group,
-		"SRPM Group should fall back to its component's component-group")
+	assert.Empty(t, srpm.PackageGroups,
+		"SRPM PackageGroups should be empty (SRPMs have no package-group membership)")
+	assert.Equal(t, []string{"base-published"}, srpm.ComponentGroups,
+		"SRPM ComponentGroups should report the component's component-group memberships")
 
 	rpm := byKey["curl-devel#"+pkgcmds.PackageTypeRPM]
-	assert.Equal(t, "base-published", rpm.Group,
-		"binary RPM Group should fall back to its component's component-group when no package-group matches")
+	assert.Empty(t, rpm.PackageGroups,
+		"binary RPM PackageGroups should be empty when no package-group contains it")
+	assert.Equal(t, []string{"base-published"}, rpm.ComponentGroups,
+		"binary RPM ComponentGroups should report the resolved component's component-group memberships")
 }
 
-// TestListPackages_SynthesizeDebugPackages_DebugsourcePackageGroupOverridesComponentGroup verifies
-// that a synthesized '-debugsource' entry uses the package-group attribution when its name is
-// listed in a package-group, overriding the component-group baseline. This mirrors the
-// resolution used by [resolvePackageListResult] for regular RPMs.
-func TestListPackages_SynthesizeDebugPackages_DebugsourcePackageGroupOverridesComponentGroup(t *testing.T) {
+// TestListPackages_SynthesizeDebugPackages_DebugsourcePackageGroupReportedAlongsideComponentGroup verifies
+// that a synthesized '-debugsource' entry reports an explicit package-group membership in
+// [PackageListResult.PackageGroups] alongside the component-group baseline in
+// [PackageListResult.ComponentGroups]. This mirrors the resolution used by
+// [resolvePackageListResult] for regular RPMs.
+func TestListPackages_SynthesizeDebugPackages_DebugsourcePackageGroupReportedAlongsideComponentGroup(t *testing.T) {
 	testEnv := testutils.NewTestEnv(t)
 
 	testEnv.Config.Components["curl"] = projectconfig.ComponentConfig{Name: "curl"}
@@ -667,8 +701,8 @@ func TestListPackages_SynthesizeDebugPackages_DebugsourcePackageGroupOverridesCo
 	}
 	testEnv.Config.GroupsByComponent["curl"] = []string{"base-published"}
 
-	// Package-group explicitly lists 'curl-debugsource' — this should win over the
-	// component-group baseline for the synthesized entry.
+	// Package-group explicitly lists 'curl-debugsource' — this should appear in the
+	// synthesized entry's PackageGroups list independently of the component-group baseline.
 	testEnv.Config.PackageGroups = map[string]projectconfig.PackageGroupConfig{
 		"debug-packages": {Packages: []string{"curl-debugsource"}},
 	}
@@ -686,6 +720,8 @@ func TestListPackages_SynthesizeDebugPackages_DebugsourcePackageGroupOverridesCo
 	}
 
 	require.Contains(t, byName, "curl-debugsource")
-	assert.Equal(t, "debug-packages", byName["curl-debugsource"].Group,
-		"synthesized -debugsource Group should be overridden by an explicit package-group membership")
+	assert.Equal(t, []string{"debug-packages"}, byName["curl-debugsource"].PackageGroups,
+		"synthesized -debugsource PackageGroups should reflect the explicit package-group membership")
+	assert.Equal(t, []string{"base-published"}, byName["curl-debugsource"].ComponentGroups,
+		"synthesized -debugsource ComponentGroups should report the component's component-group memberships")
 }


### PR DESCRIPTION
Currently the `group` field on each `PackageListResult` is the name of the package-group that contains the binary package, or "" if the package isn't in any group. After switching to component-based config, it cannot reflect the component group.

This pull request replaces the single `group` field on PackageListResult with two independent sorted []string fields: `packageGroups` (every package-group whose 'packages' list contains the package; always empty for SRPM rows) and `componentGroups` (every component-group the resolved component belongs to). Both fields are guaranteed non-nil so JSON output is '[]' instead of 'null'.
    
Updates the table output, JSON schema, CLI help, how-to docs, and unit tests accordingly.

Example output of `azldev pkg list --rpm-file <rpm_source_map.json>`:
```json
[
...
 {
    "packageName": "fence-agents",
    "type": "srpm",
    "packageGroups": [],
    "componentGroups": [
      "base-packages"
    ],
    "component": "fence-agents",
    "publishChannel": "rpm-base-srpm"
  },
 {
    "packageName": "fence-agents-amt-ws",
    "type": "rpm",
    "packageGroups": [
      "exceptions-packages"
    ],
    "componentGroups": [
      "base-packages"
    ],
    "component": "fence-agents",
    "publishChannel": "rpm-sdk"
  },
  {
    "packageName": "fence-agents-apc",
    "type": "rpm",
    "packageGroups": [],
    "componentGroups": [
      "base-packages"
    ],
    "component": "fence-agents",
    "publishChannel": "rpm-base"
  },
...
]
```