### PR TITLE
fix: Error on source vs. identity drift

### DIFF
--- a/docs/user/reference/cli/azldev_component_changed.md
+++ b/docs/user/reference/cli/azldev_component_changed.md
@@ -14,6 +14,12 @@ changed (sources change).
 This is useful for CI/CD pipelines to determine which components need to be
 rebuilt or have their lookaside tarballs re-uploaded after a PR merge.
 
+Fails with an error if any component's fingerprint is unchanged between refs
+but its rendered sources file drifted. This combination cannot occur from a
+clean render -- it usually means the rendered sources were edited by hand (a
+cache-poisoning vector if blindly uploaded) or the renderer is non-
+deterministic.
+
 Note: component selection and directory paths (lock-dir, rendered-specs-dir)
 are resolved from the current checkout's configuration, not from the compared
 refs. For accurate results, run this command from a checkout that matches the
@@ -46,7 +52,6 @@ azldev component changed [flags]
   -a, --all-components                Include all components
   -p, --component stringArray         Component name pattern
   -g, --component-group stringArray   Component group name
-      --force-recalculate             Disable optimizations that skip work for unchanged components
       --from string                   Git ref to compare from (required)
   -h, --help                          help for changed
       --include-unchanged             Include unchanged components in output (only applies to broad -a scans; explicit selections always show status)

--- a/internal/app/azldev/cmds/component/changed.go
+++ b/internal/app/azldev/cmds/component/changed.go
@@ -188,7 +188,7 @@ func ChangedComponents(
 
 		return nil, fmt.Errorf(
 			"found %d component(s) with unchanged fingerprint but drifted rendered sources "+
-				"(re-render with `azldev component render` and commit the result): %s",
+				"(run 'azldev component render' and commit the result): %s",
 			len(ctx.integrityViolations),
 			strings.Join(quotedIntegrityViolations, ", "))
 	}

--- a/internal/app/azldev/cmds/component/changed.go
+++ b/internal/app/azldev/cmds/component/changed.go
@@ -181,11 +181,16 @@ func ChangedComponents(
 		// logs and snapshot tests need a stable error string.
 		sort.Strings(ctx.integrityViolations)
 
+		quotedIntegrityViolations := make([]string, len(ctx.integrityViolations))
+		for idx, componentName := range ctx.integrityViolations {
+			quotedIntegrityViolations[idx] = fmt.Sprintf("%#q", componentName)
+		}
+
 		return nil, fmt.Errorf(
 			"found %d component(s) with unchanged fingerprint but drifted rendered sources "+
 				"(re-render with `azldev component render` and commit the result): %s",
 			len(ctx.integrityViolations),
-			strings.Join(ctx.integrityViolations, ", "))
+			strings.Join(quotedIntegrityViolations, ", "))
 	}
 
 	return results, nil

--- a/internal/app/azldev/cmds/component/changed.go
+++ b/internal/app/azldev/cmds/component/changed.go
@@ -270,7 +270,13 @@ func classifyAndCompareSources(
 
 	result.SourcesChange = sourcesChange
 
-	if result.ChangeType == changeTypeUnchanged && result.SourcesChange {
+	// Record an integrity violation only when both refs have a lock AND the
+	// two fingerprints actually agree. The classifier reports unchanged for
+	// the no-lock-on-either-side case too (e.g. an arbitrary --from/--to pair
+	// where the component didn't exist as a managed package), but there's no
+	// fingerprint to vouch for the rendered sources in that case -- a sources
+	// diff is just a sources diff, not cache-poisoning evidence.
+	if result.SourcesChange && haveMatchingFingerprints(name, fromLocks, toLocks) {
 		ctx.integrityViolations = append(ctx.integrityViolations, name)
 	}
 
@@ -431,6 +437,20 @@ func classifyComponent(
 	}
 
 	return result
+}
+
+// haveMatchingFingerprints reports whether a lock exists at both refs and
+// the two recorded InputFingerprint values are equal. Used to gate
+// integrity-violation reporting so that components which simply lack locks
+// on one or both sides aren't accused of fingerprint-vs-sources drift.
+func haveMatchingFingerprints(
+	name string,
+	fromLocks, toLocks map[string]lockfile.ComponentLock,
+) bool {
+	fromLock, inFrom := fromLocks[name]
+	toLock, inTo := toLocks[name]
+
+	return inFrom && inTo && fromLock.InputFingerprint == toLock.InputFingerprint
 }
 
 // compareSources compares the rendered sources file between two git trees.

--- a/internal/app/azldev/cmds/component/changed.go
+++ b/internal/app/azldev/cmds/component/changed.go
@@ -176,6 +176,11 @@ func ChangedComponents(
 	}
 
 	if len(ctx.integrityViolations) > 0 {
+		// Sort for deterministic output -- the slice is appended in
+		// component-resolution order, which depends on map iteration. CI
+		// logs and snapshot tests need a stable error string.
+		sort.Strings(ctx.integrityViolations)
+
 		return nil, fmt.Errorf(
 			"found %d component(s) with unchanged fingerprint but drifted rendered sources "+
 				"(re-render with `azldev component render` and commit the result): %s",
@@ -440,9 +445,13 @@ func classifyComponent(
 }
 
 // haveMatchingFingerprints reports whether a lock exists at both refs and
-// the two recorded InputFingerprint values are equal. Used to gate
-// integrity-violation reporting so that components which simply lack locks
-// on one or both sides aren't accused of fingerprint-vs-sources drift.
+// the two recorded InputFingerprint values are equal AND non-empty. Used to
+// gate integrity-violation reporting so that components which simply lack
+// locks on one or both sides aren't accused of fingerprint-vs-sources drift.
+// The non-empty guard rejects the degenerate "" == "" case: two locks
+// missing the input-fingerprint field aren't a verified-fingerprint match,
+// they're an unverified pair, and a sources diff between them is just a
+// sources diff -- not cache-poisoning evidence.
 func haveMatchingFingerprints(
 	name string,
 	fromLocks, toLocks map[string]lockfile.ComponentLock,
@@ -450,7 +459,9 @@ func haveMatchingFingerprints(
 	fromLock, inFrom := fromLocks[name]
 	toLock, inTo := toLocks[name]
 
-	return inFrom && inTo && fromLock.InputFingerprint == toLock.InputFingerprint
+	return inFrom && inTo &&
+		fromLock.InputFingerprint != "" &&
+		fromLock.InputFingerprint == toLock.InputFingerprint
 }
 
 // compareSources compares the rendered sources file between two git trees.

--- a/internal/app/azldev/cmds/component/changed.go
+++ b/internal/app/azldev/cmds/component/changed.go
@@ -30,10 +30,6 @@ type ChangedComponentOptions struct {
 	To string
 	// IncludeUnchanged includes unchanged components in the output.
 	IncludeUnchanged bool
-	// ForceRecalculate disables optimizations that skip work for unchanged
-	// components (e.g., sources comparison). Useful when you suspect stale
-	// data or want to verify correctness.
-	ForceRecalculate bool
 }
 
 func changedOnAppInit(_ *azldev.App, parentCmd *cobra.Command) {
@@ -55,6 +51,12 @@ changed (sources change).
 This is useful for CI/CD pipelines to determine which components need to be
 rebuilt or have their lookaside tarballs re-uploaded after a PR merge.
 
+Fails with an error if any component's fingerprint is unchanged between refs
+but its rendered sources file drifted. This combination cannot occur from a
+clean render -- it usually means the rendered sources were edited by hand (a
+cache-poisoning vector if blindly uploaded) or the renderer is non-
+deterministic.
+
 Note: component selection and directory paths (lock-dir, rendered-specs-dir)
 are resolved from the current checkout's configuration, not from the compared
 refs. For accurate results, run this command from a checkout that matches the
@@ -74,7 +76,7 @@ detected via lock file presence in the compared refs when using -a.`,
 		RunE: azldev.RunFuncWithExtraArgs(func(env *azldev.Env, args []string) (interface{}, error) {
 			options.ComponentFilter.ComponentNamePatterns = append(args, options.ComponentFilter.ComponentNamePatterns...)
 
-			// Skip lock validation — this command inspects historical locks at
+			// Skip lock validation -- this command inspects historical locks at
 			// arbitrary refs, so HEAD-state validation is irrelevant.
 			options.ComponentFilter.SkipLockValidation = true
 
@@ -89,12 +91,10 @@ detected via lock file presence in the compared refs when using -a.`,
 	cmd.Flags().StringVar(&options.To, "to", "HEAD", "Git ref to compare to")
 	cmd.Flags().BoolVar(&options.IncludeUnchanged, "include-unchanged", false,
 		"Include unchanged components in output (only applies to broad -a scans; explicit selections always show status)")
-	cmd.Flags().BoolVar(&options.ForceRecalculate, "force-recalculate", false,
-		"Disable optimizations that skip work for unchanged components")
 
 	_ = cmd.MarkFlagRequired("from")
 
-	// Hide inherited flag — this command always skips lock validation since
+	// Hide inherited flag -- this command always skips lock validation since
 	// it inspects historical locks at arbitrary refs.
 	_ = cmd.Flags().MarkHidden("skip-lock-validation")
 
@@ -167,11 +167,23 @@ func ChangedComponents(
 		return nil, fmt.Errorf("resolving tree for --to:\n%w", err)
 	}
 
-	return buildResults(
+	results, err := buildResults(
 		comps, fromLocks, toLocks, ctx, fromTree, toTree,
 		options.IncludeUnchanged, options.ComponentFilter.IncludeAllComponents,
-		options.ForceRecalculate,
 	)
+	if err != nil {
+		return nil, err
+	}
+
+	if len(ctx.integrityViolations) > 0 {
+		return nil, fmt.Errorf(
+			"found %d component(s) with unchanged fingerprint but drifted rendered sources "+
+				"(re-render with `azldev component render` and commit the result): %s",
+			len(ctx.integrityViolations),
+			strings.Join(ctx.integrityViolations, ", "))
+	}
+
+	return results, nil
 }
 
 // changedContext holds resolved repo state for change detection.
@@ -180,6 +192,12 @@ type changedContext struct {
 	repoRoot         string
 	lockRelDir       string
 	renderedSpecsDir string
+	// integrityViolations collects components whose fingerprint is
+	// unchanged between refs but whose rendered sources file drifted.
+	// This indicates manual tampering with the rendered output (a cache
+	// poisoning vector -- see [classifyAndCompareSources]) or a renderer
+	// non-determinism bug.
+	integrityViolations []string
 }
 
 // newChangedContext opens the project repository and resolves paths.
@@ -211,26 +229,27 @@ func newChangedContext(env *azldev.Env) (*changedContext, error) {
 
 // classifyOpts controls per-component classification behavior. Config and
 // non-config components use different opts because they have different
-// semantics — see [buildResults] and [buildNonConfigResults].
+// semantics -- see [buildResults] and [buildNonConfigResults].
 type classifyOpts struct {
 	// remapDeleted converts "deleted" to "changed". This matters for
 	// config components: a missing lock file means the component needs its
 	// lock regenerated (e.g., after a reset or manual deletion), but the
 	// component itself still exists in the project config. Reporting
-	// "deleted" would be misleading — it's a "changed" component that
+	// "deleted" would be misleading -- it's a "changed" component that
 	// needs a rebuild. For non-config components (only known from lock
 	// files), a missing lock genuinely means the component was removed
 	// from the project, so "deleted" is correct.
 	remapDeleted bool
 	// includeUnchanged keeps unchanged components in the output.
 	includeUnchanged bool
-	// forceRecalculate disables the sources-comparison skip optimization.
-	forceRecalculate bool
 }
 
-// classifyAndCompareSources classifies a component and optionally compares its
-// rendered sources file. Returns the result and whether it should be included
-// in output.
+// classifyAndCompareSources classifies a component and compares its rendered
+// sources file. Returns the result and whether it should be included in
+// output. When an unchanged component shows a drifted sources file, the
+// component name is appended to ctx.integrityViolations so [ChangedComponents]
+// can fail the run -- fingerprint-unchanged + sources-drifted is a cache-
+// poisoning vector (see security review of `comp changed`).
 func classifyAndCompareSources(
 	name string,
 	fromLocks, toLocks map[string]lockfile.ComponentLock,
@@ -244,15 +263,6 @@ func classifyAndCompareSources(
 		result.ChangeType = changeTypeChanged
 	}
 
-	// Unchanged fingerprint implies unchanged sources — skip the
-	// expensive git tree comparison. Use --force-recalculate to override.
-	if result.ChangeType == changeTypeUnchanged && !opts.forceRecalculate {
-		result.SourcesChange = false
-
-		return result, opts.includeUnchanged, nil
-	}
-
-	// Changed/added/deleted (or --force-recalculate): compare sources.
 	sourcesChange, err := compareSources(ctx.repoRoot, fromTree, toTree, ctx.renderedSpecsDir, name)
 	if err != nil {
 		return result, false, fmt.Errorf("comparing sources for %#q:\n%w", name, err)
@@ -260,8 +270,12 @@ func classifyAndCompareSources(
 
 	result.SourcesChange = sourcesChange
 
-	// With --force-recalculate, unchanged components reach here after
-	// sources comparison. Still filter unless sources actually changed.
+	if result.ChangeType == changeTypeUnchanged && result.SourcesChange {
+		ctx.integrityViolations = append(ctx.integrityViolations, name)
+	}
+
+	// Filter unchanged components from broad-scan output unless their
+	// sources changed or the caller asked to see them.
 	if result.ChangeType == changeTypeUnchanged && !result.SourcesChange && !opts.includeUnchanged {
 		return result, false, nil
 	}
@@ -275,19 +289,18 @@ func buildResults(
 	fromLocks, toLocks map[string]lockfile.ComponentLock,
 	ctx *changedContext,
 	fromTree, toTree *object.Tree,
-	includeUnchanged, includeAllComponents, forceRecalculate bool,
+	includeUnchanged, includeAllComponents bool,
 ) ([]ChangedResult, error) {
 	configNames := make(map[string]bool, comps.Len())
 	results := make([]ChangedResult, 0, comps.Len())
 
-	// Config components: remap deleted→changed (lock missing doesn't mean
+	// Config components: remap deleted->changed (lock missing doesn't mean
 	// component is gone, just that the lock needs regeneration). Always
 	// show when explicitly selected (-p, -g, -s); only filter unchanged
 	// in broad scans (-a).
 	opts := classifyOpts{
 		remapDeleted:     true,
 		includeUnchanged: !includeAllComponents || includeUnchanged,
-		forceRecalculate: forceRecalculate,
 	}
 
 	for _, comp := range comps.Components() {
@@ -307,7 +320,7 @@ func buildResults(
 	}
 
 	// Skip non-config component detection for filtered runs (-p, -g, -s,
-	// positional args) — only check historical locks when scanning all
+	// positional args) -- only check historical locks when scanning all
 	// components (-a).
 	if !includeAllComponents {
 		// Sort for deterministic output across runs.
@@ -320,7 +333,6 @@ func buildResults(
 
 	nonConfigResults, err := buildNonConfigResults(
 		fromLocks, toLocks, configNames, ctx, fromTree, toTree, includeUnchanged,
-		forceRecalculate,
 	)
 	if err != nil {
 		return nil, err
@@ -337,13 +349,13 @@ func buildResults(
 }
 
 // buildNonConfigResults detects components not in the current config that
-// changed between refs — deleted, added, or modified historical components.
+// changed between refs -- deleted, added, or modified historical components.
 func buildNonConfigResults(
 	fromLocks, toLocks map[string]lockfile.ComponentLock,
 	configNames map[string]bool,
 	ctx *changedContext,
 	fromTree, toTree *object.Tree,
-	includeUnchanged, forceRecalculate bool,
+	includeUnchanged bool,
 ) ([]ChangedResult, error) {
 	nonConfigNames := make(map[string]bool)
 
@@ -371,7 +383,6 @@ func buildNonConfigResults(
 	opts := classifyOpts{
 		remapDeleted:     false,
 		includeUnchanged: includeUnchanged,
-		forceRecalculate: forceRecalculate,
 	}
 
 	var results []ChangedResult

--- a/internal/app/azldev/cmds/component/changed_internal_test.go
+++ b/internal/app/azldev/cmds/component/changed_internal_test.go
@@ -187,6 +187,9 @@ func TestHaveMatchingFingerprints(t *testing.T) {
 		"curl": {InputFingerprint: "sha256:def"},
 	}
 	empty := map[string]lockfile.ComponentLock{}
+	emptyFingerprint := map[string]lockfile.ComponentLock{
+		"curl": {InputFingerprint: ""},
+	}
 
 	tests := []struct {
 		name string
@@ -199,6 +202,10 @@ func TestHaveMatchingFingerprints(t *testing.T) {
 		{"only from has a lock", fromHas, empty, false},
 		{"only to has a lock", empty, toHas, false},
 		{"neither ref has a lock (regression: must NOT report violation)", empty, empty, false},
+		{
+			"both refs have lock but fingerprint field is empty (regression: must NOT report violation)",
+			emptyFingerprint, emptyFingerprint, false,
+		},
 	}
 
 	for _, tt := range tests {

--- a/internal/app/azldev/cmds/component/changed_internal_test.go
+++ b/internal/app/azldev/cmds/component/changed_internal_test.go
@@ -170,6 +170,46 @@ func TestClassifyComponent_NeverExisted(t *testing.T) {
 	assert.Equal(t, changeTypeUnchanged, result.ChangeType)
 }
 
+// --- haveMatchingFingerprints tests ---
+
+func TestHaveMatchingFingerprints(t *testing.T) {
+	t.Parallel()
+
+	const fingerprint = "sha256:abc"
+
+	fromHas := map[string]lockfile.ComponentLock{
+		"curl": {InputFingerprint: fingerprint},
+	}
+	toHas := map[string]lockfile.ComponentLock{
+		"curl": {InputFingerprint: fingerprint},
+	}
+	toDifferent := map[string]lockfile.ComponentLock{
+		"curl": {InputFingerprint: "sha256:def"},
+	}
+	empty := map[string]lockfile.ComponentLock{}
+
+	tests := []struct {
+		name string
+		from map[string]lockfile.ComponentLock
+		to   map[string]lockfile.ComponentLock
+		want bool
+	}{
+		{"both refs have lock with same fingerprint", fromHas, toHas, true},
+		{"both refs have lock but fingerprints differ", fromHas, toDifferent, false},
+		{"only from has a lock", fromHas, empty, false},
+		{"only to has a lock", empty, toHas, false},
+		{"neither ref has a lock (regression: must NOT report violation)", empty, empty, false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			assert.Equal(t, tt.want, haveMatchingFingerprints("curl", tt.from, tt.to))
+		})
+	}
+}
+
 // --- compareSources tests ---
 
 func TestCompareSources_Changed(t *testing.T) {

--- a/scenario/__snapshots__/TestMCPServerMode_1.snap.json
+++ b/scenario/__snapshots__/TestMCPServerMode_1.snap.json
@@ -44,11 +44,6 @@
        "description": "dry run only (do not take action)",
        "type": "boolean"
       },
-      "force-recalculate": {
-       "default": false,
-       "description": "Disable optimizations that skip work for unchanged components",
-       "type": "boolean"
-      },
       "from": {
        "default": "",
        "description": "Git ref to compare from (required)",

--- a/scenario/component_changed_test.go
+++ b/scenario/component_changed_test.go
@@ -720,3 +720,75 @@ func TestComponentChanged_JSONContract(t *testing.T) {
 	require.Contains(t, rm, "oldpkg")
 	assert.Equal(t, "deleted", rm["oldpkg"].ChangeType)
 }
+
+// TestComponentChanged_IntegrityViolation verifies that a manually-edited
+// rendered sources file with no corresponding fingerprint change causes
+// `azldev component changed` to fail with a non-zero exit code.
+//
+// This is the cache-poisoning vector: a malicious PR commits an attacker-
+// chosen (filename, hash) pair into a rendered sources file without touching
+// the lock that drives re-rendering. The CLI fails hard on this combination
+// because it cannot occur from a clean render.
+//
+// Flow:
+//  1. Commit 1: lock + matching rendered sources file.
+//  2. Commit 2: edit ONLY the sources file (lock fingerprint identical).
+//  3. Run `azldev component changed`: must fail with an error naming the
+//     affected component.
+func TestComponentChanged_IntegrityViolation(t *testing.T) {
+	t.Parallel()
+
+	if testing.Short() {
+		t.Skip("skipping long test")
+	}
+
+	azldevBin, projectDir := setupProjectWithGit(t,
+		[]*projecttest.TestSpec{
+			projecttest.NewSpec(
+				projecttest.WithName("curl"),
+				projecttest.WithVersion("8.0.0"),
+				projecttest.WithRelease("1%{?dist}"),
+				projecttest.WithBuildArch(projecttest.NoArch),
+			),
+		},
+		[]*projectconfig.ComponentConfig{{
+			Name: "curl",
+			Spec: projectconfig.SpecSource{
+				SourceType: projectconfig.SpecSourceTypeLocal,
+				Path:       filepath.Join("specs", "curl", "curl.spec"),
+			},
+		}},
+		nil,
+	)
+
+	// Commit 1: lock + matching rendered sources.
+	writeFileInDir(t, projectDir, "locks/curl.lock",
+		fmt.Sprintf("version = 1\ninput-fingerprint = %q\n", "sha256:v1"))
+	writeFileInDir(t, projectDir, "specs/c/curl/sources",
+		"SHA512 (curl-8.0.tar.gz) = aaa111")
+	gitInDir(t, projectDir, "add", ".")
+	gitInDir(t, projectDir, "-c", "commit.gpgsign=false", "commit", "-m", "initial")
+	fromRef := gitInDir(t, projectDir, "rev-parse", "HEAD")
+
+	// Commit 2: edit ONLY the rendered sources file. Lock fingerprint
+	// identical -- no legitimate render would produce this drift.
+	writeFileInDir(t, projectDir, "specs/c/curl/sources",
+		"SHA512 (evil-payload.tar.gz) = deadbeef")
+	gitInDir(t, projectDir, "add", ".")
+	gitInDir(t, projectDir, "-c", "commit.gpgsign=false", "commit", "-m", "tamper")
+
+	cmd := exec.CommandContext(t.Context(),
+		azldevBin, "-C", projectDir, "--no-default-config", "component", "changed",
+		"--from", fromRef, "-a", "-q", "-O", "json",
+	)
+	var stdout, stderr strings.Builder
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	err := cmd.Run()
+
+	require.Error(t, err, "integrity violation must fail the command")
+	assert.Contains(t, stderr.String(), "drifted rendered sources",
+		"error should explain the integrity violation")
+	assert.Contains(t, stderr.String(), "curl",
+		"error should name the affected component")
+}


### PR DESCRIPTION
There should never be a case where a component has changed sources without a changed identity. This means either identity calculation is broken, or a manually edited change was made to the sources files.