### PR TITLE
feat(cli): Add check-only option to render

### DIFF
--- a/docs/user/reference/cli/azldev_component_render.md
+++ b/docs/user/reference/cli/azldev_component_render.md
@@ -20,12 +20,15 @@ Unlike prepare-sources, render skips downloading source tarballs from the
 lookaside cache — only spec files, patches, scripts, and other git-tracked
 sidecar files are included. Multiple components can be rendered at once.
 
-When rendering all components (-a), the --clean-stale flag removes all
-contents of the output directory before rendering, leaving the directory
-itself in place. When using a custom output directory (--output-dir),
---force is required alongside --clean-stale as a safety measure. An
-interrupted run with --clean-stale leaves the output directory partially
-populated; recover with 'git checkout'. This flag is only valid with -a.
+When rendering all components (-a), the --clean-stale flag prunes orphan
+rendered-spec directories (per-component dirs that no longer correspond to
+any component in the project config). Per-component dirs that ARE in config
+are overwritten in place by the render itself; this means each render's
+result table accurately reflects which components actually changed on disk.
+Top-level non-component siblings (e.g. a hand-placed README.md) are
+preserved. When using a custom output directory (--output-dir), --force is
+required alongside --clean-stale as a safety measure. This flag is only
+valid with -a.
 
 ```
 azldev component render [flags]
@@ -52,7 +55,7 @@ azldev component render [flags]
 ```
   -a, --all-components                Include all components
       --check-only                    render to a staging area and compare against the existing on-disk output without writing anything. Exits 0 when nothing would change and 1 when any component would drift. With -a + --clean-stale, also fails on orphan rendered-spec directories. Intended for CI gates.
-      --clean-stale                   remove contents of the output directory before rendering (only with -a; requires -f with -o)
+      --clean-stale                   prune rendered-spec directories that no longer correspond to a configured component (only with -a; requires -f with -o). Top-level non-component siblings are preserved.
   -p, --component stringArray         Component name pattern
   -g, --component-group stringArray   Component group name
       --fail-on-error                 exit with error if any component fails to render (useful for CI)

--- a/docs/user/reference/cli/azldev_component_render.md
+++ b/docs/user/reference/cli/azldev_component_render.md
@@ -51,6 +51,7 @@ azldev component render [flags]
 
 ```
   -a, --all-components                Include all components
+      --check-only                    render to a staging area and compare against the existing on-disk output without writing anything. Exits 0 when nothing would change and 1 when any component would drift. With -a + --clean-stale, also fails on orphan rendered-spec directories. Intended for CI gates.
       --clean-stale                   remove contents of the output directory before rendering (only with -a; requires -f with -o)
   -p, --component stringArray         Component name pattern
   -g, --component-group stringArray   Component group name

--- a/docs/user/reference/cli/azldev_component_render.md
+++ b/docs/user/reference/cli/azldev_component_render.md
@@ -54,7 +54,7 @@ azldev component render [flags]
 
 ```
   -a, --all-components                Include all components
-      --check-only                    render to a staging area and compare against the existing on-disk output without writing anything. Exits 0 when nothing would change and 1 when any component would drift. With -a + --clean-stale, also fails on orphan rendered-spec directories. Intended for CI gates.
+      --check-only                    render to a staging area and compare against the existing on-disk output without modifying the output directory. Exits 0 when nothing would change and 1 when any component would drift. With -a + --clean-stale, also fails on orphan rendered-spec directories. Intended for CI gates.
       --clean-stale                   prune rendered-spec directories that no longer correspond to a configured component (only with -a; requires -f with -o). Top-level non-component siblings are preserved.
   -p, --component stringArray         Component name pattern
   -g, --component-group stringArray   Component group name

--- a/internal/app/azldev/cmds/component/render.go
+++ b/internal/app/azldev/cmds/component/render.go
@@ -10,6 +10,7 @@ import (
 	"os"
 	"path/filepath"
 	"slices"
+	"sort"
 	"strings"
 	"sync"
 
@@ -18,6 +19,7 @@ import (
 	"github.com/microsoft/azure-linux-dev-tools/internal/app/azldev/core/sources"
 	"github.com/microsoft/azure-linux-dev-tools/internal/global/opctx"
 	"github.com/microsoft/azure-linux-dev-tools/internal/providers/sourceproviders"
+	"github.com/microsoft/azure-linux-dev-tools/internal/utils/dirdiff"
 	"github.com/microsoft/azure-linux-dev-tools/internal/utils/fileperms"
 	"github.com/microsoft/azure-linux-dev-tools/internal/utils/fileutils"
 	"github.com/spf13/afero"
@@ -32,6 +34,7 @@ type RenderOptions struct {
 	FailOnError       bool
 	Force             bool
 	CleanStale        bool
+	CheckOnly         bool
 }
 
 func renderOnAppInit(_ *azldev.App, parentCmd *cobra.Command) {
@@ -105,6 +108,12 @@ populated; recover with 'git checkout'. This flag is only valid with -a.`,
 	cmd.Flags().BoolVar(&options.CleanStale, "clean-stale", false,
 		"remove contents of the output directory before rendering (only with -a; requires -f with -o)")
 
+	cmd.Flags().BoolVar(&options.CheckOnly, "check-only", false,
+		"render to a staging area and compare against the existing on-disk output "+
+			"without writing anything. Exits 0 when nothing would change and 1 when "+
+			"any component would drift. With -a + --clean-stale, also fails on orphan "+
+			"rendered-spec directories. Intended for CI gates.")
+
 	return cmd
 }
 
@@ -114,6 +123,7 @@ type RenderResult struct {
 	OutputDir string `json:"outputDir"       table:"Output"`
 	Status    string `json:"status"          table:"Status"`
 	Error     string `json:"error,omitempty" table:"Error,omitempty"`
+	Changed   bool   `json:"changed" table:"Changed"`
 }
 
 // Render status constants.
@@ -133,14 +143,8 @@ func RenderComponents(env *azldev.Env, options *RenderOptions) ([]*RenderResult,
 		return nil, err
 	}
 
-	if options.CleanStale {
-		if !options.ComponentFilter.IncludeAllComponents {
-			return nil, errors.New("--clean-stale requires -a (render all components)")
-		}
-
-		if options.OutputDirExplicit && !options.Force {
-			return nil, errors.New("--clean-stale with --output-dir requires --force (-f)")
-		}
+	if err := validateCleanStaleOptions(options); err != nil {
+		return nil, err
 	}
 
 	resolver := components.NewResolver(env)
@@ -193,32 +197,103 @@ func RenderComponents(env *azldev.Env, options *RenderOptions) ([]*RenderResult,
 	// ── Phase 2: Batch mock processing ──
 	mockResultMap := batchMockProcess(env, mockProcessor, stagingDir, prepared)
 
-	// Wipe contents of the output dir between mock processing (slow: clone +
-	// chroot) and the per-component copy in phase 3. This keeps Ctrl-C-during-mock
-	// from leaving the user with no output and nothing fresh either; if they cancel
-	// before this point the existing output is untouched. Once we reach phase 3
-	// we're moments away from writing replacement content anyway.
-	if options.CleanStale {
-		if wipeErr := wipeOutputDirContents(env.FS(), options.OutputDir); wipeErr != nil {
-			return nil, fmt.Errorf("clearing output directory %#q:\n%w", options.OutputDir, wipeErr)
+	// Prune orphan component dirs (components removed from config) when
+	// --clean-stale is set. Per-component output dirs that match the resolved
+	// component set are NOT touched here; phase 3 will RemoveAll+rewrite each
+	// of them via copyRenderedOutput. This keeps the diff against existing
+	// output meaningful (so result.Changed reflects actual content drift
+	// instead of being unconditionally true after a blanket wipe) and reduces
+	// the blast radius of a Ctrl-C: we only ever delete dirs that wouldn't
+	// have been re-rendered anyway.
+	//
+	// Skipped in --check-only mode -- check-only must never touch disk; the
+	// orphan list is computed read-only later via checkOnlyRenderResult.
+	if options.CleanStale && !options.CheckOnly {
+		names := make([]string, len(componentList))
+		for idx, comp := range componentList {
+			names[idx] = comp.GetName()
+		}
+
+		if pruneErr := pruneOrphanRenderedDirs(env.FS(), options.OutputDir, names); pruneErr != nil {
+			return nil, fmt.Errorf("pruning orphan rendered-spec dirs in %#q:\n%w", options.OutputDir, pruneErr)
 		}
 	}
 
 	// ── Phase 3: Parallel finishing ──
 	parallelFinish(env, prepared, mockResultMap, results, stagingDir,
-		options.Force)
+		options.Force, options.CheckOnly)
 
 	// Write RENDER_FAILED markers for any component that errored in phase 1
 	// (source preparation) or phase 3 (mock result application + copy).
 	// Centralizing this here makes it idempotent with the --clean-stale wipe
 	// (which sits between phases 2 and 3) and keeps the per-phase code free
-	// of bookkeeping.
-	writeFailureMarkers(env.FS(), results, options.Force)
+	// of bookkeeping. In --check-only mode this verifies that on-disk state
+	// matches the expected single-marker shape and flags drift on mismatch.
+	writeFailureMarkers(env.FS(), results, options.Force, options.CheckOnly)
 
 	// Sort results alphabetically for consistent output.
 	sortRenderResults(results)
 
+	if options.CheckOnly {
+		return results, checkOnlyRenderResult(env.FS(), options, componentList, results)
+	}
+
 	return results, checkRenderErrors(results, options.FailOnError)
+}
+
+// checkOnlyRenderResult inspects results from a --check-only run and returns
+// a non-nil error when any component changed or any orphan rendered-spec
+// directory was detected. Orphan detection runs only with -a + --clean-stale
+// (the only configuration where a normal run would actually remove orphans).
+// The error message names every changed component and orphan so CI logs are
+// useful at a glance.
+func checkOnlyRenderResult(
+	fileSystem opctx.FS,
+	options *RenderOptions,
+	resolvedComps []components.Component,
+	results []*RenderResult,
+) error {
+	var changed []string
+
+	for _, result := range results {
+		if result != nil && result.Changed {
+			changed = append(changed, result.Component)
+		}
+	}
+
+	var orphans []string
+
+	if options.ComponentFilter.IncludeAllComponents && options.CleanStale {
+		names := make([]string, len(resolvedComps))
+		for idx, comp := range resolvedComps {
+			names[idx] = comp.GetName()
+		}
+
+		found, err := findOrphanRenderedDirs(fileSystem, options.OutputDir, names)
+		if err != nil {
+			return fmt.Errorf("checking for orphan rendered-spec dirs:\n%w", err)
+		}
+
+		orphans = found
+	}
+
+	if len(changed) == 0 && len(orphans) == 0 {
+		return nil
+	}
+
+	parts := make([]string, 0)
+	if len(changed) > 0 {
+		parts = append(parts, fmt.Sprintf("%d component(s) would change: %s",
+			len(changed), strings.Join(changed, ", ")))
+	}
+
+	if len(orphans) > 0 {
+		parts = append(parts, fmt.Sprintf("%d orphan rendered-spec dir(s): %s",
+			len(orphans), strings.Join(orphans, ", ")))
+	}
+
+	return fmt.Errorf("rendered output is stale; %s. Run 'azldev component render -a' to refresh",
+		strings.Join(parts, "; "))
 }
 
 // sortRenderResults sorts render results alphabetically by component name,
@@ -518,7 +593,9 @@ func batchMockProcess(
 // ──────────────────────────────────────────────────────────────────────────────
 
 // parallelFinish applies mock results (file filtering, .git removal) and copies
-// rendered output for all successfully prepared components.
+// rendered output for all successfully prepared components. In --check-only
+// mode, the copy step is replaced with a tree comparison and no disk writes
+// happen.
 func parallelFinish(
 	env *azldev.Env,
 	prepared []*preparedComponent,
@@ -526,6 +603,7 @@ func parallelFinish(
 	results []*RenderResult,
 	stagingDir string,
 	allowOverwrite bool,
+	checkOnly bool,
 ) {
 	if len(prepared) == 0 {
 		return
@@ -553,7 +631,9 @@ func parallelFinish(
 		go func(prep *preparedComponent) {
 			defer waitGroup.Done()
 
-			result := finishOneComponent(workerEnv, env, prep, mockResultMap, semaphore, stagingDir, allowOverwrite)
+			result := finishOneComponent(
+				workerEnv, env, prep, mockResultMap, semaphore, stagingDir, allowOverwrite, checkOnly,
+			)
 			resultsChan <- finishResult{index: prep.index, result: result}
 		}(prep)
 	}
@@ -582,6 +662,7 @@ func finishOneComponent(
 	semaphore chan struct{},
 	stagingDir string,
 	allowOverwrite bool,
+	checkOnly bool,
 ) *RenderResult {
 	componentName := prep.comp.GetName()
 	compOutputDir := prep.compOutputDir
@@ -605,7 +686,7 @@ func finishOneComponent(
 		Status:    renderStatusOK,
 	}
 
-	err := finishComponentRender(env, prep, mockResultMap, stagingDir, allowOverwrite)
+	drifted, err := finishComponentRender(env, prep, mockResultMap, stagingDir, allowOverwrite, checkOnly)
 	if err != nil {
 		slog.Error("Failed to finish rendering component",
 			"component", componentName, "error", err)
@@ -614,19 +695,28 @@ func finishOneComponent(
 		result.Error = err.Error()
 	}
 
+	result.Changed = drifted
+
 	return result
 }
 
 // finishComponentRender applies mock results, filters unreferenced files,
-// removes .git, and copies rendered output for a single component.
+// removes .git, diffs the staging tree against the existing on-disk output,
+// and (unless checkOnly is set) copies the staging tree to the output dir.
 // stagingDir is the root staging directory containing the component's subdirectory.
+//
+// Returns changed=true when the staging tree differs from the existing output
+// (or no existing output is present). The diff is computed unconditionally so
+// every render run gets a meaningful 'Changed' value in its result table; the
+// disk write is the only thing gated by checkOnly.
 func finishComponentRender(
 	env *azldev.Env,
 	prep *preparedComponent,
 	mockResultMap map[string]*sources.ComponentMockResult,
 	stagingDir string,
 	allowOverwrite bool,
-) error {
+	checkOnly bool,
+) (bool, error) {
 	componentName := prep.comp.GetName()
 	componentDir := filepath.Join(stagingDir, componentName)
 	specPath := filepath.Join(componentDir, prep.specFilename)
@@ -634,12 +724,12 @@ func finishComponentRender(
 	// Check mock result.
 	mockResult, hasMockResult := mockResultMap[componentName]
 	if !hasMockResult {
-		return fmt.Errorf(
+		return false, fmt.Errorf(
 			"no mock result for %#q (batch mock processing failed; see earlier errors)", componentName)
 	}
 
 	if mockResult.Error != nil {
-		return fmt.Errorf(
+		return false, fmt.Errorf(
 			"mock processing failed for %#q:\n%w", componentName, mockResult.Error)
 	}
 
@@ -656,7 +746,7 @@ func finishComponentRender(
 	} else if filterErr := removeUnreferencedFiles(
 		env.FS(), componentDir, specPath, mockResult.SpecFiles, componentName,
 	); filterErr != nil {
-		return fmt.Errorf("filtering unreferenced files for %#q:\n%w", componentName, filterErr)
+		return false, fmt.Errorf("filtering unreferenced files for %#q:\n%w", componentName, filterErr)
 	}
 
 	// Remove .git directory — must not appear in rendered output.
@@ -666,9 +756,21 @@ func finishComponentRender(
 		slog.Debug("Failed to remove .git directory", "path", gitDir, "error", removeErr)
 	}
 
+	// Compare staging tree to existing output. Always done so the result table
+	// reflects which components actually changed on disk this run, not just
+	// in --check-only mode.
+	changed, diffErr := diffRenderedOutput(env.FS(), componentDir, prep.compOutputDir)
+	if diffErr != nil {
+		return false, fmt.Errorf("comparing rendered output for %#q:\n%w", componentName, diffErr)
+	}
+
+	if checkOnly {
+		return changed, nil
+	}
+
 	// Copy rendered files to the component's output directory.
 	if copyErr := copyRenderedOutput(env, componentDir, prep.compOutputDir, allowOverwrite); copyErr != nil {
-		return copyErr
+		return changed, copyErr
 	}
 
 	// Best-effort: create a sibling symlink at the URL-encoded component name to
@@ -689,7 +791,7 @@ func finishComponentRender(
 	slog.Info("Rendered component", "component", componentName,
 		"output", prep.compOutputDir)
 
-	return nil
+	return changed, nil
 }
 
 // writeAliasSymlink creates a sibling symlink alongside componentOutputDir at the
@@ -937,29 +1039,32 @@ func validateOutputDir(outputDir string) error {
 	return nil
 }
 
-// wipeOutputDirContents removes every direct child of outputDir (files and
-// directories alike) but leaves the directory itself in place.
-// Missing outputDir is a no-op.
-func wipeOutputDirContents(fileSystem opctx.FS, outputDir string) error {
-	exists, existsErr := fileutils.DirExists(fileSystem, outputDir)
-	if existsErr != nil {
-		return fmt.Errorf("checking output directory %#q:\n%w", outputDir, existsErr)
+// pruneOrphanRenderedDirs removes per-component rendered-spec directories
+// under outputDir that don't correspond to any component in resolvedComps.
+// Per-component dirs that ARE in resolvedComps are left alone -- phase 3 will
+// overwrite them via copyRenderedOutput, and leaving the prior content here
+// lets the unconditional diff in finishComponentRender produce a meaningful
+// result.Changed value for the user-visible table.
+//
+// Top-level non-letter entries (e.g. a hand-placed README.md at the root of
+// SPECS/) are intentionally NOT removed. The previous implementation wiped
+// them too, but in practice the only callers want orphan cleanup, not a
+// blanket sweep.
+func pruneOrphanRenderedDirs(
+	fileSystem opctx.FS, outputDir string, componentNames []string,
+) error {
+	orphans, err := findOrphanRenderedDirs(fileSystem, outputDir, componentNames)
+	if err != nil {
+		return err
 	}
 
-	if !exists {
-		return nil
-	}
-
-	entries, readErr := fileutils.ReadDir(fileSystem, outputDir)
-	if readErr != nil {
-		return fmt.Errorf("reading output directory %#q:\n%w", outputDir, readErr)
-	}
-
-	for _, entry := range entries {
-		childPath := filepath.Join(outputDir, entry.Name())
-		if removeErr := fileSystem.RemoveAll(childPath); removeErr != nil {
-			return fmt.Errorf("removing %#q:\n%w", childPath, removeErr)
+	for _, rel := range orphans {
+		fullPath := filepath.Join(outputDir, rel)
+		if removeErr := fileSystem.RemoveAll(fullPath); removeErr != nil {
+			return fmt.Errorf("removing orphan rendered-spec dir %#q:\n%w", fullPath, removeErr)
 		}
+
+		slog.Info("Removed orphan rendered-spec dir", "path", fullPath)
 	}
 
 	return nil
@@ -973,9 +1078,38 @@ func wipeOutputDirContents(fileSystem opctx.FS, outputDir string) error {
 // Cancelled components are intentionally skipped — a Ctrl-C is not a render
 // failure, just an incomplete run, and silently planting markers under those
 // circumstances would lie in git diff.
-func writeFailureMarkers(fileSystem opctx.FS, results []*RenderResult, allowOverwrite bool) {
+//
+// In --check-only mode, no marker is written. Instead, the existing on-disk
+// state for each errored component is verified to be exactly the standard
+// failure marker; any deviation flips result.Changed so the caller can fail
+// the run. This delivers the 1:1 invariant the user asked for: a component
+// that would fail must already be marked as failed on disk, with no extra
+// stale output around it.
+func writeFailureMarkers(
+	fileSystem opctx.FS, results []*RenderResult, allowOverwrite, checkOnly bool,
+) {
 	for _, result := range results {
 		if result == nil || result.Status != renderStatusError {
+			continue
+		}
+
+		if checkOnly {
+			drifted, err := isFailureMarkerOnly(fileSystem, result.OutputDir)
+			if err != nil {
+				// Treat inspection errors as drift -- safer to fail loudly
+				// in CI than to silently skip.
+				slog.Debug("Failed to inspect output dir for failure-marker check",
+					"path", result.OutputDir, "error", err)
+
+				result.Changed = true
+
+				continue
+			}
+
+			if drifted {
+				result.Changed = true
+			}
+
 			continue
 		}
 
@@ -1010,4 +1144,147 @@ func createMockProcessor(env *azldev.Env) *sources.MockProcessor {
 	slog.Info("Mock processor available", "mockConfig", distroVerDef.MockConfigPath)
 
 	return sources.NewMockProcessor(env, distroVerDef.MockConfigPath)
+}
+
+// validateCleanStaleOptions enforces the constraints around --clean-stale.
+// Extracted from RenderComponents to keep its complexity below the linter's
+// cyclomatic threshold.
+func validateCleanStaleOptions(options *RenderOptions) error {
+	if !options.CleanStale {
+		return nil
+	}
+
+	if !options.ComponentFilter.IncludeAllComponents {
+		return errors.New("--clean-stale requires -a (render all components)")
+	}
+
+	if options.OutputDirExplicit && !options.Force {
+		return errors.New("--clean-stale with --output-dir requires --force (-f)")
+	}
+
+	return nil
+}
+
+// renderErrorMarkerContent is the static body of the RENDER_FAILED marker file.
+// It must match exactly what writeRenderErrorMarker writes; --check-only relies
+// on this constant to verify on-disk failure markers are byte-identical to a
+// fresh run's output.
+const renderErrorMarkerContent = "Rendering failed. See azldev logs for details.\n"
+
+// diffRenderedOutput compares the rendered staging tree (expectedDir) against
+// the existing on-disk output (actualDir) and returns true when they differ.
+// A missing actualDir always counts as drift. Symlinks are compared by target
+// (filesystems without symlink support skip that check; matches production
+// render behavior).
+func diffRenderedOutput(fileSystem opctx.FS, expectedDir, actualDir string) (bool, error) {
+	actualExists, err := fileutils.DirExists(fileSystem, actualDir)
+	if err != nil {
+		return false, fmt.Errorf("checking actual output dir %#q:\n%w", actualDir, err)
+	}
+
+	if !actualExists {
+		// First-time render -- every file in expectedDir is drift.
+		return true, nil
+	}
+
+	result, err := dirdiff.DiffDirs(fileSystem, actualDir, expectedDir)
+	if err != nil {
+		return false, fmt.Errorf("diffing %#q vs %#q:\n%w", actualDir, expectedDir, err)
+	}
+
+	return len(result.Files) > 0, nil
+}
+
+// isFailureMarkerOnly reports whether outputDir's contents diverge from a
+// fresh failure write -- i.e., a single RENDER_FAILED file containing the
+// canonical marker body. Returns true when the on-disk state would change
+// if a real failure write ran. Used by --check-only to enforce 1:1 parity:
+// a component that would fail must already be marked failed on disk, with
+// no extra stale output around it.
+func isFailureMarkerOnly(fileSystem opctx.FS, outputDir string) (bool, error) {
+	exists, err := fileutils.DirExists(fileSystem, outputDir)
+	if err != nil {
+		return false, fmt.Errorf("checking output dir %#q:\n%w", outputDir, err)
+	}
+
+	if !exists {
+		return true, nil
+	}
+
+	entries, err := fileutils.ReadDir(fileSystem, outputDir)
+	if err != nil {
+		return false, fmt.Errorf("reading output dir %#q:\n%w", outputDir, err)
+	}
+
+	if len(entries) != 1 || entries[0].Name() != renderErrorMarkerFile {
+		return true, nil
+	}
+
+	content, err := fileutils.ReadFile(fileSystem, filepath.Join(outputDir, renderErrorMarkerFile))
+	if err != nil {
+		return false, fmt.Errorf("reading marker %#q:\n%w", outputDir, err)
+	}
+
+	return string(content) != renderErrorMarkerContent, nil
+}
+
+// findOrphanRenderedDirs returns the names of rendered-spec directories under
+// outputDir that don't correspond to any resolved component (or its alias).
+// Names are returned as "<letter>/<name>" relative paths and sorted.
+//
+// Only meaningful with -a (we know the full component set) and --clean-stale
+// (the only configuration where a normal run would actually remove orphans).
+// Top-level non-letter entries are intentionally NOT flagged -- that matches
+// the existing wipe semantics where users may store unrelated siblings in a
+// custom output dir; flagging them here would surprise CI gates.
+func findOrphanRenderedDirs(
+	fileSystem opctx.FS, outputDir string, componentNames []string,
+) ([]string, error) {
+	exists, err := fileutils.DirExists(fileSystem, outputDir)
+	if err != nil {
+		return nil, fmt.Errorf("checking output dir %#q:\n%w", outputDir, err)
+	}
+
+	if !exists {
+		return nil, nil
+	}
+
+	expectedNames := make(map[string]struct{}, len(componentNames)*2) //nolint:mnd // name + optional alias
+	for _, name := range componentNames {
+		expectedNames[name] = struct{}{}
+
+		if alias := components.RenderedSpecDirAliasName(name); alias != "" {
+			expectedNames[alias] = struct{}{}
+		}
+	}
+
+	letterDirs, err := fileutils.ReadDir(fileSystem, outputDir)
+	if err != nil {
+		return nil, fmt.Errorf("reading output dir %#q:\n%w", outputDir, err)
+	}
+
+	var orphans []string
+
+	for _, letterEntry := range letterDirs {
+		if !letterEntry.IsDir() {
+			continue
+		}
+
+		letterPath := filepath.Join(outputDir, letterEntry.Name())
+
+		children, readErr := fileutils.ReadDir(fileSystem, letterPath)
+		if readErr != nil {
+			return nil, fmt.Errorf("reading letter dir %#q:\n%w", letterPath, readErr)
+		}
+
+		for _, child := range children {
+			if _, ok := expectedNames[child.Name()]; !ok {
+				orphans = append(orphans, filepath.Join(letterEntry.Name(), child.Name()))
+			}
+		}
+	}
+
+	sort.Strings(orphans)
+
+	return orphans, nil
 }

--- a/internal/app/azldev/cmds/component/render.go
+++ b/internal/app/azldev/cmds/component/render.go
@@ -1300,6 +1300,13 @@ func findOrphanRenderedDirs(
 		}
 
 		for _, child := range children {
+			// Component output is always a directory. Stray files (e.g. an
+			// editor's swap file or a hand-placed .gitkeep) are not orphan
+			// rendered-spec dirs and must not be flagged for removal.
+			if !child.IsDir() {
+				continue
+			}
+
 			if _, ok := expectedNames[child.Name()]; !ok {
 				orphans = append(orphans, filepath.Join(letterEntry.Name(), child.Name()))
 			}

--- a/internal/app/azldev/cmds/component/render.go
+++ b/internal/app/azldev/cmds/component/render.go
@@ -64,12 +64,15 @@ Unlike prepare-sources, render skips downloading source tarballs from the
 lookaside cache — only spec files, patches, scripts, and other git-tracked
 sidecar files are included. Multiple components can be rendered at once.
 
-When rendering all components (-a), the --clean-stale flag removes all
-contents of the output directory before rendering, leaving the directory
-itself in place. When using a custom output directory (--output-dir),
---force is required alongside --clean-stale as a safety measure. An
-interrupted run with --clean-stale leaves the output directory partially
-populated; recover with 'git checkout'. This flag is only valid with -a.`,
+When rendering all components (-a), the --clean-stale flag prunes orphan
+rendered-spec directories (per-component dirs that no longer correspond to
+any component in the project config). Per-component dirs that ARE in config
+are overwritten in place by the render itself; this means each render's
+result table accurately reflects which components actually changed on disk.
+Top-level non-component siblings (e.g. a hand-placed README.md) are
+preserved. When using a custom output directory (--output-dir), --force is
+required alongside --clean-stale as a safety measure. This flag is only
+valid with -a.`,
 		Example: `  # Render all components (output dir from config)
   azldev component render -a
 
@@ -106,13 +109,21 @@ populated; recover with 'git checkout'. This flag is only valid with -a.`,
 		"allow overwriting existing rendered component directories")
 
 	cmd.Flags().BoolVar(&options.CleanStale, "clean-stale", false,
-		"remove contents of the output directory before rendering (only with -a; requires -f with -o)")
+		"prune rendered-spec directories that no longer correspond to a configured "+
+			"component (only with -a; requires -f with -o). Top-level non-component "+
+			"siblings are preserved.")
 
 	cmd.Flags().BoolVar(&options.CheckOnly, "check-only", false,
 		"render to a staging area and compare against the existing on-disk output "+
 			"without writing anything. Exits 0 when nothing would change and 1 when "+
 			"any component would drift. With -a + --clean-stale, also fails on orphan "+
 			"rendered-spec directories. Intended for CI gates.")
+
+	// --check-only is a read-only diff against on-disk state; --fail-on-error
+	// is the loud-failure-per-run knob. Combining them is semantically
+	// muddled (CI would fail on stale failures even when on-disk markers
+	// already record them) and forcing a choice keeps the contract crisp.
+	cmd.MarkFlagsMutuallyExclusive("fail-on-error", "check-only")
 
 	return cmd
 }
@@ -123,7 +134,7 @@ type RenderResult struct {
 	OutputDir string `json:"outputDir"       table:"Output"`
 	Status    string `json:"status"          table:"Status"`
 	Error     string `json:"error,omitempty" table:"Error,omitempty"`
-	Changed   bool   `json:"changed" table:"Changed"`
+	Changed   bool   `json:"changed"         table:"Changed"`
 }
 
 // Render status constants.
@@ -996,9 +1007,10 @@ func writeRenderErrorMarker(fs opctx.FS, componentOutputDir string) {
 	}
 
 	markerPath := filepath.Join(componentOutputDir, renderErrorMarkerFile)
-	content := "Rendering failed. See azldev logs for details.\n"
 
-	if writeErr := fileutils.WriteFile(fs, markerPath, []byte(content), fileperms.PublicFile); writeErr != nil {
+	if writeErr := fileutils.WriteFile(
+		fs, markerPath, []byte(renderErrorMarkerContent), fileperms.PublicFile,
+	); writeErr != nil {
 		slog.Debug("Failed to write render error marker", "path", markerPath, "error", writeErr)
 	}
 }
@@ -1094,11 +1106,12 @@ func writeFailureMarkers(
 		}
 
 		if checkOnly {
-			drifted, err := isFailureMarkerOnly(fileSystem, result.OutputDir)
+			drifted, err := outputDriftsFromMarker(fileSystem, result.OutputDir)
 			if err != nil {
-				// Treat inspection errors as drift -- safer to fail loudly
-				// in CI than to silently skip.
-				slog.Debug("Failed to inspect output dir for failure-marker check",
+				// Surface inspection errors at Warn so a CI failure is
+				// debuggable. Treat them as drift -- safer to fail loudly
+				// than silently pass.
+				slog.Warn("Failed to inspect output dir for failure-marker check; treating as drift",
 					"path", result.OutputDir, "error", err)
 
 				result.Changed = true
@@ -1195,13 +1208,13 @@ func diffRenderedOutput(fileSystem opctx.FS, expectedDir, actualDir string) (boo
 	return len(result.Files) > 0, nil
 }
 
-// isFailureMarkerOnly reports whether outputDir's contents diverge from a
+// outputDriftsFromMarker reports whether outputDir's contents diverge from a
 // fresh failure write -- i.e., a single RENDER_FAILED file containing the
 // canonical marker body. Returns true when the on-disk state would change
 // if a real failure write ran. Used by --check-only to enforce 1:1 parity:
 // a component that would fail must already be marked failed on disk, with
 // no extra stale output around it.
-func isFailureMarkerOnly(fileSystem opctx.FS, outputDir string) (bool, error) {
+func outputDriftsFromMarker(fileSystem opctx.FS, outputDir string) (bool, error) {
 	exists, err := fileutils.DirExists(fileSystem, outputDir)
 	if err != nil {
 		return false, fmt.Errorf("checking output dir %#q:\n%w", outputDir, err)
@@ -1267,6 +1280,15 @@ func findOrphanRenderedDirs(
 
 	for _, letterEntry := range letterDirs {
 		if !letterEntry.IsDir() {
+			continue
+		}
+
+		// Only descend into single-character prefix dirs (a/, c/, ...) --
+		// matches the layout written by [components.RenderedSpecDir]. A
+		// hand-placed sibling like 'tooling/' or 'overlays/' is left
+		// alone; treating its children as orphans would silently delete
+		// unrelated content on the next --clean-stale run.
+		if len(letterEntry.Name()) != 1 {
 			continue
 		}
 

--- a/internal/app/azldev/cmds/component/render.go
+++ b/internal/app/azldev/cmds/component/render.go
@@ -115,9 +115,9 @@ valid with -a.`,
 
 	cmd.Flags().BoolVar(&options.CheckOnly, "check-only", false,
 		"render to a staging area and compare against the existing on-disk output "+
-			"without writing anything. Exits 0 when nothing would change and 1 when "+
-			"any component would drift. With -a + --clean-stale, also fails on orphan "+
-			"rendered-spec directories. Intended for CI gates.")
+			"without modifying the output directory. Exits 0 when nothing would change "+
+			"and 1 when any component would drift. With -a + --clean-stale, also fails "+
+			"on orphan rendered-spec directories. Intended for CI gates.")
 
 	// --check-only is a read-only diff against on-disk state; --fail-on-error
 	// is the loud-failure-per-run knob. Combining them is semantically

--- a/internal/app/azldev/cmds/component/render_internal_test.go
+++ b/internal/app/azldev/cmds/component/render_internal_test.go
@@ -635,14 +635,14 @@ func TestDiffRenderedOutput(t *testing.T) {
 	})
 }
 
-func TestIsFailureMarkerOnly(t *testing.T) {
+func TestOutputDriftsFromMarker(t *testing.T) {
 	t.Parallel()
 
 	t.Run("missing dir -> drift", func(t *testing.T) {
 		t.Parallel()
 
 		testFS := afero.NewMemMapFs()
-		drifted, err := isFailureMarkerOnly(testFS, "/missing")
+		drifted, err := outputDriftsFromMarker(testFS, "/missing")
 		require.NoError(t, err)
 		assert.True(t, drifted)
 	})
@@ -656,7 +656,7 @@ func TestIsFailureMarkerOnly(t *testing.T) {
 			"/out/"+renderErrorMarkerFile,
 			[]byte(renderErrorMarkerContent), fileperms.PublicFile))
 
-		drifted, err := isFailureMarkerOnly(testFS, "/out")
+		drifted, err := outputDriftsFromMarker(testFS, "/out")
 		require.NoError(t, err)
 		assert.False(t, drifted)
 	})
@@ -670,7 +670,7 @@ func TestIsFailureMarkerOnly(t *testing.T) {
 			"/out/"+renderErrorMarkerFile,
 			[]byte("hand-edited"), fileperms.PublicFile))
 
-		drifted, err := isFailureMarkerOnly(testFS, "/out")
+		drifted, err := outputDriftsFromMarker(testFS, "/out")
 		require.NoError(t, err)
 		assert.True(t, drifted)
 	})
@@ -686,7 +686,7 @@ func TestIsFailureMarkerOnly(t *testing.T) {
 		require.NoError(t, fileutils.WriteFile(testFS,
 			"/out/curl.spec", []byte("stale"), fileperms.PublicFile))
 
-		drifted, err := isFailureMarkerOnly(testFS, "/out")
+		drifted, err := outputDriftsFromMarker(testFS, "/out")
 		require.NoError(t, err)
 		assert.True(t, drifted)
 	})
@@ -734,5 +734,22 @@ func TestFindOrphanRenderedDirs(t *testing.T) {
 		orphans, err := findOrphanRenderedDirs(testFS, "/out", []string{"curl"})
 		require.NoError(t, err)
 		assert.Empty(t, orphans)
+	})
+
+	t.Run("ignores multi-character top-level directories", func(t *testing.T) {
+		t.Parallel()
+
+		// Regression: an unrelated multi-char sibling directory like
+		// 'tooling/' or 'overlays/' must NOT have its children walked
+		// and flagged as orphans, or pruneOrphanRenderedDirs would
+		// silently delete them on the next --clean-stale run.
+		testFS := afero.NewMemMapFs()
+		require.NoError(t, fileutils.MkdirAll(testFS, "/out/c/curl"))
+		require.NoError(t, fileutils.MkdirAll(testFS, "/out/tooling/build.sh"))
+		require.NoError(t, fileutils.MkdirAll(testFS, "/out/overlays/curl-fix"))
+
+		orphans, err := findOrphanRenderedDirs(testFS, "/out", []string{"curl"})
+		require.NoError(t, err)
+		assert.Empty(t, orphans, "multi-char top-level dirs must be left alone")
 	})
 }

--- a/internal/app/azldev/cmds/component/render_internal_test.go
+++ b/internal/app/azldev/cmds/component/render_internal_test.go
@@ -752,4 +752,22 @@ func TestFindOrphanRenderedDirs(t *testing.T) {
 		require.NoError(t, err)
 		assert.Empty(t, orphans, "multi-char top-level dirs must be left alone")
 	})
+
+	t.Run("ignores non-directory children inside letter dirs", func(t *testing.T) {
+		t.Parallel()
+
+		// Regression: a stray file like .gitkeep or an editor swap file
+		// inside a letter prefix dir is not a rendered-spec component dir
+		// and must NOT be flagged for removal.
+		testFS := afero.NewMemMapFs()
+		require.NoError(t, fileutils.MkdirAll(testFS, "/out/c/curl"))
+		require.NoError(t, fileutils.WriteFile(testFS, "/out/c/.gitkeep",
+			[]byte(""), fileperms.PublicFile))
+		require.NoError(t, fileutils.WriteFile(testFS, "/out/c/.curl.spec.swp",
+			[]byte("vim swap"), fileperms.PublicFile))
+
+		orphans, err := findOrphanRenderedDirs(testFS, "/out", []string{"curl"})
+		require.NoError(t, err)
+		assert.Empty(t, orphans, "non-directory children must not be flagged as orphan dirs")
+	})
 }

--- a/internal/app/azldev/cmds/component/render_internal_test.go
+++ b/internal/app/azldev/cmds/component/render_internal_test.go
@@ -162,7 +162,7 @@ func TestRemoveUnreferencedFiles(t *testing.T) {
 		require.NoError(t, fileutils.WriteFile(testFS, "/render/patches/fix.patch", []byte("patch"), fileperms.PublicFile))
 		require.NoError(t, fileutils.WriteFile(testFS, "/render/unrelated.txt", []byte("junk"), fileperms.PublicFile))
 
-		// spectool reports "patches/fix.patch" — top-level "patches" dir should be kept.
+		// spectool reports "patches/fix.patch" -- top-level "patches" dir should be kept.
 		specFiles := []string{"patches/fix.patch"}
 
 		err := removeUnreferencedFiles(testFS, "/render", "/render/curl.spec", specFiles, "curl")
@@ -343,7 +343,7 @@ func TestWriteAliasSymlink(t *testing.T) {
 		linkInfo := osLstat(t, osFS, aliasPath)
 		assert.NotZero(t, linkInfo.Mode()&os.ModeSymlink, "alias should be a symlink")
 
-		// Relative target — must be just the basename, not absolute.
+		// Relative target -- must be just the basename, not absolute.
 		assert.Equal(t, "libxml++", osReadlink(t, osFS, aliasPath))
 	})
 
@@ -396,14 +396,14 @@ func TestWriteAliasSymlink(t *testing.T) {
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "non-symlink")
 
-		// Collision dir must still exist — the guard MUST NOT have destroyed it.
+		// Collision dir must still exist -- the guard MUST NOT have destroyed it.
 		exists, existsErr := fileutils.DirExists(osFS, collisionDir)
 		require.NoError(t, existsErr)
 		assert.True(t, exists, "non-symlink at alias path must be preserved")
 	})
 
 	t.Run("no-op on filesystem without symlink support", func(t *testing.T) {
-		// MemMapFs does NOT implement afero.Linker — function should silently no-op.
+		// MemMapFs does NOT implement afero.Linker -- function should silently no-op.
 		memFS := afero.NewMemMapFs()
 		require.NoError(t, fileutils.MkdirAll(memFS, "/SPECS/l/libxml++"))
 
@@ -412,47 +412,37 @@ func TestWriteAliasSymlink(t *testing.T) {
 	})
 }
 
-func TestWipeOutputDirContents(t *testing.T) {
+func TestPruneOrphanRenderedDirs(t *testing.T) {
 	t.Parallel()
 
-	t.Run("missing directory is a no-op", func(t *testing.T) {
-		t.Parallel()
-
-		fs := afero.NewMemMapFs()
-		assert.NoError(t, wipeOutputDirContents(fs, "/output"))
-	})
-
-	t.Run("empty directory is a no-op", func(t *testing.T) {
-		t.Parallel()
-
-		fs := afero.NewMemMapFs()
-		require.NoError(t, fileutils.MkdirAll(fs, "/output"))
-
-		assert.NoError(t, wipeOutputDirContents(fs, "/output"))
-	})
-
-	t.Run("removes all children but keeps directory", func(t *testing.T) {
+	t.Run("removes only orphan dirs, leaves resolved components", func(t *testing.T) {
 		t.Parallel()
 
 		testFS := afero.NewMemMapFs()
-		for _, letter := range []string{"a", "c", "l"} {
-			require.NoError(t, fileutils.MkdirAll(testFS, filepath.Join("/output", letter, "pkg")))
-		}
+		require.NoError(t, fileutils.MkdirAll(testFS, "/out/c/curl"))
+		require.NoError(t, fileutils.WriteFile(testFS, "/out/c/curl/curl.spec",
+			[]byte("Name: curl"), fileperms.PublicFile))
+		require.NoError(t, fileutils.MkdirAll(testFS, "/out/r/removed-pkg"))
+		require.NoError(t, fileutils.WriteFile(testFS, "/out/README.md",
+			[]byte("docs"), fileperms.PublicFile))
 
-		require.NoError(t, fileutils.WriteFile(testFS, "/output/README.md", []byte("keep me"), fileperms.PublicFile))
-		require.NoError(t, fileutils.MkdirAll(testFS, "/output/multi-char-dir"))
-
-		require.NoError(t, wipeOutputDirContents(testFS, "/output"))
-
-		// Directory itself still exists.
-		exists, err := fileutils.DirExists(testFS, "/output")
+		err := pruneOrphanRenderedDirs(testFS, "/out", []string{"curl"})
 		require.NoError(t, err)
-		assert.True(t, exists, "output directory itself must be preserved")
 
-		// All children removed.
-		entries, err := fileutils.ReadDir(testFS, "/output")
+		// Resolved component is preserved (content untouched).
+		spec, err := fileutils.ReadFile(testFS, "/out/c/curl/curl.spec")
 		require.NoError(t, err)
-		assert.Empty(t, entries, "all contents should be removed")
+		assert.Equal(t, "Name: curl", string(spec))
+
+		// Orphan removed.
+		exists, err := fileutils.DirExists(testFS, "/out/r/removed-pkg")
+		require.NoError(t, err)
+		assert.False(t, exists)
+
+		// Top-level non-letter entry preserved.
+		exists, err = fileutils.Exists(testFS, "/out/README.md")
+		require.NoError(t, err)
+		assert.True(t, exists, "top-level non-letter siblings must NOT be pruned")
 	})
 }
 
@@ -470,14 +460,14 @@ func TestWriteFailureMarkers(t *testing.T) {
 			nil, // gap from a still-pending phase-3 slot.
 		}
 
-		writeFailureMarkers(testFS, results, false)
+		writeFailureMarkers(testFS, results, false, false)
 
-		// Error result → marker present.
+		// Error result -> marker present.
 		exists, err := fileutils.Exists(testFS, "/output/b/broken-pkg/"+renderErrorMarkerFile)
 		require.NoError(t, err)
 		assert.True(t, exists, "error result should have a marker")
 
-		// Non-error results → no marker.
+		// Non-error results -> no marker.
 		nonErrorPaths := []string{
 			"/output/o/ok-pkg/" + renderErrorMarkerFile,
 			"/output/c/cancelled-pkg/" + renderErrorMarkerFile,
@@ -504,7 +494,7 @@ func TestWriteFailureMarkers(t *testing.T) {
 			{Component: "broken-pkg", OutputDir: "/output/b/broken-pkg", Status: renderStatusError},
 		}
 
-		writeFailureMarkers(testFS, results, true)
+		writeFailureMarkers(testFS, results, true, false)
 
 		// Stale spec gone.
 		exists, err := fileutils.Exists(testFS, "/output/b/broken-pkg/broken-pkg.spec")
@@ -521,7 +511,7 @@ func TestWriteFailureMarkers(t *testing.T) {
 		t.Parallel()
 
 		// Without --force, a previous successful render's content stays in
-		// place — the marker just appears alongside it. (Realistically this
+		// place -- the marker just appears alongside it. (Realistically this
 		// scenario can't happen with the current call sites, but the helper
 		// must respect its allowOverwrite contract.)
 		testFS := afero.NewMemMapFs()
@@ -534,10 +524,215 @@ func TestWriteFailureMarkers(t *testing.T) {
 			{Component: "broken-pkg", OutputDir: "/output/b/broken-pkg", Status: renderStatusError},
 		}
 
-		writeFailureMarkers(testFS, results, false)
+		writeFailureMarkers(testFS, results, false, false)
 
 		exists, err := fileutils.Exists(testFS, "/output/b/broken-pkg/broken-pkg.spec")
 		require.NoError(t, err)
 		assert.True(t, exists, "spec should be preserved when overwrite is not allowed")
+	})
+
+	t.Run("check-only flips Drifted when on-disk state diverges from marker", func(t *testing.T) {
+		t.Parallel()
+
+		testFS := afero.NewMemMapFs()
+
+		// Component "missing-marker": output dir has the standard marker (no drift).
+		require.NoError(t, fileutils.MkdirAll(testFS, "/output/o/ok-pkg"))
+		require.NoError(t, fileutils.WriteFile(testFS,
+			"/output/o/ok-pkg/"+renderErrorMarkerFile,
+			[]byte(renderErrorMarkerContent), fileperms.PublicFile))
+
+		// Component "extra-files": dir has the marker AND stale render output -> drift.
+		require.NoError(t, fileutils.MkdirAll(testFS, "/output/e/extra-pkg"))
+		require.NoError(t, fileutils.WriteFile(testFS,
+			"/output/e/extra-pkg/"+renderErrorMarkerFile,
+			[]byte(renderErrorMarkerContent), fileperms.PublicFile))
+		require.NoError(t, fileutils.WriteFile(testFS,
+			"/output/e/extra-pkg/extra-pkg.spec",
+			[]byte("Name: extra-pkg"), fileperms.PublicFile))
+
+		// Component "no-marker": dir exists but the marker is absent -> drift.
+		require.NoError(t, fileutils.MkdirAll(testFS, "/output/n/no-marker"))
+
+		// Component "no-dir": output dir doesn't exist at all -> drift.
+
+		results := []*RenderResult{
+			{Component: "ok-pkg", OutputDir: "/output/o/ok-pkg", Status: renderStatusError},
+			{Component: "extra-pkg", OutputDir: "/output/e/extra-pkg", Status: renderStatusError},
+			{Component: "no-marker", OutputDir: "/output/n/no-marker", Status: renderStatusError},
+			{Component: "no-dir", OutputDir: "/output/x/no-dir", Status: renderStatusError},
+		}
+
+		writeFailureMarkers(testFS, results, false, true)
+
+		assert.False(t, results[0].Changed, "matching marker -> no drift")
+		assert.True(t, results[1].Changed, "extra files alongside marker -> drift")
+		assert.True(t, results[2].Changed, "missing marker file -> drift")
+		assert.True(t, results[3].Changed, "missing output dir -> drift")
+
+		// Disk must be untouched in check-only mode -- no markers planted on no-marker/no-dir.
+		exists, err := fileutils.Exists(testFS, "/output/n/no-marker/"+renderErrorMarkerFile)
+		require.NoError(t, err)
+		assert.False(t, exists, "check-only must not write markers")
+
+		exists, err = fileutils.DirExists(testFS, "/output/x/no-dir")
+		require.NoError(t, err)
+		assert.False(t, exists, "check-only must not create output dirs")
+	})
+}
+
+func TestDiffRenderedOutput(t *testing.T) {
+	t.Parallel()
+
+	t.Run("identical trees -> no drift", func(t *testing.T) {
+		t.Parallel()
+
+		testFS := afero.NewMemMapFs()
+		require.NoError(t, fileutils.WriteFile(testFS, "/exp/curl.spec", []byte("Name: curl"), fileperms.PublicFile))
+		require.NoError(t, fileutils.WriteFile(testFS, "/exp/sources", []byte("hash"), fileperms.PublicFile))
+		require.NoError(t, fileutils.WriteFile(testFS, "/act/curl.spec", []byte("Name: curl"), fileperms.PublicFile))
+		require.NoError(t, fileutils.WriteFile(testFS, "/act/sources", []byte("hash"), fileperms.PublicFile))
+
+		drifted, err := diffRenderedOutput(testFS, "/exp", "/act")
+		require.NoError(t, err)
+		assert.False(t, drifted)
+	})
+
+	t.Run("missing actual dir -> drift", func(t *testing.T) {
+		t.Parallel()
+
+		testFS := afero.NewMemMapFs()
+		require.NoError(t, fileutils.WriteFile(testFS, "/exp/curl.spec", []byte("x"), fileperms.PublicFile))
+
+		drifted, err := diffRenderedOutput(testFS, "/exp", "/missing")
+		require.NoError(t, err)
+		assert.True(t, drifted)
+	})
+
+	t.Run("content difference -> drift", func(t *testing.T) {
+		t.Parallel()
+
+		testFS := afero.NewMemMapFs()
+		require.NoError(t, fileutils.WriteFile(testFS, "/exp/curl.spec", []byte("v2"), fileperms.PublicFile))
+		require.NoError(t, fileutils.WriteFile(testFS, "/act/curl.spec", []byte("v1"), fileperms.PublicFile))
+
+		drifted, err := diffRenderedOutput(testFS, "/exp", "/act")
+		require.NoError(t, err)
+		assert.True(t, drifted)
+	})
+
+	t.Run("extra file in actual -> drift", func(t *testing.T) {
+		t.Parallel()
+
+		testFS := afero.NewMemMapFs()
+		require.NoError(t, fileutils.WriteFile(testFS, "/exp/curl.spec", []byte("x"), fileperms.PublicFile))
+		require.NoError(t, fileutils.WriteFile(testFS, "/act/curl.spec", []byte("x"), fileperms.PublicFile))
+		require.NoError(t, fileutils.WriteFile(testFS, "/act/stale.patch", []byte("y"), fileperms.PublicFile))
+
+		drifted, err := diffRenderedOutput(testFS, "/exp", "/act")
+		require.NoError(t, err)
+		assert.True(t, drifted)
+	})
+}
+
+func TestIsFailureMarkerOnly(t *testing.T) {
+	t.Parallel()
+
+	t.Run("missing dir -> drift", func(t *testing.T) {
+		t.Parallel()
+
+		testFS := afero.NewMemMapFs()
+		drifted, err := isFailureMarkerOnly(testFS, "/missing")
+		require.NoError(t, err)
+		assert.True(t, drifted)
+	})
+
+	t.Run("dir with only the canonical marker -> no drift", func(t *testing.T) {
+		t.Parallel()
+
+		testFS := afero.NewMemMapFs()
+		require.NoError(t, fileutils.MkdirAll(testFS, "/out"))
+		require.NoError(t, fileutils.WriteFile(testFS,
+			"/out/"+renderErrorMarkerFile,
+			[]byte(renderErrorMarkerContent), fileperms.PublicFile))
+
+		drifted, err := isFailureMarkerOnly(testFS, "/out")
+		require.NoError(t, err)
+		assert.False(t, drifted)
+	})
+
+	t.Run("marker with wrong content -> drift", func(t *testing.T) {
+		t.Parallel()
+
+		testFS := afero.NewMemMapFs()
+		require.NoError(t, fileutils.MkdirAll(testFS, "/out"))
+		require.NoError(t, fileutils.WriteFile(testFS,
+			"/out/"+renderErrorMarkerFile,
+			[]byte("hand-edited"), fileperms.PublicFile))
+
+		drifted, err := isFailureMarkerOnly(testFS, "/out")
+		require.NoError(t, err)
+		assert.True(t, drifted)
+	})
+
+	t.Run("dir with extra files alongside marker -> drift", func(t *testing.T) {
+		t.Parallel()
+
+		testFS := afero.NewMemMapFs()
+		require.NoError(t, fileutils.MkdirAll(testFS, "/out"))
+		require.NoError(t, fileutils.WriteFile(testFS,
+			"/out/"+renderErrorMarkerFile,
+			[]byte(renderErrorMarkerContent), fileperms.PublicFile))
+		require.NoError(t, fileutils.WriteFile(testFS,
+			"/out/curl.spec", []byte("stale"), fileperms.PublicFile))
+
+		drifted, err := isFailureMarkerOnly(testFS, "/out")
+		require.NoError(t, err)
+		assert.True(t, drifted)
+	})
+}
+
+func TestFindOrphanRenderedDirs(t *testing.T) {
+	t.Parallel()
+
+	t.Run("missing output dir -> no orphans", func(t *testing.T) {
+		t.Parallel()
+
+		testFS := afero.NewMemMapFs()
+		orphans, err := findOrphanRenderedDirs(testFS, "/missing", nil)
+		require.NoError(t, err)
+		assert.Empty(t, orphans)
+	})
+
+	t.Run("returns orphan component dirs sorted", func(t *testing.T) {
+		t.Parallel()
+
+		testFS := afero.NewMemMapFs()
+		// Resolved components: curl, bash.
+		require.NoError(t, fileutils.MkdirAll(testFS, "/out/c/curl"))
+		require.NoError(t, fileutils.MkdirAll(testFS, "/out/b/bash"))
+		// Orphans: removed-pkg, ancient-pkg.
+		require.NoError(t, fileutils.MkdirAll(testFS, "/out/r/removed-pkg"))
+		require.NoError(t, fileutils.MkdirAll(testFS, "/out/a/ancient-pkg"))
+
+		orphans, err := findOrphanRenderedDirs(testFS, "/out", []string{"curl", "bash"})
+		require.NoError(t, err)
+		assert.Equal(t, []string{
+			filepath.Join("a", "ancient-pkg"),
+			filepath.Join("r", "removed-pkg"),
+		}, orphans)
+	})
+
+	t.Run("ignores top-level non-letter entries", func(t *testing.T) {
+		t.Parallel()
+
+		testFS := afero.NewMemMapFs()
+		require.NoError(t, fileutils.MkdirAll(testFS, "/out/c/curl"))
+		// README at top level -- not flagged.
+		require.NoError(t, fileutils.WriteFile(testFS, "/out/README.md", []byte("docs"), fileperms.PublicFile))
+
+		orphans, err := findOrphanRenderedDirs(testFS, "/out", []string{"curl"})
+		require.NoError(t, err)
+		assert.Empty(t, orphans)
 	})
 }

--- a/internal/app/azldev/cmds/component/render_test.go
+++ b/internal/app/azldev/cmds/component/render_test.go
@@ -44,6 +44,10 @@ func TestNewRenderCmd_Flags(t *testing.T) {
 	cleanStaleFlag := cmd.Flags().Lookup("clean-stale")
 	require.NotNil(t, cleanStaleFlag, "clean-stale flag should be registered")
 	assert.Equal(t, "false", cleanStaleFlag.DefValue)
+
+	checkOnlyFlag := cmd.Flags().Lookup("check-only")
+	require.NotNil(t, checkOnlyFlag, "check-only flag should be registered")
+	assert.Equal(t, "false", checkOnlyFlag.DefValue)
 }
 
 func TestRenderCmd_NoComponents(t *testing.T) {


### PR DESCRIPTION
<!--
PR Title must follow Conventional Commits format. Available types:

- feat: A new feature
- fix: A bug fix
- docs: Documentation only changes
- style: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
- refactor: A code change that neither fixes a bug nor adds a feature
- perf: A code change that improves performance
- test: Adding missing tests or correcting existing tests
- build: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
- ci: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
- chore: Other changes that don't modify src or test files
- revert: Reverts a previous commit

Reference: https://www.conventionalcommits.org/en/v1.0.0/
-->
