### PR TITLE
feat(cli): Add check-only option to update

### DIFF
--- a/docs/user/reference/cli/azldev_component_update.md
+++ b/docs/user/reference/cli/azldev_component_update.md
@@ -56,7 +56,7 @@ azldev component update [flags]
 ```
   -a, --all-components                Include all components
       --bump                          increment the manual-rebuild counter to trigger a new release
-      --check-only                    resolve identities and recompute fingerprints but do not write lock files or prune orphans. Exits 0 when nothing would change and 1 when any component is stale or any lock would be pruned. Intended for CI gates. Cannot be combined with --bump
+      --check-only                    resolve identities and recompute fingerprints but do not write lock files or prune orphans. Exits 0 when nothing would change and 1 when any component is stale (or, with --all-components, when any orphan lock would be pruned). Intended for CI gates. Cannot be combined with --bump
   -p, --component stringArray         Component name pattern
   -g, --component-group stringArray   Component group name
       --force-recalculate             force re-resolution of all components, ignoring freshness checks that would skip unchanged components. Use when upstream state may have changed independently of the snapshot time and the new commit is preferred

--- a/docs/user/reference/cli/azldev_component_update.md
+++ b/docs/user/reference/cli/azldev_component_update.md
@@ -23,6 +23,11 @@ The --bump flag updates matching lock files to increment the manual-rebuild
 counter, triggering a new release. Useful for mass-rebuild scenarios (e.g.,
 toolchain bug, static library update). Orphan pruning is skipped under --bump.
 
+The --check-only flag runs the full pipeline but does NOT write lock files or
+prune orphans. The command exits 0 when nothing would change and exits 1 when
+any component is stale or any lock would be pruned. Intended for CI gates.
+Cannot be combined with --bump.
+
 ```
 azldev component update [flags]
 ```
@@ -41,6 +46,9 @@ azldev component update [flags]
 
   # Bump rebuild counter for a component (triggers new release)
   azldev component update --bump curl
+
+  # CI gate: exit 0 if locks are fresh, 1 if anything would change
+  azldev component update -a --check-only -q
 ```
 
 ### Options
@@ -48,6 +56,7 @@ azldev component update [flags]
 ```
   -a, --all-components                Include all components
       --bump                          increment the manual-rebuild counter to trigger a new release
+      --check-only                    resolve identities and recompute fingerprints but do not write lock files or prune orphans. Exits 0 when nothing would change and 1 when any component is stale or any lock would be pruned. Intended for CI gates. Cannot be combined with --bump
   -p, --component stringArray         Component name pattern
   -g, --component-group stringArray   Component group name
       --force-recalculate             force re-resolution of all components, ignoring freshness checks that would skip unchanged components. Use when upstream state may have changed independently of the snapshot time and the new commit is preferred

--- a/internal/app/azldev/cmds/component/update.go
+++ b/internal/app/azldev/cmds/component/update.go
@@ -27,6 +27,13 @@ type UpdateComponentOptions struct {
 	// Bump increments the manual-rebuild counter on matched components'
 	// lock files. Used for mass-rebuild scenarios.
 	Bump bool
+	// CheckOnly runs the full update pipeline (resolve identities,
+	// recompute fingerprints) but does not write lock files or prune
+	// orphans. Returns a non-nil error when any component would be
+	// changed or any lock file would be pruned. Intended for CI gates:
+	// `azldev component update -a --check-only` exits 0 when locks are
+	// fresh and 1 when something is stale.
+	CheckOnly bool
 	// ForceRecalculate disables freshness optimizations that skip
 	// re-resolution for unchanged components. When set, all components
 	// are re-resolved regardless of their freshness status.
@@ -59,7 +66,12 @@ accidentally removing lock files for components not included in the filter.
 
 The --bump flag updates matching lock files to increment the manual-rebuild
 counter, triggering a new release. Useful for mass-rebuild scenarios (e.g.,
-toolchain bug, static library update). Orphan pruning is skipped under --bump.`,
+toolchain bug, static library update). Orphan pruning is skipped under --bump.
+
+The --check-only flag runs the full pipeline but does NOT write lock files or
+prune orphans. The command exits 0 when nothing would change and exits 1 when
+any component is stale or any lock would be pruned. Intended for CI gates.
+Cannot be combined with --bump.`,
 		Example: `  # Update all components
   azldev component update -a
 
@@ -70,9 +82,12 @@ toolchain bug, static library update). Orphan pruning is skipped under --bump.`,
   azldev component update -g core
 
   # Bump rebuild counter for a component (triggers new release)
-  azldev component update --bump curl`,
+  azldev component update --bump curl
+
+  # CI gate: exit 0 if locks are fresh, 1 if anything would change
+  azldev component update -a --check-only -q`,
 		RunE: azldev.RunFuncWithExtraArgs(func(env *azldev.Env, args []string) (interface{}, error) {
-			// Skip lock validation — update is the lock file writer.
+			// Skip lock validation -- update is the lock file writer.
 			options.ComponentFilter.SkipLockValidation = true
 
 			options.ComponentFilter.ComponentNamePatterns = append(
@@ -88,11 +103,18 @@ toolchain bug, static library update). Orphan pruning is skipped under --bump.`,
 
 	cmd.Flags().BoolVar(&options.Bump, "bump", false,
 		"increment the manual-rebuild counter to trigger a new release")
+	cmd.Flags().BoolVar(&options.CheckOnly, "check-only", false,
+		"resolve identities and recompute fingerprints but do not write lock files "+
+			"or prune orphans. Exits 0 when nothing would change and 1 when any "+
+			"component is stale or any lock would be pruned. Intended for CI gates. "+
+			"Cannot be combined with --bump")
 	cmd.Flags().BoolVar(&options.ForceRecalculate, "force-recalculate", false,
 		"force re-resolution of all components, ignoring freshness checks that "+
 			"would skip unchanged components. Use when upstream state may have "+
 			"changed independently of the snapshot time and the new commit is "+
 			"preferred")
+
+	cmd.MarkFlagsMutuallyExclusive("bump", "check-only")
 
 	return cmd
 }
@@ -128,6 +150,10 @@ type UpdateResult struct {
 // UpdateComponents resolves source identities for all selected components and
 // writes the results to per-component lock files under locks/.
 func UpdateComponents(env *azldev.Env, options *UpdateComponentOptions) ([]UpdateResult, error) {
+	if options.Bump && options.CheckOnly {
+		return nil, fmt.Errorf("%w: --bump and --check-only are mutually exclusive", azldev.ErrInvalidUsage)
+	}
+
 	resolver := components.NewResolver(env)
 	// Suppress staleness warnings — we're about to refresh the locks ourselves,
 	// so warning the user to "run component update" would be self-referential noise.
@@ -183,7 +209,8 @@ func UpdateComponents(env *azldev.Env, options *UpdateComponentOptions) ([]Updat
 
 	// Write per-component lock files only on full success.
 	// saveComponentLocks may flip Changed for fingerprint-only diffs.
-	if err := saveComponentLocks(env, store, results); err != nil {
+	// In --check-only mode it computes everything but skips disk writes.
+	if err := saveComponentLocks(env, store, results, options.CheckOnly); err != nil {
 		return results, err
 	}
 
@@ -195,28 +222,94 @@ func UpdateComponents(env *azldev.Env, options *UpdateComponentOptions) ([]Updat
 	// spec-glob-discovered components that aren't in config directly.
 	// Lock files are version controlled, so pruning is safe even if the
 	// resolved set is empty (e.g., all components removed from config).
-	if options.ComponentFilter.IncludeAllComponents {
-		if len(comps) == 0 {
-			slog.Warn("No components resolved; all existing lock files will be treated as orphans")
-		}
+	wouldPrune, orphanErr := handleOrphanLocks(store, comps, options)
+	if orphanErr != nil {
+		return results, orphanErr
+	}
 
-		resolvedNames := make(map[string]projectconfig.ComponentConfig, len(comps))
-		for _, comp := range comps {
-			resolvedNames[comp.GetName()] = *comp.GetConfig()
-		}
-
-		pruned, pruneErr := store.PruneOrphans(resolvedNames)
-		if pruneErr != nil {
-			return results, fmt.Errorf("pruning orphan lock files:\n%w", pruneErr)
-		}
-
-		if pruned > 0 {
-			slog.Info("Pruned orphan lock files", "count", pruned)
-		}
+	if options.CheckOnly {
+		return checkOnlyResult(results, wouldPrune)
 	}
 
 	// Filter results for table output: show changed and skipped components.
 	return filterDisplayResults(results), nil
+}
+
+// handleOrphanLocks reconciles the lockfile directory with the resolved
+// component set. In normal mode it deletes orphan locks; in --check-only
+// mode it returns the list of orphans that would be deleted without
+// touching disk. Returns (nil, nil) when not running with --all-components,
+// since orphan handling is scoped to whole-set updates.
+func handleOrphanLocks(
+	store *lockfile.Store,
+	comps []components.Component,
+	options *UpdateComponentOptions,
+) ([]string, error) {
+	if !options.ComponentFilter.IncludeAllComponents {
+		return nil, nil
+	}
+
+	if len(comps) == 0 {
+		slog.Warn("No components resolved; all existing lock files will be treated as orphans")
+	}
+
+	resolvedNames := make(map[string]projectconfig.ComponentConfig, len(comps))
+	for _, comp := range comps {
+		resolvedNames[comp.GetName()] = *comp.GetConfig()
+	}
+
+	if options.CheckOnly {
+		orphans, findErr := store.FindOrphanLockFiles(resolvedNames)
+		if findErr != nil {
+			return nil, fmt.Errorf("finding orphan lock files:\n%w", findErr)
+		}
+
+		return orphans, nil
+	}
+
+	pruned, pruneErr := store.PruneOrphans(resolvedNames)
+	if pruneErr != nil {
+		return nil, fmt.Errorf("pruning orphan lock files:\n%w", pruneErr)
+	}
+
+	if pruned > 0 {
+		slog.Info("Pruned orphan lock files", "count", pruned)
+	}
+
+	return nil, nil
+}
+
+// checkOnlyResult inspects the results of a --check-only update run and
+// returns (nil, error) when any component would change or any lock file
+// would be pruned. The error is structured as a sentinel-style message that
+// names the affected components so CI logs are useful at a glance. Returns
+// (nil, nil) when nothing would change -- the caller exits 0.
+func checkOnlyResult(results []UpdateResult, wouldPrune []string) ([]UpdateResult, error) {
+	var changed []string
+
+	for idx := range results {
+		if results[idx].Changed {
+			changed = append(changed, results[idx].Component)
+		}
+	}
+
+	if len(changed) == 0 && len(wouldPrune) == 0 {
+		return nil, nil
+	}
+
+	parts := make([]string, 0)
+	if len(changed) > 0 {
+		parts = append(parts, fmt.Sprintf("%d component(s) would change: %s",
+			len(changed), strings.Join(changed, ", ")))
+	}
+
+	if len(wouldPrune) > 0 {
+		parts = append(parts, fmt.Sprintf("%d orphan lock file(s) would be pruned: %s",
+			len(wouldPrune), strings.Join(wouldPrune, ", ")))
+	}
+
+	return nil, fmt.Errorf("lock files are stale; %s. Run 'azldev component update -a' to refresh",
+		strings.Join(parts, "; "))
 }
 
 // saveComponentLocks recomputes fingerprints and writes lock files for all
@@ -224,7 +317,10 @@ func UpdateComponents(env *azldev.Env, options *UpdateComponentOptions) ([]Updat
 // or the input fingerprint has changed. The fingerprint is recomputed on every
 // update, so config/overlay changes are detected even when the upstream commit
 // stays the same.
-func saveComponentLocks(env *azldev.Env, store *lockfile.Store, results []UpdateResult) error {
+//
+// When checkOnly is true, fingerprints are still recomputed and Changed flags
+// are still set on the results, but no lock files are written to disk.
+func saveComponentLocks(env *azldev.Env, store *lockfile.Store, results []UpdateResult, checkOnly bool) error {
 	saved := make([]string, 0, len(results))
 
 	// Log partially-saved components on any error so the user knows which
@@ -242,7 +338,7 @@ func saveComponentLocks(env *azldev.Env, store *lockfile.Store, results []Update
 			continue
 		}
 
-		written, err := updateComponentLock(env, store, &results[idx])
+		written, err := updateComponentLock(env, store, &results[idx], checkOnly)
 		if err != nil {
 			retErr = err
 
@@ -260,7 +356,11 @@ func saveComponentLocks(env *azldev.Env, store *lockfile.Store, results []Update
 // updateComponentLock recomputes the fingerprint for a single component and
 // writes its lock file if anything changed. Returns true when the lock file
 // was written.
-func updateComponentLock(env *azldev.Env, store *lockfile.Store, result *UpdateResult) (bool, error) {
+//
+// When checkOnly is true, the fingerprint is still recomputed and result.Changed
+// is still flipped if anything would change, but no lock file is written. The
+// returned 'written' flag is always false in check-only mode.
+func updateComponentLock(env *azldev.Env, store *lockfile.Store, result *UpdateResult, checkOnly bool) (bool, error) {
 	lock, lockErr := store.GetOrNew(result.Component)
 	if lockErr != nil {
 		return false, fmt.Errorf("loading lock for %#q:\n%w", result.Component, lockErr)
@@ -322,6 +422,13 @@ func updateComponentLock(env *azldev.Env, store *lockfile.Store, result *UpdateR
 	// Write if either hash changed. ResolutionInputHash updates are silent
 	// (don't set Changed) since they don't affect build outputs.
 	if !result.Changed && !resHashChanged {
+		return false, nil
+	}
+
+	// In check-only mode the caller wants to know what *would* change without
+	// touching disk. Skip the write but keep result.Changed flipped so the
+	// caller can build the user-visible diff list.
+	if checkOnly {
 		return false, nil
 	}
 

--- a/internal/app/azldev/cmds/component/update.go
+++ b/internal/app/azldev/cmds/component/update.go
@@ -106,8 +106,8 @@ Cannot be combined with --bump.`,
 	cmd.Flags().BoolVar(&options.CheckOnly, "check-only", false,
 		"resolve identities and recompute fingerprints but do not write lock files "+
 			"or prune orphans. Exits 0 when nothing would change and 1 when any "+
-			"component is stale or any lock would be pruned. Intended for CI gates. "+
-			"Cannot be combined with --bump")
+			"component is stale (or, with --all-components, when any orphan lock "+
+			"would be pruned). Intended for CI gates. Cannot be combined with --bump")
 	cmd.Flags().BoolVar(&options.ForceRecalculate, "force-recalculate", false,
 		"force re-resolution of all components, ignoring freshness checks that "+
 			"would skip unchanged components. Use when upstream state may have "+
@@ -215,7 +215,12 @@ func UpdateComponents(env *azldev.Env, options *UpdateComponentOptions) ([]Updat
 	}
 
 	// Log summary after save so Changed counts include fingerprint-only diffs.
-	logUpdateSummary(results)
+	// Skipped in --check-only mode -- the "changed" counter would lie about a
+	// run that wrote nothing, and the structured error returned below already
+	// names every affected component.
+	if !options.CheckOnly {
+		logUpdateSummary(results)
+	}
 
 	// Prune orphan lock files when updating all components.
 	// Use the resolved component set (not raw config) to include
@@ -250,7 +255,11 @@ func handleOrphanLocks(
 	}
 
 	if len(comps) == 0 {
-		slog.Warn("No components resolved; all existing lock files will be treated as orphans")
+		if options.CheckOnly {
+			slog.Warn("No components resolved; all existing lock files would be treated as orphans")
+		} else {
+			slog.Warn("No components resolved; all existing lock files will be treated as orphans")
+		}
 	}
 
 	resolvedNames := make(map[string]projectconfig.ComponentConfig, len(comps))
@@ -280,11 +289,15 @@ func handleOrphanLocks(
 }
 
 // checkOnlyResult inspects the results of a --check-only update run and
-// returns (nil, error) when any component would change or any lock file
-// would be pruned. The error is structured as a sentinel-style message that
-// names the affected components so CI logs are useful at a glance. Returns
-// (nil, nil) when nothing would change -- the caller exits 0.
-func checkOnlyResult(results []UpdateResult, wouldPrune []string) ([]UpdateResult, error) {
+// returns (results, error) when any component would change or any lock file
+// would be pruned. The error names the affected components so CI logs are
+// useful at a glance. Returns (results, nil) when nothing would change --
+// the caller exits 0. Results are returned in both cases so structured
+// consumers (e.g. -O json) retain the per-component data the pipeline just
+// computed.
+func checkOnlyResult(
+	results []UpdateResult, wouldPrune []string,
+) ([]UpdateResult, error) {
 	var changed []string
 
 	for idx := range results {
@@ -293,11 +306,13 @@ func checkOnlyResult(results []UpdateResult, wouldPrune []string) ([]UpdateResul
 		}
 	}
 
+	display := filterDisplayResults(results)
+
 	if len(changed) == 0 && len(wouldPrune) == 0 {
-		return nil, nil
+		return display, nil
 	}
 
-	parts := make([]string, 0)
+	var parts []string
 	if len(changed) > 0 {
 		parts = append(parts, fmt.Sprintf("%d component(s) would change: %s",
 			len(changed), strings.Join(changed, ", ")))
@@ -308,7 +323,7 @@ func checkOnlyResult(results []UpdateResult, wouldPrune []string) ([]UpdateResul
 			len(wouldPrune), strings.Join(wouldPrune, ", ")))
 	}
 
-	return nil, fmt.Errorf("lock files are stale; %s. Run 'azldev component update -a' to refresh",
+	return display, fmt.Errorf("lock files are stale; %s. Run 'azldev component update -a' to refresh",
 		strings.Join(parts, "; "))
 }
 

--- a/internal/app/azldev/cmds/component/update_internal_test.go
+++ b/internal/app/azldev/cmds/component/update_internal_test.go
@@ -76,7 +76,7 @@ func TestSaveComponentLocks_ComputesFingerprint(t *testing.T) {
 		makeResult("curl", testCommitHash, baseConfig("curl")),
 	}
 
-	err := saveComponentLocks(env.Env, store, results)
+	err := saveComponentLocks(env.Env, store, results, false)
 	require.NoError(t, err)
 
 	lock := readLock(t, store, "curl")
@@ -93,7 +93,7 @@ func TestSaveComponentLocks_DetectsFingerprintChange(t *testing.T) {
 	config1 := baseConfig("curl")
 	results1 := []UpdateResult{makeResult("curl", testCommitHash, config1)}
 
-	require.NoError(t, saveComponentLocks(env.Env, store, results1))
+	require.NoError(t, saveComponentLocks(env.Env, store, results1, false))
 
 	fp1 := readLock(t, store, "curl").InputFingerprint
 	require.NotEmpty(t, fp1)
@@ -112,7 +112,7 @@ func TestSaveComponentLocks_DetectsFingerprintChange(t *testing.T) {
 		},
 	}
 
-	require.NoError(t, saveComponentLocks(env.Env, store, results2))
+	require.NoError(t, saveComponentLocks(env.Env, store, results2, false))
 
 	fp2 := readLock(t, store, "curl").InputFingerprint
 	assert.NotEqual(t, fp1, fp2, "fingerprint should change when config changes")
@@ -127,7 +127,7 @@ func TestSaveComponentLocks_SkipsUnchanged(t *testing.T) {
 
 	// First save.
 	results1 := []UpdateResult{makeResult("curl", testCommitHash, config)}
-	require.NoError(t, saveComponentLocks(env.Env, store, results1))
+	require.NoError(t, saveComponentLocks(env.Env, store, results1, false))
 
 	fp1 := readLock(t, store, "curl").InputFingerprint
 
@@ -142,7 +142,7 @@ func TestSaveComponentLocks_SkipsUnchanged(t *testing.T) {
 		},
 	}
 
-	require.NoError(t, saveComponentLocks(env.Env, store, results2))
+	require.NoError(t, saveComponentLocks(env.Env, store, results2, false))
 
 	assert.False(t, results2[0].Changed, "should remain unchanged when fingerprint matches")
 
@@ -160,7 +160,7 @@ func TestSaveComponentLocks_SkipsErrorAndSkipped(t *testing.T) {
 		{Component: "skipped", Skipped: true, SkipReason: "local", config: baseConfig("skipped")},
 	}
 
-	err := saveComponentLocks(env.Env, store, results)
+	err := saveComponentLocks(env.Env, store, results, false)
 	require.NoError(t, err)
 
 	// Neither should have lock files.
@@ -181,7 +181,7 @@ func TestSaveComponentLocks_SkipsUpToDate(t *testing.T) {
 		{Component: "skipped-fresh", UpstreamCommit: "abc", upToDate: true},
 	}
 
-	err := saveComponentLocks(env.Env, store, results)
+	err := saveComponentLocks(env.Env, store, results, false)
 	require.NoError(t, err)
 
 	exists, _ := store.Exists("skipped-fresh")
@@ -202,7 +202,7 @@ func TestSaveComponentLocks_PreservesManualBump(t *testing.T) {
 	// Update with new commit.
 	results := []UpdateResult{makeResult("curl", "new-commit", baseConfig("curl"))}
 
-	require.NoError(t, saveComponentLocks(env.Env, store, results))
+	require.NoError(t, saveComponentLocks(env.Env, store, results, false))
 
 	lock := readLock(t, store, "curl")
 	assert.Equal(t, "new-commit", lock.UpstreamCommit)
@@ -217,7 +217,7 @@ func TestSaveComponentLocks_ManualBumpAffectsFingerprint(t *testing.T) {
 
 	// Save with ManualBump = 0.
 	results1 := []UpdateResult{makeResult("curl", testCommitHash, config)}
-	require.NoError(t, saveComponentLocks(env.Env, store, results1))
+	require.NoError(t, saveComponentLocks(env.Env, store, results1, false))
 
 	fp1 := readLock(t, store, "curl").InputFingerprint
 
@@ -234,7 +234,7 @@ func TestSaveComponentLocks_ManualBumpAffectsFingerprint(t *testing.T) {
 		{Component: "curl", UpstreamCommit: testCommitHash, Changed: false, config: config, sourceIdentity: testCommitHash},
 	}
 
-	require.NoError(t, saveComponentLocks(env.Env, store, results2))
+	require.NoError(t, saveComponentLocks(env.Env, store, results2, false))
 
 	fp2 := readLock(t, store, "curl").InputFingerprint
 	assert.NotEqual(t, fp1, fp2, "ManualBump change should produce different fingerprint")

--- a/internal/app/azldev/cmds/component/update_test.go
+++ b/internal/app/azldev/cmds/component/update_test.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/microsoft/azure-linux-dev-tools/internal/app/azldev"
 	componentcmds "github.com/microsoft/azure-linux-dev-tools/internal/app/azldev/cmds/component"
 	"github.com/microsoft/azure-linux-dev-tools/internal/app/azldev/core/components"
 	"github.com/microsoft/azure-linux-dev-tools/internal/app/azldev/core/testutils"
@@ -383,4 +384,138 @@ func TestUpdateComponents_AdvancesStaleLock(t *testing.T) {
 	require.NoError(t, loadErr)
 	assert.Equal(t, advancedCommit, updatedLock.UpstreamCommit,
 		"lock file on disk must contain the new commit")
+}
+
+// TestUpdateComponents_CheckOnlyAndBumpRejected verifies that callers (CLI or
+// programmatic) cannot combine --bump and --check-only. Cobra rejects this at
+// flag-parse time on the CLI, but UpdateComponents must also enforce it for
+// in-process callers; otherwise --bump would silently override --check-only's
+// no-write contract since the bump branch runs first.
+func TestUpdateComponents_CheckOnlyAndBumpRejected(t *testing.T) {
+	env := testutils.NewTestEnv(t)
+	addUpstreamComponent(env, "curl")
+	require.NoError(t, fileutils.MkdirAll(env.TestFS, testLockDir))
+
+	_, err := componentcmds.UpdateComponents(env.Env, &componentcmds.UpdateComponentOptions{
+		ComponentFilter: components.ComponentFilter{IncludeAllComponents: true},
+		Bump:            true,
+		CheckOnly:       true,
+	})
+	require.Error(t, err)
+	require.ErrorIs(t, err, azldev.ErrInvalidUsage,
+		"combining --bump and --check-only must surface as ErrInvalidUsage")
+}
+
+// TestUpdateComponents_CheckOnly_StaleReturnsError verifies that --check-only
+// returns a non-nil error (-> exit 1) when a component's lock is stale, and
+// that no lock file is written.
+func TestUpdateComponents_CheckOnly_StaleReturnsError(t *testing.T) {
+	env := testutils.NewTestEnv(t)
+
+	const initialCommit = "initial-aaa111"
+
+	const advancedCommit = "advanced-bbb222"
+
+	// Pre-populate a lock at initialCommit, then move upstream forward.
+	require.NoError(t, fileutils.MkdirAll(env.TestFS, testLockDir))
+	preStore := lockfile.NewStore(env.TestFS, testLockDir)
+	preLock := lockfile.New()
+	preLock.UpstreamCommit = initialCommit
+	require.NoError(t, preStore.Save("curl", preLock))
+
+	addUpstreamComponent(env, "curl")
+	setupMockGit(env, advancedCommit)
+
+	_, err := componentcmds.UpdateComponents(env.Env, &componentcmds.UpdateComponentOptions{
+		ComponentFilter: components.ComponentFilter{IncludeAllComponents: true},
+		CheckOnly:       true,
+	})
+	require.Error(t, err, "stale lock must produce a non-nil error in --check-only mode")
+	assert.Contains(t, err.Error(), "stale", "error message should mention staleness")
+	assert.Contains(t, err.Error(), "curl", "error message should name the stale component")
+
+	// Lock on disk must still hold the OLD commit -- --check-only must not write.
+	freshStore := lockfile.NewStore(env.TestFS, testLockDir)
+	lock, loadErr := freshStore.Get("curl")
+	require.NoError(t, loadErr)
+	assert.Equal(t, initialCommit, lock.UpstreamCommit,
+		"--check-only must not modify the lock file on disk")
+}
+
+// TestUpdateComponents_CheckOnly_FreshReturnsNil verifies that --check-only
+// returns nil (-> exit 0) when all locks are already fresh.
+func TestUpdateComponents_CheckOnly_FreshReturnsNil(t *testing.T) {
+	env := testutils.NewTestEnv(t)
+
+	const commit = "fresh-commit-aaa"
+
+	setupMockGit(env, commit)
+	addUpstreamComponent(env, "curl")
+	require.NoError(t, fileutils.MkdirAll(env.TestFS, testLockDir))
+
+	options := &componentcmds.UpdateComponentOptions{
+		ComponentFilter: components.ComponentFilter{IncludeAllComponents: true},
+	}
+
+	// Phase 1: populate the lock with a real update run.
+	_, err := componentcmds.UpdateComponents(env.Env, options)
+	require.NoError(t, err)
+
+	// Snapshot the on-disk lock state so we can assert nothing was rewritten.
+	freshStore := lockfile.NewStore(env.TestFS, testLockDir)
+	before, loadErr := freshStore.Get("curl")
+	require.NoError(t, loadErr)
+
+	// Phase 2: --check-only against the now-fresh lock. Must return nil.
+	options.CheckOnly = true
+	_, err = componentcmds.UpdateComponents(env.Env, options)
+	require.NoError(t, err, "fresh locks must return nil error in --check-only mode")
+
+	// Lock on disk must be byte-identical (no rewrite, no timestamp churn).
+	freshStore = lockfile.NewStore(env.TestFS, testLockDir)
+	after, loadErr := freshStore.Get("curl")
+	require.NoError(t, loadErr)
+	assert.Equal(t, before.InputFingerprint, after.InputFingerprint)
+	assert.Equal(t, before.UpstreamCommit, after.UpstreamCommit)
+}
+
+// TestUpdateComponents_CheckOnly_DetectsOrphans verifies that --check-only
+// returns an error when an orphan lock file would be pruned by a normal run,
+// and that the orphan is NOT actually deleted.
+func TestUpdateComponents_CheckOnly_DetectsOrphans(t *testing.T) {
+	env := testutils.NewTestEnv(t)
+
+	const commit = "fresh-commit-aaa"
+
+	setupMockGit(env, commit)
+	addUpstreamComponent(env, "curl")
+	require.NoError(t, fileutils.MkdirAll(env.TestFS, testLockDir))
+
+	// First, do a real update so curl's lock is fresh -- isolates the orphan as
+	// the only thing --check-only should flag.
+	_, err := componentcmds.UpdateComponents(env.Env, &componentcmds.UpdateComponentOptions{
+		ComponentFilter: components.ComponentFilter{IncludeAllComponents: true},
+	})
+	require.NoError(t, err)
+
+	// Plant an orphan lock AFTER the update -- a normal update would have
+	// pruned it. The orphan does NOT correspond to any component in config.
+	preStore := lockfile.NewStore(env.TestFS, testLockDir)
+	orphanLock := lockfile.New()
+	orphanLock.UpstreamCommit = "orphan-commit"
+	require.NoError(t, preStore.Save("removed-pkg", orphanLock))
+
+	// --check-only must report the orphan and not delete it.
+	_, err = componentcmds.UpdateComponents(env.Env, &componentcmds.UpdateComponentOptions{
+		ComponentFilter: components.ComponentFilter{IncludeAllComponents: true},
+		CheckOnly:       true,
+	})
+	require.Error(t, err, "orphan lock must produce an error in --check-only mode")
+	assert.Contains(t, err.Error(), "orphan")
+	assert.Contains(t, err.Error(), "removed-pkg")
+
+	// Orphan lock must still exist on disk.
+	freshStore := lockfile.NewStore(env.TestFS, testLockDir)
+	_, loadErr := freshStore.Get("removed-pkg")
+	require.NoError(t, loadErr, "--check-only must not prune orphan locks")
 }

--- a/internal/app/azldev/cmds/component/update_test.go
+++ b/internal/app/azldev/cmds/component/update_test.go
@@ -426,13 +426,31 @@ func TestUpdateComponents_CheckOnly_StaleReturnsError(t *testing.T) {
 	addUpstreamComponent(env, "curl")
 	setupMockGit(env, advancedCommit)
 
-	_, err := componentcmds.UpdateComponents(env.Env, &componentcmds.UpdateComponentOptions{
+	results, err := componentcmds.UpdateComponents(env.Env, &componentcmds.UpdateComponentOptions{
 		ComponentFilter: components.ComponentFilter{IncludeAllComponents: true},
 		CheckOnly:       true,
 	})
 	require.Error(t, err, "stale lock must produce a non-nil error in --check-only mode")
 	assert.Contains(t, err.Error(), "stale", "error message should mention staleness")
 	assert.Contains(t, err.Error(), "curl", "error message should name the stale component")
+	assert.Contains(t, err.Error(), "azldev component update -a",
+		"-a-scoped run should suggest the same -a invocation to refresh")
+
+	// Results slice must be returned alongside the error so structured
+	// consumers (e.g. -O json) retain per-component data on stale runs.
+	require.NotEmpty(t, results, "results must be returned even when stale")
+
+	var foundCurl bool
+
+	for _, r := range results {
+		if r.Component == "curl" {
+			foundCurl = true
+
+			assert.True(t, r.Changed, "stale curl must surface as Changed in returned results")
+		}
+	}
+
+	assert.True(t, foundCurl, "stale curl must appear in returned results slice")
 
 	// Lock on disk must still hold the OLD commit -- --check-only must not write.
 	freshStore := lockfile.NewStore(env.TestFS, testLockDir)


### PR DESCRIPTION
<!--
PR Title must follow Conventional Commits format. Available types:

- feat: A new feature
- fix: A bug fix
- docs: Documentation only changes
- style: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
- refactor: A code change that neither fixes a bug nor adds a feature
- perf: A code change that improves performance
- test: Adding missing tests or correcting existing tests
- build: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
- ci: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
- chore: Other changes that don't modify src or test files
- revert: Reverts a previous commit

Reference: https://www.conventionalcommits.org/en/v1.0.0/
-->
