### PR TITLE
feat: add dirty commit for uncommitted config changes in dist-git

### DIFF
--- a/internal/app/azldev/cmds/component/build.go
+++ b/internal/app/azldev/cmds/component/build.go
@@ -253,7 +253,9 @@ func BuildComponent(
 
 	var preparerOpts []sources.PreparerOption
 	if !options.WithoutGitRepo {
-		preparerOpts = append(preparerOpts, sources.WithGitRepo(env, env.LockReader()))
+		preparerOpts = append(preparerOpts,
+			sources.WithGitRepo(env, env.LockReader(), distro.Version.ReleaseVer),
+		)
 	}
 
 	sourcePreparer, err := sources.NewPreparer(sourceManager, env.FS(), env, env, preparerOpts...)

--- a/internal/app/azldev/cmds/component/build.go
+++ b/internal/app/azldev/cmds/component/build.go
@@ -255,6 +255,7 @@ func BuildComponent(
 	if !options.WithoutGitRepo {
 		preparerOpts = append(preparerOpts,
 			sources.WithGitRepo(env, env.LockReader(), distro.Version.ReleaseVer),
+			sources.WithDirtyDetection(),
 		)
 	}
 

--- a/internal/app/azldev/cmds/component/preparesources.go
+++ b/internal/app/azldev/cmds/component/preparesources.go
@@ -130,6 +130,7 @@ func PrepareComponentSources(env *azldev.Env, options *PrepareSourcesOptions) er
 	if !options.WithoutGitRepo && !options.SkipOverlays {
 		preparerOpts = append(preparerOpts,
 			sources.WithGitRepo(env, env.LockReader(), distro.Version.ReleaseVer),
+			sources.WithDirtyDetection(),
 		)
 	}
 

--- a/internal/app/azldev/cmds/component/preparesources.go
+++ b/internal/app/azldev/cmds/component/preparesources.go
@@ -128,7 +128,9 @@ func PrepareComponentSources(env *azldev.Env, options *PrepareSourcesOptions) er
 
 	var preparerOpts []sources.PreparerOption
 	if !options.WithoutGitRepo && !options.SkipOverlays {
-		preparerOpts = append(preparerOpts, sources.WithGitRepo(env, env.LockReader()))
+		preparerOpts = append(preparerOpts,
+			sources.WithGitRepo(env, env.LockReader(), distro.Version.ReleaseVer),
+		)
 	}
 
 	if options.AllowNoHashes {

--- a/internal/app/azldev/cmds/component/render.go
+++ b/internal/app/azldev/cmds/component/render.go
@@ -442,6 +442,7 @@ func prepareComponentSources(
 	// sidecar files are needed for rendering.
 	preparerOpts := []sources.PreparerOption{
 		sources.WithGitRepo(env, env.LockReader(), distro.Version.ReleaseVer),
+		sources.WithDirtyDetection(),
 		sources.WithSkipLookaside(),
 	}
 

--- a/internal/app/azldev/cmds/component/render.go
+++ b/internal/app/azldev/cmds/component/render.go
@@ -441,7 +441,7 @@ func prepareComponentSources(
 	// WithSkipLookaside avoids expensive tarball downloads — only spec +
 	// sidecar files are needed for rendering.
 	preparerOpts := []sources.PreparerOption{
-		sources.WithGitRepo(env, env.LockReader()),
+		sources.WithGitRepo(env, env.LockReader(), distro.Version.ReleaseVer),
 		sources.WithSkipLookaside(),
 	}
 

--- a/internal/app/azldev/core/sources/sourceprep.go
+++ b/internal/app/azldev/core/sources/sourceprep.go
@@ -18,6 +18,7 @@ import (
 	"github.com/go-git/go-git/v5/plumbing/filemode"
 	"github.com/go-git/go-git/v5/plumbing/object"
 	"github.com/microsoft/azure-linux-dev-tools/internal/app/azldev/core/components"
+	"github.com/microsoft/azure-linux-dev-tools/internal/fingerprint"
 	"github.com/microsoft/azure-linux-dev-tools/internal/global/opctx"
 	"github.com/microsoft/azure-linux-dev-tools/internal/lockfile"
 	"github.com/microsoft/azure-linux-dev-tools/internal/projectconfig"
@@ -66,14 +67,18 @@ type PreparerOption func(*sourcePreparerImpl)
 //
 // The cmdFactory is used to shell out to git for fingerprint change detection.
 // The lockReader provides access to per-component lock files and their directory.
+// The releaseVer is the distro's formal release version (e.g., "4.0"), used to
+// compute the current fingerprint for uncommitted-change detection.
 func WithGitRepo(
 	cmdFactory opctx.CmdFactory,
 	lockReader lockfile.LockReader,
+	releaseVer string,
 ) PreparerOption {
 	return func(p *sourcePreparerImpl) {
 		p.withGitRepo = true
 		p.cmdFactory = cmdFactory
 		p.lockReader = lockReader
+		p.releaseVer = releaseVer
 	}
 }
 
@@ -134,6 +139,10 @@ type sourcePreparerImpl struct {
 	// allowNoHashes, when true, allows source file references without hash
 	// values. Missing hashes are computed from the downloaded files.
 	allowNoHashes bool
+
+	// releaseVer is the distro's formal release version. Used to compute the
+	// current fingerprint for uncommitted-change detection. Set via [WithGitRepo].
+	releaseVer string
 }
 
 // NewPreparer creates a new [SourcePreparer] instance. All positional arguments
@@ -373,9 +382,15 @@ func (p *sourcePreparerImpl) trySyntheticHistory(
 	config := component.GetConfig()
 	componentName := component.GetName()
 
-	// Build commit metadata from lock file fingerprint changes.
+	// Compute the current fingerprint for uncommitted-change detection.
+	currentFingerprint, fpErr := computeCurrentFingerprint(p.fs, config, p.releaseVer)
+	if fpErr != nil {
+		return fmt.Errorf("failed to compute current fingerprint:\n%w", fpErr)
+	}
+
 	changes, importCommit, err := buildSyntheticCommits(
 		ctx, p.cmdFactory, config, componentName, p.lockReader.LockDir(),
+		currentFingerprint,
 	)
 	if err != nil {
 		return fmt.Errorf("failed to build synthetic commits:\n%w", err)
@@ -427,6 +442,45 @@ func (p *sourcePreparerImpl) trySyntheticHistory(
 	}
 
 	return nil
+}
+
+// computeCurrentFingerprint computes the current input fingerprint for a
+// component from its resolved config. Returns an empty string for local
+// components or when the source identity cannot be determined — these cases
+// skip uncommitted-change detection gracefully.
+func computeCurrentFingerprint(
+	fs opctx.FS,
+	config *projectconfig.ComponentConfig,
+	releaseVer string,
+) (string, error) {
+	if config == nil {
+		return "", nil
+	}
+
+	sourceIdentity := config.EffectiveUpstreamCommit()
+	if sourceIdentity == "" {
+		return "", nil
+	}
+
+	var manualBump int
+	if config.Locked != nil {
+		manualBump = config.Locked.ManualBump
+	}
+
+	identity, err := fingerprint.ComputeIdentity(
+		fs,
+		*config,
+		releaseVer,
+		fingerprint.IdentityOptions{
+			ManualBump:     manualBump,
+			SourceIdentity: sourceIdentity,
+		},
+	)
+	if err != nil {
+		return "", fmt.Errorf("computing fingerprint:\n%w", err)
+	}
+
+	return identity.Fingerprint, nil
 }
 
 // removeSubmoduleEntries strips gitlink (mode 160000) entries from the repository

--- a/internal/app/azldev/core/sources/sourceprep.go
+++ b/internal/app/azldev/core/sources/sourceprep.go
@@ -67,8 +67,9 @@ type PreparerOption func(*sourcePreparerImpl)
 //
 // The cmdFactory is used to shell out to git for fingerprint change detection.
 // The lockReader provides access to per-component lock files and their directory.
-// The releaseVer is the distro's formal release version (e.g., "4.0"), used to
-// compute the current fingerprint for uncommitted-change detection.
+// The releaseVer must be the per-component resolved distro release version
+// (e.g., "4.0"), not the project default — components may override the distro
+// via [projectconfig.SpecSource.UpstreamDistro].
 func WithGitRepo(
 	cmdFactory opctx.CmdFactory,
 	lockReader lockfile.LockReader,
@@ -79,6 +80,21 @@ func WithGitRepo(
 		p.cmdFactory = cmdFactory
 		p.lockReader = lockReader
 		p.releaseVer = releaseVer
+	}
+}
+
+// WithDirtyDetection returns a [PreparerOption] that enables uncommitted-change
+// detection during synthetic history generation. When set, the current input
+// fingerprint is compared against the committed lock file; if they differ, a
+// "dirty" synthetic commit is appended to represent the uncommitted changes.
+// Without this option, only committed fingerprint changes produce synthetic commits.
+//
+// This should be enabled for commands that operate on the working tree state
+// (build, render, prepare-sources) and left disabled for commands that should
+// only reflect committed state.
+func WithDirtyDetection() PreparerOption {
+	return func(p *sourcePreparerImpl) {
+		p.dirtyDetection = true
 	}
 }
 
@@ -140,8 +156,12 @@ type sourcePreparerImpl struct {
 	// values. Missing hashes are computed from the downloaded files.
 	allowNoHashes bool
 
-	// releaseVer is the distro's formal release version. Used to compute the
-	// current fingerprint for uncommitted-change detection. Set via [WithGitRepo].
+	// dirtyDetection, when true, enables uncommitted-change detection during
+	// synthetic history generation. Set via [WithDirtyDetection].
+	dirtyDetection bool
+
+	// releaseVer is the per-component resolved distro release version, not the
+	// project default. Set via [WithGitRepo].
 	releaseVer string
 }
 
@@ -181,6 +201,11 @@ func NewPreparer(
 		if opt != nil {
 			opt(impl)
 		}
+	}
+
+	if impl.dirtyDetection && !impl.withGitRepo {
+		return nil, errors.New("WithDirtyDetection requires WithGitRepo; " +
+			"dirty detection compares fingerprints against committed lock files in the git history")
 	}
 
 	return impl, nil
@@ -383,7 +408,18 @@ func (p *sourcePreparerImpl) trySyntheticHistory(
 	componentName := component.GetName()
 
 	// Compute the current fingerprint for uncommitted-change detection.
-	currentFingerprint := computeCurrentFingerprint(p.fs, config, p.releaseVer)
+	// Only computed when dirty detection is enabled (e.g., build, render).
+	// An empty fingerprint skips dirty detection in buildSyntheticCommits.
+	var currentFingerprint string
+
+	if p.dirtyDetection {
+		var fpErr error
+
+		currentFingerprint, fpErr = computeCurrentFingerprint(p.fs, config, p.releaseVer)
+		if fpErr != nil {
+			return fmt.Errorf("dirty detection failed for component %#q:\n%w", componentName, fpErr)
+		}
+	}
 
 	changes, importCommit, err := buildSyntheticCommits(
 		ctx, p.cmdFactory, config, componentName, p.lockReader.LockDir(),
@@ -442,21 +478,22 @@ func (p *sourcePreparerImpl) trySyntheticHistory(
 }
 
 // computeCurrentFingerprint computes the current input fingerprint for a
-// component from its resolved config. Returns an empty string for local
-// components or when the source identity cannot be determined — these cases
-// skip uncommitted-change detection gracefully.
+// component from its resolved config. Returns ("", nil) for local components
+// or when the source identity cannot be determined — dirty detection is
+// silently skipped for these. Returns a non-nil error when the fingerprint
+// computation itself fails.
 func computeCurrentFingerprint(
 	fs opctx.FS,
 	config *projectconfig.ComponentConfig,
 	releaseVer string,
-) string {
+) (string, error) {
 	if config == nil {
-		return ""
+		return "", nil
 	}
 
 	sourceIdentity := config.EffectiveUpstreamCommit()
 	if sourceIdentity == "" {
-		return ""
+		return "", nil
 	}
 
 	var manualBump int
@@ -474,15 +511,10 @@ func computeCurrentFingerprint(
 		},
 	)
 	if err != nil {
-		slog.Debug("Skipping dirty detection because current fingerprint could not be computed",
-			"component", config.Name,
-			"releaseVer", releaseVer,
-			"error", err)
-
-		return ""
+		return "", fmt.Errorf("computing current fingerprint for %#q:\n%w", config.Name, err)
 	}
 
-	return identity.Fingerprint
+	return identity.Fingerprint, nil
 }
 
 // removeSubmoduleEntries strips gitlink (mode 160000) entries from the repository

--- a/internal/app/azldev/core/sources/sourceprep.go
+++ b/internal/app/azldev/core/sources/sourceprep.go
@@ -383,10 +383,7 @@ func (p *sourcePreparerImpl) trySyntheticHistory(
 	componentName := component.GetName()
 
 	// Compute the current fingerprint for uncommitted-change detection.
-	currentFingerprint, fpErr := computeCurrentFingerprint(p.fs, config, p.releaseVer)
-	if fpErr != nil {
-		return fmt.Errorf("failed to compute current fingerprint:\n%w", fpErr)
-	}
+	currentFingerprint := computeCurrentFingerprint(p.fs, config, p.releaseVer)
 
 	changes, importCommit, err := buildSyntheticCommits(
 		ctx, p.cmdFactory, config, componentName, p.lockReader.LockDir(),
@@ -452,14 +449,14 @@ func computeCurrentFingerprint(
 	fs opctx.FS,
 	config *projectconfig.ComponentConfig,
 	releaseVer string,
-) (string, error) {
+) string {
 	if config == nil {
-		return "", nil
+		return ""
 	}
 
 	sourceIdentity := config.EffectiveUpstreamCommit()
 	if sourceIdentity == "" {
-		return "", nil
+		return ""
 	}
 
 	var manualBump int
@@ -477,10 +474,15 @@ func computeCurrentFingerprint(
 		},
 	)
 	if err != nil {
-		return "", fmt.Errorf("computing fingerprint:\n%w", err)
+		slog.Debug("Skipping dirty detection because current fingerprint could not be computed",
+			"component", config.Name,
+			"releaseVer", releaseVer,
+			"error", err)
+
+		return ""
 	}
 
-	return identity.Fingerprint, nil
+	return identity.Fingerprint
 }
 
 // removeSubmoduleEntries strips gitlink (mode 160000) entries from the repository

--- a/internal/app/azldev/core/sources/sourceprep_internal_test.go
+++ b/internal/app/azldev/core/sources/sourceprep_internal_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/go-git/go-git/v5/plumbing/filemode"
 	"github.com/go-git/go-git/v5/plumbing/format/index"
 	"github.com/go-git/go-git/v5/storage/memory"
+	"github.com/microsoft/azure-linux-dev-tools/internal/projectconfig"
 	"github.com/microsoft/azure-linux-dev-tools/internal/utils/fileperms"
 	"github.com/microsoft/azure-linux-dev-tools/internal/utils/fileutils"
 	"github.com/spf13/afero"
@@ -162,4 +163,121 @@ func TestRemoveSubmoduleEntries_PreservesNormalEntriesWithMixedModes(t *testing.
 	require.Len(t, updatedIdx.Entries, 2)
 	assert.Equal(t, "build.sh", updatedIdx.Entries[0].Name)
 	assert.Equal(t, "pkg.spec", updatedIdx.Entries[1].Name)
+}
+
+func TestComputeCurrentFingerprint(t *testing.T) {
+	memFS := afero.NewMemMapFs()
+
+	lockedConfig := func(commit string, manualBump int) *projectconfig.ComponentConfig {
+		return &projectconfig.ComponentConfig{
+			Name: "test",
+			Spec: projectconfig.SpecSource{SourceType: projectconfig.SpecSourceTypeUpstream},
+			Locked: &projectconfig.ComponentLockData{
+				UpstreamCommit: commit,
+				ManualBump:     manualBump,
+			},
+		}
+	}
+
+	tests := []struct {
+		name      string
+		config    *projectconfig.ComponentConfig
+		wantEmpty bool
+		wantErr   bool
+	}{
+		{
+			name:      "nil config returns empty",
+			config:    nil,
+			wantEmpty: true,
+		},
+		{
+			name:      "no upstream commit returns empty",
+			config:    &projectconfig.ComponentConfig{Name: "test"},
+			wantEmpty: true,
+		},
+		{
+			name: "empty spec upstream commit without lock returns empty",
+			config: &projectconfig.ComponentConfig{
+				Name: "test",
+				Spec: projectconfig.SpecSource{SourceType: projectconfig.SpecSourceTypeUpstream},
+			},
+			wantEmpty: true,
+		},
+		{
+			name:   "locked upstream commit produces fingerprint",
+			config: lockedConfig("abc123def456", 0),
+		},
+		{
+			name: "spec upstream commit fallback produces fingerprint",
+			config: &projectconfig.ComponentConfig{
+				Name: "test",
+				Spec: projectconfig.SpecSource{
+					SourceType:     projectconfig.SpecSourceTypeUpstream,
+					UpstreamCommit: "abc123def456",
+				},
+			},
+		},
+		{
+			name:   "locked manual bump produces fingerprint",
+			config: lockedConfig("abc123def456", 5),
+		},
+		{
+			name: "source file without hash returns error",
+			config: &projectconfig.ComponentConfig{
+				Name: "test",
+				Spec: projectconfig.SpecSource{
+					SourceType:     projectconfig.SpecSourceTypeUpstream,
+					UpstreamCommit: "abc123def456",
+				},
+				SourceFiles: []projectconfig.SourceFileReference{
+					{Filename: "extra.tar.gz"},
+				},
+			},
+			wantErr: true,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			result, err := computeCurrentFingerprint(memFS, test.config, "3.0")
+
+			if test.wantErr {
+				assert.Error(t, err)
+
+				return
+			}
+
+			require.NoError(t, err)
+
+			if test.wantEmpty {
+				assert.Empty(t, result)
+			} else {
+				assert.NotEmpty(t, result)
+			}
+		})
+	}
+
+	// Determinism: same inputs → same fingerprint.
+	fp1, err := computeCurrentFingerprint(memFS, lockedConfig("abc123def456", 0), "3.0")
+	require.NoError(t, err)
+
+	fp2, err := computeCurrentFingerprint(memFS, lockedConfig("abc123def456", 0), "3.0")
+	require.NoError(t, err)
+
+	require.NotEmpty(t, fp1)
+	assert.Equal(t, fp1, fp2, "identical inputs should produce identical fingerprint")
+
+	// Sensitivity: changing any input changes the fingerprint.
+	fpDiffRelease, err := computeCurrentFingerprint(memFS, lockedConfig("abc123def456", 0), "4.0")
+	require.NoError(t, err)
+
+	fpDiffCommit, err := computeCurrentFingerprint(memFS, lockedConfig("999888777666", 0), "3.0")
+	require.NoError(t, err)
+
+	fpDiffBump, err := computeCurrentFingerprint(memFS, lockedConfig("abc123def456", 1), "3.0")
+	require.NoError(t, err)
+
+	assert.NotEqual(t, fp1, fpDiffRelease, "different releaseVer should change fingerprint")
+	assert.NotEqual(t, fp1, fpDiffCommit, "different upstream commit should change fingerprint")
+	assert.NotEqual(t, fp1, fpDiffBump, "different manual bump should change fingerprint")
 }

--- a/internal/app/azldev/core/sources/sourceprep_test.go
+++ b/internal/app/azldev/core/sources/sourceprep_test.go
@@ -45,6 +45,19 @@ func TestNewPreparer_NilArgs(t *testing.T) {
 	require.Contains(t, err.Error(), "filesystem")
 }
 
+func TestNewPreparer_DirtyDetectionWithoutGitRepo(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	sourceManager := sourceproviders_test.NewMockSourceManager(ctrl)
+	ctx := testctx.NewCtx()
+
+	preparer, err := sources.NewPreparer(sourceManager, ctx.FS(), ctx, ctx,
+		sources.WithDirtyDetection(),
+	)
+	require.Nil(t, preparer)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "WithDirtyDetection requires WithGitRepo")
+}
+
 func TestPrepareSources_Success(t *testing.T) {
 	const (
 		testSpecName   = "test-component.spec"

--- a/internal/app/azldev/core/sources/synthistory.go
+++ b/internal/app/azldev/core/sources/synthistory.go
@@ -506,42 +506,31 @@ func buildSyntheticCommits(
 			lockFileRelPath, err)
 	}
 
+	// In a shallow clone the commit that added the lock file may have been
+	// pruned. Detect this before falling through to dirty detection.
 	if len(fpChanges) == 0 {
-		// In a shallow clone the commit that added the lock file may have
-		// been pruned, so check explicitly.
 		shallowCommits, _ := projectRepo.Storer.Shallow()
 		if len(shallowCommits) > 0 {
 			return nil, "", fmt.Errorf(
 				"lock file %#q has no git history; a full clone is required",
 				lockFileRelPath)
 		}
-
-		// Even with no committed fingerprint changes, there may be
-		// uncommitted ("dirty") changes worth representing.
-		if dirty := BuildDirtyChange(currentFingerprint, headLock, fpChanges); dirty != nil {
-			slog.Info("Current fingerprint differs from HEAD lock file; adding dirty entry",
-				"lockFile", lockFileRelPath)
-
-			return []FingerprintChange{*dirty}, importCommit, nil
-		}
-
-		slog.Warn("Lock file has no fingerprint changes; skipping synthetic history",
-			"lockFile", lockFileRelPath)
-
-		return nil, "", nil
 	}
-
-	slog.Info("Found fingerprint changes",
-		"lockFile", lockFileRelPath,
-		"changeCount", len(fpChanges))
 
 	// Check for uncommitted ("dirty") changes by comparing the caller-provided
 	// current fingerprint against the fingerprint stored in the HEAD lock file.
-	if dirty := BuildDirtyChange(currentFingerprint, headLock, fpChanges); dirty != nil {
+	if dirty := BuildDirtyChange(currentFingerprint, headLock, config.EffectiveUpstreamCommit()); dirty != nil {
 		slog.Info("Current fingerprint differs from HEAD lock file; adding dirty entry",
 			"lockFile", lockFileRelPath)
 
 		fpChanges = append(fpChanges, *dirty)
+	}
+
+	if len(fpChanges) == 0 {
+		slog.Warn("Lock file has no fingerprint changes; skipping synthetic history",
+			"lockFile", lockFileRelPath)
+
+		return nil, "", nil
 	}
 
 	return fpChanges, importCommit, nil
@@ -550,12 +539,22 @@ func buildSyntheticCommits(
 // BuildDirtyChange returns a [FingerprintChange] representing uncommitted
 // config/overlay changes. Returns nil when currentFingerprint is empty or
 // matches the HEAD lock file's fingerprint.
+//
+// currentUpstreamCommit is the effective upstream commit from the on-disk
+// (possibly uncommitted) lock file. This is used instead of
+// [headLock.UpstreamCommit] so that upstream commit changes from
+// 'component update' (written to disk but not yet committed) are reflected
+// in the dirty entry.
 func BuildDirtyChange(
 	currentFingerprint string,
 	headLock *lockfile.ComponentLock,
-	existingChanges []FingerprintChange,
+	currentUpstreamCommit string,
 ) *FingerprintChange {
 	if currentFingerprint == "" {
+		return nil
+	}
+
+	if headLock == nil || headLock.InputFingerprint == "" {
 		return nil
 	}
 
@@ -565,8 +564,7 @@ func BuildDirtyChange(
 
 	slog.Debug("Dirty fingerprint detected",
 		"current", currentFingerprint,
-		"head", headLock.InputFingerprint,
-		"existingChanges", len(existingChanges))
+		"head", headLock.InputFingerprint)
 
 	return &FingerprintChange{
 		CommitMetadata: CommitMetadata{
@@ -576,7 +574,7 @@ func BuildDirtyChange(
 			Timestamp:   time.Now().Unix(),
 			Message:     "Local changes (uncommitted)",
 		},
-		UpstreamCommit: headLock.UpstreamCommit,
+		UpstreamCommit: currentUpstreamCommit,
 	}
 }
 

--- a/internal/app/azldev/core/sources/synthistory.go
+++ b/internal/app/azldev/core/sources/synthistory.go
@@ -451,6 +451,11 @@ func updateHead(repo *gogit.Repository, commitHash plumbing.Hash) error {
 // The second return value is the import-commit hash from the lock file, used
 // to scope the upstream commit walk in [CommitInterleavedHistory].
 //
+// When currentFingerprint is non-empty it is compared against the fingerprint
+// stored in the HEAD commit's lock file. If they differ a "dirty" entry is
+// appended so that uncommitted config/overlay changes are represented in the
+// synthetic history.
+//
 // The lockDir is the absolute path to the lock file directory. It is converted
 // to a repo-relative path internally once the git repository root is known.
 func buildSyntheticCommits(
@@ -459,6 +464,7 @@ func buildSyntheticCommits(
 	config *projectconfig.ComponentConfig,
 	componentName string,
 	lockDir string,
+	currentFingerprint string,
 ) (changes []FingerprintChange, importCommit string, err error) {
 	projectRepo, projectRepoDir, err := openProjectRepo(config, componentName)
 	if err != nil {
@@ -510,6 +516,15 @@ func buildSyntheticCommits(
 				lockFileRelPath)
 		}
 
+		// Even with no committed fingerprint changes, there may be
+		// uncommitted ("dirty") changes worth representing.
+		if dirty := BuildDirtyChange(currentFingerprint, headLock, fpChanges); dirty != nil {
+			slog.Info("Current fingerprint differs from HEAD lock file; adding dirty entry",
+				"lockFile", lockFileRelPath)
+
+			return []FingerprintChange{*dirty}, importCommit, nil
+		}
+
 		slog.Warn("Lock file has no fingerprint changes; skipping synthetic history",
 			"lockFile", lockFileRelPath)
 
@@ -520,7 +535,49 @@ func buildSyntheticCommits(
 		"lockFile", lockFileRelPath,
 		"changeCount", len(fpChanges))
 
+	// Check for uncommitted ("dirty") changes by comparing the caller-provided
+	// current fingerprint against the fingerprint stored in the HEAD lock file.
+	if dirty := BuildDirtyChange(currentFingerprint, headLock, fpChanges); dirty != nil {
+		slog.Info("Current fingerprint differs from HEAD lock file; adding dirty entry",
+			"lockFile", lockFileRelPath)
+
+		fpChanges = append(fpChanges, *dirty)
+	}
+
 	return fpChanges, importCommit, nil
+}
+
+// BuildDirtyChange returns a [FingerprintChange] representing uncommitted
+// config/overlay changes. Returns nil when currentFingerprint is empty or
+// matches the HEAD lock file's fingerprint.
+func BuildDirtyChange(
+	currentFingerprint string,
+	headLock *lockfile.ComponentLock,
+	existingChanges []FingerprintChange,
+) *FingerprintChange {
+	if currentFingerprint == "" {
+		return nil
+	}
+
+	if currentFingerprint == headLock.InputFingerprint {
+		return nil
+	}
+
+	slog.Debug("Dirty fingerprint detected",
+		"current", currentFingerprint,
+		"head", headLock.InputFingerprint,
+		"existingChanges", len(existingChanges))
+
+	return &FingerprintChange{
+		CommitMetadata: CommitMetadata{
+			Hash:        "dirty",
+			Author:      "azldev",
+			AuthorEmail: "azldev@local",
+			Timestamp:   time.Now().Unix(),
+			Message:     "Local changes (uncommitted)",
+		},
+		UpstreamCommit: headLock.UpstreamCommit,
+	}
 }
 
 // openProjectRepo opens the git repository that contains the component's

--- a/internal/app/azldev/core/sources/synthistory.go
+++ b/internal/app/azldev/core/sources/synthistory.go
@@ -447,9 +447,9 @@ func updateHead(repo *gogit.Repository, commitHash plumbing.Hash) error {
 // buildSyntheticCommits resolves the project repository from the component's
 // config file, walks the lock file's git history for fingerprint changes, and
 // returns the matching [FingerprintChange] entries sorted chronologically.
-// Returns an error if the lock file exists but has no fingerprint changes.
-// The second return value is the import-commit hash from the lock file, used
-// to scope the upstream commit walk in [CommitInterleavedHistory].
+// Returns (nil, "", nil) when there are no changes to represent — either the
+// lock file is missing, has no fingerprint changes (with a warning), or the
+// current fingerprint matches the committed one.
 //
 // When currentFingerprint is non-empty it is compared against the fingerprint
 // stored in the HEAD commit's lock file. If they differ a "dirty" entry is

--- a/internal/app/azldev/core/sources/synthistory_test.go
+++ b/internal/app/azldev/core/sources/synthistory_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/go-git/go-git/v5/plumbing/object"
 	"github.com/go-git/go-git/v5/storage/memory"
 	"github.com/microsoft/azure-linux-dev-tools/internal/app/azldev/core/sources"
+	"github.com/microsoft/azure-linux-dev-tools/internal/lockfile"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -715,6 +716,71 @@ func TestParseCommitMetadata(t *testing.T) {
 
 			require.NoError(t, err)
 			assert.Equal(t, test.want, got)
+		})
+	}
+}
+
+func TestBuildDirtyChange(t *testing.T) {
+	tests := []struct {
+		name               string
+		currentFingerprint string
+		headLock           *lockfile.ComponentLock
+		existingChanges    []sources.FingerprintChange
+		wantNil            bool
+		wantUpstream       string
+	}{
+		{
+			name:               "empty fingerprint disables detection",
+			currentFingerprint: "",
+			headLock:           &lockfile.ComponentLock{InputFingerprint: "sha256:abc123", UpstreamCommit: "upc"},
+			wantNil:            true,
+		},
+		{
+			name:               "matching fingerprint returns nil",
+			currentFingerprint: "sha256:abc123",
+			headLock:           &lockfile.ComponentLock{InputFingerprint: "sha256:abc123", UpstreamCommit: "upc"},
+			wantNil:            true,
+		},
+		{
+			name:               "different fingerprint creates dirty entry",
+			currentFingerprint: "sha256:new",
+			headLock:           &lockfile.ComponentLock{InputFingerprint: "sha256:old", UpstreamCommit: "upc"},
+			wantUpstream:       "upc",
+		},
+		{
+			name:               "dirty entry created even with existing changes",
+			currentFingerprint: "sha256:new",
+			headLock:           &lockfile.ComponentLock{InputFingerprint: "sha256:old", UpstreamCommit: "upc"},
+			existingChanges: []sources.FingerprintChange{
+				{CommitMetadata: sources.CommitMetadata{Hash: "abc"}, UpstreamCommit: "upc"},
+			},
+			wantUpstream: "upc",
+		},
+		{
+			name:               "empty upstream commit preserved for local components",
+			currentFingerprint: "sha256:new",
+			headLock:           &lockfile.ComponentLock{InputFingerprint: "sha256:old", UpstreamCommit: ""},
+			wantUpstream:       "",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			result := sources.BuildDirtyChange(test.currentFingerprint, test.headLock, test.existingChanges)
+
+			if test.wantNil {
+				assert.Nil(t, result)
+
+				return
+			}
+
+			require.NotNil(t, result)
+			assert.Equal(t, "dirty", result.Hash)
+			assert.Equal(t, "azldev", result.Author)
+			assert.Equal(t, "azldev@local", result.AuthorEmail)
+			assert.Equal(t, "Local changes (uncommitted)", result.Message)
+			assert.Equal(t, test.wantUpstream, result.UpstreamCommit)
+			assert.NotZero(t, result.Timestamp)
 		})
 	}
 }

--- a/internal/app/azldev/core/sources/synthistory_test.go
+++ b/internal/app/azldev/core/sources/synthistory_test.go
@@ -722,51 +722,60 @@ func TestParseCommitMetadata(t *testing.T) {
 
 func TestBuildDirtyChange(t *testing.T) {
 	tests := []struct {
-		name               string
-		currentFingerprint string
-		headLock           *lockfile.ComponentLock
-		existingChanges    []sources.FingerprintChange
-		wantNil            bool
-		wantUpstream       string
+		name                  string
+		currentFingerprint    string
+		headLock              *lockfile.ComponentLock
+		currentUpstreamCommit string
+		wantNil               bool
+		wantUpstream          string
 	}{
 		{
-			name:               "empty fingerprint disables detection",
-			currentFingerprint: "",
-			headLock:           &lockfile.ComponentLock{InputFingerprint: "sha256:abc123", UpstreamCommit: "upc"},
-			wantNil:            true,
+			name:                  "empty fingerprint disables detection",
+			currentFingerprint:    "",
+			headLock:              &lockfile.ComponentLock{InputFingerprint: "sha256:abc123", UpstreamCommit: "old"},
+			currentUpstreamCommit: "new",
+			wantNil:               true,
 		},
 		{
-			name:               "matching fingerprint returns nil",
-			currentFingerprint: "sha256:abc123",
-			headLock:           &lockfile.ComponentLock{InputFingerprint: "sha256:abc123", UpstreamCommit: "upc"},
-			wantNil:            true,
+			name:                  "matching fingerprint returns nil",
+			currentFingerprint:    "sha256:abc123",
+			headLock:              &lockfile.ComponentLock{InputFingerprint: "sha256:abc123", UpstreamCommit: "old"},
+			currentUpstreamCommit: "new",
+			wantNil:               true,
 		},
 		{
-			name:               "different fingerprint creates dirty entry",
-			currentFingerprint: "sha256:new",
-			headLock:           &lockfile.ComponentLock{InputFingerprint: "sha256:old", UpstreamCommit: "upc"},
-			wantUpstream:       "upc",
+			name:                  "nil headLock returns nil",
+			currentFingerprint:    "sha256:abc123",
+			headLock:              nil,
+			currentUpstreamCommit: "new",
+			wantNil:               true,
 		},
 		{
-			name:               "dirty entry created even with existing changes",
-			currentFingerprint: "sha256:new",
-			headLock:           &lockfile.ComponentLock{InputFingerprint: "sha256:old", UpstreamCommit: "upc"},
-			existingChanges: []sources.FingerprintChange{
-				{CommitMetadata: sources.CommitMetadata{Hash: "abc"}, UpstreamCommit: "upc"},
-			},
-			wantUpstream: "upc",
+			name:                  "different fingerprint uses current upstream commit",
+			currentFingerprint:    "sha256:new",
+			headLock:              &lockfile.ComponentLock{InputFingerprint: "sha256:old", UpstreamCommit: "old-commit"},
+			currentUpstreamCommit: "new-commit",
+			wantUpstream:          "new-commit",
 		},
 		{
-			name:               "empty upstream commit preserved for local components",
-			currentFingerprint: "sha256:new",
-			headLock:           &lockfile.ComponentLock{InputFingerprint: "sha256:old", UpstreamCommit: ""},
-			wantUpstream:       "",
+			name:                  "uses current upstream even when it matches head lock",
+			currentFingerprint:    "sha256:new",
+			headLock:              &lockfile.ComponentLock{InputFingerprint: "sha256:old", UpstreamCommit: "same-commit"},
+			currentUpstreamCommit: "same-commit",
+			wantUpstream:          "same-commit",
+		},
+		{
+			name:                  "empty current upstream preserved for local components",
+			currentFingerprint:    "sha256:new",
+			headLock:              &lockfile.ComponentLock{InputFingerprint: "sha256:old", UpstreamCommit: ""},
+			currentUpstreamCommit: "",
+			wantUpstream:          "",
 		},
 	}
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			result := sources.BuildDirtyChange(test.currentFingerprint, test.headLock, test.existingChanges)
+			result := sources.BuildDirtyChange(test.currentFingerprint, test.headLock, test.currentUpstreamCommit)
 
 			if test.wantNil {
 				assert.Nil(t, result)


### PR DESCRIPTION
When preparing sources with a synthetic dist-git, the tool now computes the component's current input fingerprint and compares it against the fingerprint stored in the project repo's HEAD lock file. If they differ, an extra "dirty" synthetic commit is appended so the dist-git reflects the developer's uncommitted config/overlay changes.

This ensures that local edits to component config, overlays, or build settings are represented in the dist-git history without requiring a commit to the project repo first.