### PR TITLE
fix(cli): Don't return null json when getting empty slices

### DIFF
--- a/internal/app/azldev/command.go
+++ b/internal/app/azldev/command.go
@@ -8,6 +8,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"reflect"
 
 	"github.com/charmbracelet/x/term"
 	"github.com/mattn/go-isatty"
@@ -233,6 +234,19 @@ func createReflectableOptions(env *Env, format reflectable.Format) *reflectable.
 
 // Displays the results of a command to stdout in JSON format.
 func reportResultsAsJSON(env *Env, results interface{}) error {
+	// Normalize a typed-nil slice/map to an empty one so it marshals as `[]`
+	// or `{}` rather than `null`. This keeps JSON output friendly for
+	// downstream pipelines (e.g., `jq '.[]'` and `jq 'keys'` work whether or
+	// not there are results).
+	value := reflect.ValueOf(results)
+	if value.IsValid() && value.Kind() == reflect.Slice && value.IsNil() {
+		results = reflect.MakeSlice(value.Type(), 0, 0).Interface()
+	}
+
+	if value.IsValid() && value.Kind() == reflect.Map && value.IsNil() {
+		results = reflect.MakeMap(value.Type()).Interface()
+	}
+
 	jsonBytes, err := json.MarshalIndent(results, "", "  ")
 	if err != nil {
 		return fmt.Errorf("failed to marshal command results to JSON:\n%w", err)

--- a/internal/app/azldev/command_test.go
+++ b/internal/app/azldev/command_test.go
@@ -87,6 +87,54 @@ func TestRunFunc_ResultsAsJSON(t *testing.T) {
 	}
 }
 
+func TestRunFunc_ResultsAsJSON_NilSlice(t *testing.T) {
+	// A typed-nil slice should marshal as `[]` rather than `null` so the
+	// JSON output is safe to pipe into jq without `(. // [])` guards.
+	runFunc := azldev.RunFunc(func(env *azldev.Env) (interface{}, error) {
+		var results []string
+
+		return results, nil
+	})
+
+	env := testutils.NewTestEnv(t)
+	env.Env.SetDefaultReportFormat(azldev.ReportFormatJSON)
+
+	reportOutput := new(strings.Builder)
+	env.Env.SetReportFile(reportOutput)
+
+	if assert.NotNil(t, runFunc) {
+		err := runFunc(testCmd(env.Env), []string{})
+
+		if assert.NoError(t, err) {
+			assert.Equal(t, "[]\n", reportOutput.String())
+		}
+	}
+}
+
+func TestRunFunc_ResultsAsJSON_NilMap(t *testing.T) {
+	// A typed-nil map should marshal as `{}` rather than `null` so the
+	// JSON output is safe to pipe into jq without `(. // {})` guards.
+	runFunc := azldev.RunFunc(func(env *azldev.Env) (interface{}, error) {
+		var results map[string]int
+
+		return results, nil
+	})
+
+	env := testutils.NewTestEnv(t)
+	env.Env.SetDefaultReportFormat(azldev.ReportFormatJSON)
+
+	reportOutput := new(strings.Builder)
+	env.Env.SetReportFile(reportOutput)
+
+	if assert.NotNil(t, runFunc) {
+		err := runFunc(testCmd(env.Env), []string{})
+
+		if assert.NoError(t, err) {
+			assert.Equal(t, "{}\n", reportOutput.String())
+		}
+	}
+}
+
 func TestRunFunc_ResultsAsCSV(t *testing.T) {
 	runFunc := azldev.RunFunc(func(env *azldev.Env) (interface{}, error) {
 		return "a", nil


### PR DESCRIPTION
Removes the need to do:
```
azldev some cmd -O json | jq '(. // []) | .[] | select ...
```