### PR TITLE
refactor(component): extract bounded parallel-map helper

### DIFF
--- a/.github/instructions/concurrency.instructions.md
+++ b/.github/instructions/concurrency.instructions.md
@@ -16,9 +16,49 @@ Use `env.IOBoundConcurrency()` or `env.CPUBoundConcurrency()` from `azldev.Env` 
 
 **Never launch unbounded goroutines.** With 7k+ components, unbounded parallelism will overwhelm the system (loadavg 500+).
 
-## Semaphore Pattern
+## Preferred: `parmap.Map` for slice-parallel work
 
-Use a buffered channel as a semaphore to limit concurrency:
+For the common case — "run a worker over every item in a slice with bounded concurrency" — use [`internal/utils/parmap`](../../internal/utils/parmap/parmap.go) instead of hand-rolling a worker pool. It wraps `golang.org/x/sync/errgroup`, adds per-item results, surfaces "cancelled before start" via `Result.Cancelled`, and serializes the optional progress callback so callers don't need their own mutex.
+
+```go
+workerEnv, cancel := env.WithCancel()
+defer cancel()
+
+progressEvent := env.StartEvent("Doing the thing", "count", len(items))
+defer progressEvent.End()
+
+total := int64(len(items))
+
+results := parmap.Map(
+    workerEnv,                          // workerEnv satisfies context.Context
+    env.IOBoundConcurrency(),
+    items,
+    func(done, _ int) { progressEvent.SetProgress(int64(done), total) },
+    func(ctx context.Context, item Item) Result {
+        // workerEnv (captured) supplies FS, locks, etc.; ctx is the same
+        // cancellation signal, useful for ctx-aware APIs like exec.CommandContext.
+        return doWork(workerEnv, item)
+    },
+)
+
+for idx, r := range results {
+    if r.Cancelled {
+        // worker never ran (ctx ended before parmap reached this item)
+        continue
+    }
+    // consume r.Value
+}
+```
+
+When to skip `parmap.Map` and use the manual pattern below:
+
+- Streaming results before all items finish (e.g. `render.go`'s historical `resultsChan` pattern — though current render code uses parmap).
+- Push-based / event-driven work that isn't a fixed input slice.
+- Cases where the worker really does need an unbuffered, hand-tuned channel topology.
+
+## Manual semaphore pattern
+
+When `parmap.Map` doesn't fit, use a buffered channel as a semaphore to limit concurrency:
 
 ```go
 semaphore := make(chan struct{}, env.IOBoundConcurrency())
@@ -40,10 +80,11 @@ go func() {
 Always support graceful cancellation via `env.WithCancel()`:
 
 1. Create a cancellable child env: `workerEnv, cancel := env.WithCancel(); defer cancel()`
-2. Use context-aware semaphore acquisition (select on semaphore and `workerEnv.Done()`)
-3. Pass `workerEnv` (not `env`) to worker goroutines so they respect cancellation
+2. Pass `workerEnv` (not `env`) to worker goroutines so they respect cancellation
+3. With `parmap.Map`, just pass `workerEnv` as the ctx — cancellation handling is built in
+4. With the manual pattern, use context-aware semaphore acquisition (select on semaphore and `workerEnv.Done()`)
 
-Example from `render.go` and `update.go`:
+Example of the manual pattern:
 
 ```go
 workerEnv, cancel := env.WithCancel()
@@ -78,4 +119,4 @@ The `Env` type provides a set of methods to determine appropriate concurrency li
 
 ## Thread Safety
 
-- Events are currently not thread-safe; control long-running event handling outside of worker goroutines.
+- Events are currently not thread-safe; control long-running event handling outside of worker goroutines. `parmap.Map`'s `onProgress` callback is invoked serialized under an internal mutex, so calling `progressEvent.SetProgress` from there is safe.

--- a/go.mod
+++ b/go.mod
@@ -54,6 +54,7 @@ require (
 	github.com/ulikunitz/xz v0.5.15
 	go.szostok.io/version v1.2.0
 	go.uber.org/mock v0.6.0
+	golang.org/x/sync v0.20.0
 	golang.org/x/sys v0.43.0
 	gopkg.in/yaml.v3 v3.0.1
 )

--- a/go.sum
+++ b/go.sum
@@ -381,6 +381,8 @@ golang.org/x/exp v0.0.0-20260410095643-746e56fc9e2f/go.mod h1:J1xhfL/vlindoeF/aI
 golang.org/x/net v0.0.0-20211112202133-69e39bad7dc2/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
 golang.org/x/net v0.53.0 h1:d+qAbo5L0orcWAr0a9JweQpjXF19LMXJE8Ey7hwOdUA=
 golang.org/x/net v0.53.0/go.mod h1:JvMuJH7rrdiCfbeHoo3fCQU24Lf5JJwT9W3sJFulfgs=
+golang.org/x/sync v0.20.0 h1:e0PTpb7pjO8GAtTs2dQ6jYa5BWYlMuX047Dco/pItO4=
+golang.org/x/sync v0.20.0/go.mod h1:9xrNwdLfx4jkKbNva9FpL6vEN7evnE43NNNJQ2LF3+0=
 golang.org/x/sys v0.0.0-20190916202348-b4ddaad3f8a3/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20191026070338-33540a1f6037/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20201119102817-f84b799fce68/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=

--- a/internal/app/azldev/cmds/component/update.go
+++ b/internal/app/azldev/cmds/component/update.go
@@ -10,7 +10,6 @@ import (
 	"log/slog"
 	"path/filepath"
 	"strings"
-	"sync"
 
 	"github.com/microsoft/azure-linux-dev-tools/internal/app/azldev"
 	"github.com/microsoft/azure-linux-dev-tools/internal/app/azldev/core/components"
@@ -18,6 +17,7 @@ import (
 	"github.com/microsoft/azure-linux-dev-tools/internal/lockfile"
 	"github.com/microsoft/azure-linux-dev-tools/internal/projectconfig"
 	"github.com/microsoft/azure-linux-dev-tools/internal/providers/sourceproviders"
+	"github.com/microsoft/azure-linux-dev-tools/internal/utils/parmap"
 	"github.com/spf13/cobra"
 )
 
@@ -683,32 +683,78 @@ func resolveSourceIdentitiesParallel(
 	workerEnv, cancel := env.WithCancel()
 	defer cancel()
 
-	// Channel signals goroutine completions so the main goroutine
-	// can update progress as results arrive.
-	doneChan := make(chan struct{}, len(comps))
+	total := int64(len(comps))
 
-	var waitGroup sync.WaitGroup
+	// Pre-filter: cases 1 and 2 fill results synchronously (no upstream
+	// contact needed); case 3 needs parallel resolution.
+	parallel, syncCompleted := classifyForResolution(comps, results)
+
+	// Surface sync-skip progress immediately so users see movement even when
+	// the parallel batch is empty or slow to start.
+	if syncCompleted > 0 {
+		progressEvent.SetProgress(syncCompleted, total)
+	}
 
 	// Each resolution may involve network I/O (upstream git clone) or
 	// filesystem traversal (local spec-dir hashing), so we parallelize.
-	semaphore := make(chan struct{}, env.FastConcurrency())
+	parmapResults := parmap.Map(
+		workerEnv,
+		env.FastConcurrency(),
+		parallel,
+		func(done, _ int) {
+			progressEvent.SetProgress(syncCompleted+int64(done), total)
+		},
+		func(ctx context.Context, item parallelItem) struct{} {
+			resolveAndRecordIdentity(ctx, workerEnv, cancel, item.comp, store, &results[item.idx])
+
+			return struct{}{}
+		},
+	)
+
+	// Items that never acquired a worker slot (ctx cancelled mid-flight) get
+	// marked Skipped — matches the legacy semaphore-select behaviour.
+	for i, pr := range parmapResults {
+		if pr.Cancelled {
+			idx := parallel[i].idx
+			results[idx].Skipped = true
+			results[idx].SkipReason = "cancelled"
+		}
+	}
+
+	return results
+}
+
+// parallelItem pairs a component with its result index for parmap workers.
+type parallelItem struct {
+	idx  int
+	comp components.Component
+}
+
+// classifyForResolution applies the three-way freshness check to each
+// component. Cases 1 and 2 (fully fresh / build-input-only changes) are
+// resolved synchronously by mutating results in place. Case 3 components are
+// returned in the parallel slice for upstream resolution. syncCompleted is
+// the count of cases 1+2, used to seed the progress event.
+//
+// Only upstream components qualify for the freshness shortcut — local
+// components resolve via filesystem hashing (cheap, no network), so skipping
+// gains little and their empty UpstreamCommit can't serve as source identity.
+//
+//  1. FreshnessCurrent → nothing changed, skip entirely (no re-resolution).
+//  2. FreshnessStale + resolution fresh → only build inputs changed
+//     (e.g., overlay edit). Reuse locked commit, but enter save path
+//     to update the fingerprint.
+//  3. FreshnessStale + resolution stale → resolution inputs changed
+//     (e.g., snapshot bump). Must re-resolve upstream.
+func classifyForResolution(
+	comps []components.Component, results []UpdateResult,
+) (parallel []parallelItem, syncCompleted int64) {
+	parallel = make([]parallelItem, 0, len(comps))
 
 	for idx, comp := range comps {
 		results[idx].Component = comp.GetName()
 
 		locked := comp.GetConfig().Locked
-
-		// Three-way freshness check (when lock data is available).
-		// Only applies to upstream components — local components resolve via
-		// filesystem hashing (cheap, no network), so skipping gains little
-		// and their empty UpstreamCommit can't serve as source identity.
-		//
-		// 1. FreshnessCurrent → nothing changed, skip entirely (no re-resolution).
-		// 2. FreshnessStale + resolution fresh → only build inputs changed
-		//    (e.g., overlay edit). Reuse locked commit, but enter save path
-		//    to update the fingerprint.
-		// 3. FreshnessStale + resolution stale → resolution inputs changed
-		//    (e.g., snapshot bump). Must re-resolve upstream.
 		isUpstream := comp.GetConfig().Spec.SourceType == projectconfig.SpecSourceTypeUpstream
 
 		if isUpstream && locked != nil && locked.Freshness == projectconfig.FreshnessCurrent {
@@ -716,6 +762,7 @@ func resolveSourceIdentitiesParallel(
 			results[idx].UpstreamCommit = locked.UpstreamCommit
 			results[idx].sourceIdentity = comp.GetConfig().EffectiveUpstreamCommit()
 			results[idx].upToDate = true
+			syncCompleted++
 
 			continue
 		}
@@ -728,64 +775,35 @@ func resolveSourceIdentitiesParallel(
 			results[idx].PreviousCommit = locked.UpstreamCommit
 			results[idx].sourceIdentity = comp.GetConfig().EffectiveUpstreamCommit()
 			results[idx].config = comp.GetConfig()
+			syncCompleted++
 
 			continue
 		}
 
 		// Case 3: resolution stale, unknown, or no lock — must re-resolve.
-		waitGroup.Add(1)
-
-		go func() {
-			defer waitGroup.Done()
-			defer func() { doneChan <- struct{}{} }()
-
-			resolveAndRecordIdentity(workerEnv, semaphore, cancel, comp, store, &results[idx])
-		}()
+		parallel = append(parallel, parallelItem{idx: idx, comp: comp})
 	}
 
-	// Close doneChan once all goroutines finish.
-	go func() { waitGroup.Wait(); close(doneChan) }()
-
-	total := int64(len(comps))
-
-	var completed int64
-
-	for range doneChan {
-		completed++
-		progressEvent.SetProgress(completed, total)
-	}
-
-	return results
+	return parallel, syncCompleted
 }
 
 // resolveAndRecordIdentity resolves a single component's source identity and
-// records the result. Called from a goroutine in [resolveSourceIdentitiesParallel].
+// records the result. Called from a parmap worker in [resolveSourceIdentitiesParallel].
 func resolveAndRecordIdentity(
+	ctx context.Context,
 	env *azldev.Env,
-	semaphore chan struct{},
 	cancel context.CancelFunc,
 	comp components.Component,
 	store *lockfile.Store,
 	result *UpdateResult,
 ) {
-	// Context-aware semaphore acquisition.
-	select {
-	case semaphore <- struct{}{}:
-		defer func() { <-semaphore }()
-	case <-env.Done():
-		result.Skipped = true
-		result.SkipReason = "cancelled"
-
-		return
-	}
-
 	// Drop populated lock data so the source provider re-resolves
 	// from upstream (snapshot/HEAD or pinned commit) or re-hashes
 	// local spec content instead of short-circuiting with stale
 	// locked values. We're about to overwrite the lock anyway.
 	comp.GetConfig().Locked = nil
 
-	identity, resolveErr := resolveOneSourceIdentity(env, comp)
+	identity, resolveErr := resolveOneSourceIdentity(ctx, env, comp)
 	if resolveErr != nil {
 		result.Error = resolveErr.Error()
 
@@ -841,6 +859,7 @@ func checkLockChanged(store *lockfile.Store, componentName string, result *Updat
 }
 
 func resolveOneSourceIdentity(
+	ctx context.Context,
 	env *azldev.Env,
 	comp components.Component,
 ) (string, error) {
@@ -856,7 +875,7 @@ func resolveOneSourceIdentity(
 		return "", fmt.Errorf("creating source manager for %#q:\n%w", componentName, err)
 	}
 
-	identity, err := sourceManager.ResolveSourceIdentity(env.Context(), comp)
+	identity, err := sourceManager.ResolveSourceIdentity(ctx, comp)
 	if err != nil {
 		return "", fmt.Errorf("resolving identity for %#q:\n%w", componentName, err)
 	}

--- a/internal/utils/parmap/parmap.go
+++ b/internal/utils/parmap/parmap.go
@@ -1,0 +1,132 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+// Package parmap provides a bounded parallel map over a slice of inputs.
+//
+// It is a thin wrapper around [golang.org/x/sync/errgroup] that adds two
+// things our callers want and errgroup doesn't:
+//
+//  1. Per-item results: callers get a slice of [Result] in input order. The
+//     worker function encodes per-item errors inside its returned value
+//     (e.g., as a status field). errgroup's first-error aggregation isn't
+//     a good fit when every item must report its own outcome (render
+//     status, update result, etc.).
+//  2. A "didn't start" signal: items that were never invoked because ctx
+//     was already done are flagged via [Result.Cancelled], so callers can
+//     distinguish "cancelled before start" from "started but bailed out
+//     inside worker".
+//
+// Concurrency is bounded via [errgroup.Group.SetLimit] — the worker
+// goroutine for each item only launches when a slot is free, so peak
+// goroutine count stays ≤ limit even with millions of items.
+package parmap
+
+import (
+	"context"
+	"sync/atomic"
+
+	"golang.org/x/sync/errgroup"
+)
+
+// Result wraps the output of a single [Map] invocation for one input item.
+//
+// Cancelled is true when ctx was done before the worker function was
+// invoked, so Value is the zero value of Out. Workers that did run and
+// observed cancellation inside their body are responsible for surfacing
+// that in their returned Value (so callers can distinguish "didn't start"
+// from "started but bailed out").
+type Result[T any] struct {
+	Value     T
+	Cancelled bool
+}
+
+// Map runs worker for each item in items with at most limit concurrent
+// goroutines, respecting ctx cancellation. Results are returned in input order.
+//
+// Behaviour:
+//   - Returns nil for an empty items slice.
+//   - limit < 1 is treated as 1.
+//   - onProgress, when non-nil, is invoked after each item completes
+//     (success or cancelled). Callers must ensure onProgress is safe to
+//     call concurrently; it is given (completed, total).
+//   - Items that never start because ctx is done set Result.Cancelled = true
+//     and never call worker. Items that did start always call worker with
+//     ctx; it is the worker function's job to react to ctx cancellation
+//     (e.g., by returning early).
+//   - Internally uses [errgroup.Group.SetLimit]: worker goroutines are
+//     launched lazily, so peak goroutine count is bounded by limit
+//     regardless of items length.
+func Map[In, Out any](
+	ctx context.Context,
+	limit int,
+	items []In,
+	onProgress func(completed, total int),
+	worker func(context.Context, In) Out,
+) []Result[Out] {
+	if len(items) == 0 {
+		return nil
+	}
+
+	if limit < 1 {
+		limit = 1
+	}
+
+	results := make([]Result[Out], len(items))
+	total := len(items)
+
+	var completed atomic.Int64
+
+	notifyProgress := func() {
+		if onProgress == nil {
+			return
+		}
+
+		done := int(completed.Add(1))
+		onProgress(done, total)
+	}
+
+	group, groupCtx := errgroup.WithContext(ctx)
+	group.SetLimit(limit)
+
+	for idx, item := range items {
+		// If ctx is already done, don't bother launching — mark every
+		// remaining item as Cancelled. group.Go would block waiting for a
+		// slot, but [errgroup.Group.SetLimit] does not consult ctx, so we
+		// must short-circuit here ourselves.
+		if groupCtx.Err() != nil {
+			for j := idx; j < len(items); j++ {
+				results[j].Cancelled = true
+
+				notifyProgress()
+			}
+
+			break
+		}
+
+		group.Go(func() error {
+			defer notifyProgress()
+
+			// Slot acquired but ctx ended between SetLimit's release and
+			// our entry — surface as Cancelled rather than invoking worker
+			// against a dead ctx. Returning nil (not ctx.Err()) is
+			// intentional: cancellation status lives in Result.Cancelled,
+			// not in errgroup's aggregated error.
+			if groupCtx.Err() != nil {
+				results[idx].Cancelled = true
+
+				return nil
+			}
+
+			results[idx].Value = worker(groupCtx, item)
+
+			return nil
+		})
+	}
+
+	// Wait returns the first non-nil error from a worker; our workers never
+	// return errors (per-item outcomes live in Result.Value), so the return
+	// is always nil. Wait also ensures all launched goroutines finish.
+	_ = group.Wait()
+
+	return results
+}

--- a/internal/utils/parmap/parmap.go
+++ b/internal/utils/parmap/parmap.go
@@ -59,6 +59,9 @@ type Result[T any] struct {
 //   - Internally uses [errgroup.Group.SetLimit]: worker goroutines are
 //     launched lazily, so peak goroutine count is bounded by limit
 //     regardless of items length.
+//   - Panics inside worker are NOT recovered — they propagate through
+//     errgroup and crash the program. This matches [errgroup.Group.Go]'s
+//     contract; recover inside worker if you need different behaviour.
 func Map[In, Out any](
 	ctx context.Context,
 	limit int,
@@ -102,10 +105,13 @@ func Map[In, Out any](
 	group.SetLimit(limit)
 
 	for idx, item := range items {
-		// If ctx is already done, don't bother launching — mark every
-		// remaining item as Cancelled. group.Go would block waiting for a
-		// slot, but [errgroup.Group.SetLimit] does not consult ctx, so we
-		// must short-circuit here ourselves.
+		// If ctx is already done, short-circuit the rest of the launch loop
+		// and mark remaining items as Cancelled. Without this, group.Go
+		// would still try to acquire a slot — [errgroup.Group.SetLimit]
+		// blocks on a free slot without consulting ctx, so a cancelled run
+		// with a saturated pool could still queue more workers behind the
+		// currently-running ones. The in-worker groupCtx.Err() check then
+		// catches whatever did slip through.
 		if groupCtx.Err() != nil {
 			for j := idx; j < len(items); j++ {
 				results[j].Cancelled = true

--- a/internal/utils/parmap/parmap.go
+++ b/internal/utils/parmap/parmap.go
@@ -23,7 +23,7 @@ package parmap
 
 import (
 	"context"
-	"sync/atomic"
+	"sync"
 
 	"golang.org/x/sync/errgroup"
 )
@@ -46,9 +46,12 @@ type Result[T any] struct {
 // Behaviour:
 //   - Returns nil for an empty items slice.
 //   - limit < 1 is treated as 1.
-//   - onProgress, when non-nil, is invoked after each item completes
-//     (success or cancelled). Callers must ensure onProgress is safe to
-//     call concurrently; it is given (completed, total).
+//   - onProgress, when non-nil, is invoked once per completed item (success
+//     or cancelled). Invocations are serialized under an internal mutex and
+//     observe a monotonically increasing 'completed' value, so callers do
+//     not need to add their own synchronization. The callback is invoked
+//     synchronously from worker goroutines: keep it fast, since a slow
+//     callback backpressures the entire worker pool.
 //   - Items that never start because ctx is done set Result.Cancelled = true
 //     and never call worker. Items that did start always call worker with
 //     ctx; it is the worker function's job to react to ctx cancellation
@@ -74,15 +77,25 @@ func Map[In, Out any](
 	results := make([]Result[Out], len(items))
 	total := len(items)
 
-	var completed atomic.Int64
+	// progressMu serializes the (increment, callback) pair so onProgress
+	// always observes a monotonically increasing 'completed' value. Holding
+	// the mutex across the callback also lets callers assume the callback
+	// will never be invoked concurrently with itself.
+	var (
+		progressMu sync.Mutex
+		completed  int
+	)
 
 	notifyProgress := func() {
 		if onProgress == nil {
 			return
 		}
 
-		done := int(completed.Add(1))
-		onProgress(done, total)
+		progressMu.Lock()
+		defer progressMu.Unlock()
+
+		completed++
+		onProgress(completed, total)
 	}
 
 	group, groupCtx := errgroup.WithContext(ctx)

--- a/internal/utils/parmap/parmap_test.go
+++ b/internal/utils/parmap/parmap_test.go
@@ -185,6 +185,74 @@ func TestMap_ProgressCallback(t *testing.T) {
 	}
 }
 
+func TestMap_ProgressIsMonotonicAndSerialized(t *testing.T) {
+	t.Parallel()
+
+	const (
+		items = 200
+		limit = 16
+	)
+
+	inputs := make([]int, items)
+	for i := range inputs {
+		inputs[i] = i
+	}
+
+	var (
+		// Track concurrent entries into the callback. Map serializes
+		// onProgress under an internal mutex, so this must never exceed 1.
+		inCallback    atomic.Int64
+		maxInCallback atomic.Int64
+		// observed[k] is the k-th completed value passed to the callback;
+		// reading them back in append order verifies monotonicity.
+		mutex    sync.Mutex
+		observed []int
+	)
+
+	parmap.Map(
+		t.Context(),
+		limit,
+		inputs,
+		func(completed, _ int) {
+			cur := inCallback.Add(1)
+			defer inCallback.Add(-1)
+
+			for {
+				prev := maxInCallback.Load()
+				if cur <= prev || maxInCallback.CompareAndSwap(prev, cur) {
+					break
+				}
+			}
+
+			mutex.Lock()
+
+			observed = append(observed, completed)
+
+			mutex.Unlock()
+		},
+		func(_ context.Context, n int) int { return n },
+	)
+
+	if peak := maxInCallback.Load(); peak > 1 {
+		t.Fatalf("onProgress saw %d concurrent invocations; expected serialized", peak)
+	}
+
+	mutex.Lock()
+	defer mutex.Unlock()
+
+	if len(observed) != items {
+		t.Fatalf("expected %d progress callbacks, got %d", items, len(observed))
+	}
+
+	for i, val := range observed {
+		if val != i+1 {
+			t.Fatalf(
+				"progress callback %d saw completed=%d, want %d (non-monotonic): %v",
+				i, val, i+1, observed)
+		}
+	}
+}
+
 func TestMap_NilProgressIsSafe(t *testing.T) {
 	t.Parallel()
 

--- a/internal/utils/parmap/parmap_test.go
+++ b/internal/utils/parmap/parmap_test.go
@@ -293,18 +293,21 @@ func TestMap_CancelledBeforeStart(t *testing.T) {
 		t.Fatalf("expected 5 results, got %d", len(got))
 	}
 
-	// With an already-cancelled context, the select on semaphore acquisition
-	// may pick either branch (semaphore has spare slots, ctx is done). The
-	// strict invariants are:
-	//   - every result that ran has Cancelled=false and a valid Value.
-	//   - every result that didn't run has Cancelled=true and zero Value.
+	// With an already-cancelled context, errgroup.WithContext(ctx)'s
+	// derived context is also already done. The launch loop's pre-Go
+	// check fires on iteration 0 and short-circuits every item to
+	// Cancelled=true; worker is never invoked for any item.
+	if n := ran.Load(); n != 0 {
+		t.Errorf("worker ran %d times despite pre-cancelled ctx; expected 0", n)
+	}
+
 	for idx, result := range got {
-		if result.Cancelled && result.Value != 0 {
-			t.Errorf("item %d: cancelled but Value=%d (want zero)", idx, result.Value)
+		if !result.Cancelled {
+			t.Errorf("item %d: expected Cancelled=true, got false (Value=%d)", idx, result.Value)
 		}
 
-		if !result.Cancelled && result.Value != idx+1 {
-			t.Errorf("item %d: ran but Value=%d (want %d)", idx, result.Value, idx+1)
+		if result.Value != 0 {
+			t.Errorf("item %d: expected zero Value, got %d", idx, result.Value)
 		}
 	}
 }
@@ -323,8 +326,9 @@ func TestMap_CancelMidFlight(t *testing.T) {
 	}
 
 	// Cancel as soon as the first worker enters fn. With a small limit (2),
-	// only a handful of workers will ever acquire a slot; the rest must
-	// observe ctx.Done() at the semaphore select and surface Cancelled=true.
+	// only a handful of workers will ever acquire a slot; the rest hit the
+	// launch loop's pre-Go ctx check (or the in-worker check, racing) and
+	// surface Cancelled=true.
 	var firstOnce sync.Once
 
 	got := parmap.Map(

--- a/internal/utils/parmap/parmap_test.go
+++ b/internal/utils/parmap/parmap_test.go
@@ -1,0 +1,329 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+package parmap_test
+
+import (
+	"context"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/microsoft/azure-linux-dev-tools/internal/utils/parmap"
+)
+
+func TestMap_EmptyReturnsNil(t *testing.T) {
+	t.Parallel()
+
+	got := parmap.Map(
+		t.Context(),
+		4,
+		[]int(nil),
+		nil,
+		func(_ context.Context, n int) int { return n },
+	)
+	if got != nil {
+		t.Fatalf("expected nil result for empty input, got %v", got)
+	}
+}
+
+func TestMap_PreservesOrder(t *testing.T) {
+	t.Parallel()
+
+	items := []int{1, 2, 3, 4, 5, 6, 7, 8, 9, 10}
+	got := parmap.Map(
+		t.Context(),
+		3,
+		items,
+		nil,
+		func(_ context.Context, n int) int { return n * 2 },
+	)
+
+	if len(got) != len(items) {
+		t.Fatalf("expected %d results, got %d", len(items), len(got))
+	}
+
+	for idx, item := range items {
+		if got[idx].Cancelled {
+			t.Errorf("item %d unexpectedly cancelled", idx)
+		}
+
+		if got[idx].Value != item*2 {
+			t.Errorf("item %d: expected %d, got %d", idx, item*2, got[idx].Value)
+		}
+	}
+}
+
+func TestMap_LimitTreatedAsAtLeastOne(t *testing.T) {
+	t.Parallel()
+
+	// limit=0 must still process all items (treated as 1).
+	got := parmap.Map(
+		t.Context(),
+		0,
+		[]int{1, 2, 3},
+		nil,
+		func(_ context.Context, n int) int { return n },
+	)
+
+	if len(got) != 3 {
+		t.Fatalf("expected 3 results, got %d", len(got))
+	}
+
+	for idx, result := range got {
+		if result.Cancelled || result.Value != idx+1 {
+			t.Errorf("item %d: cancelled=%v value=%d", idx, result.Cancelled, result.Value)
+		}
+	}
+}
+
+func TestMap_RespectsLimit(t *testing.T) {
+	t.Parallel()
+
+	const (
+		items = 50
+		limit = 4
+	)
+
+	var (
+		inFlight    atomic.Int64
+		maxInFlight atomic.Int64
+	)
+
+	inputs := make([]int, items)
+	for i := range inputs {
+		inputs[i] = i
+	}
+
+	parmap.Map(
+		t.Context(),
+		limit,
+		inputs,
+		nil,
+		func(_ context.Context, _ int) int {
+			cur := inFlight.Add(1)
+			defer inFlight.Add(-1)
+
+			for {
+				prev := maxInFlight.Load()
+				if cur <= prev || maxInFlight.CompareAndSwap(prev, cur) {
+					break
+				}
+			}
+
+			// Brief work to make concurrency observable.
+			time.Sleep(time.Millisecond)
+
+			return 0
+		},
+	)
+
+	peak := maxInFlight.Load()
+	if peak > int64(limit) {
+		t.Fatalf("observed %d concurrent workers, limit was %d", peak, limit)
+	}
+
+	if peak == 0 {
+		t.Fatalf("no workers ran")
+	}
+}
+
+func TestMap_ProgressCallback(t *testing.T) {
+	t.Parallel()
+
+	items := []int{10, 20, 30, 40}
+
+	var (
+		mutex      sync.Mutex
+		progresses []int
+		totals     []int
+	)
+
+	got := parmap.Map(
+		t.Context(),
+		2,
+		items,
+		func(completed, total int) {
+			mutex.Lock()
+			defer mutex.Unlock()
+
+			progresses = append(progresses, completed)
+			totals = append(totals, total)
+		},
+		func(_ context.Context, n int) int { return n },
+	)
+
+	if len(got) != len(items) {
+		t.Fatalf("expected %d results, got %d", len(items), len(got))
+	}
+
+	mutex.Lock()
+	defer mutex.Unlock()
+
+	if len(progresses) != len(items) {
+		t.Fatalf("expected %d progress callbacks, got %d", len(items), len(progresses))
+	}
+
+	// Final callback must see completed==total.
+	seenFinal := false
+
+	for _, p := range progresses {
+		if p == len(items) {
+			seenFinal = true
+		}
+	}
+
+	if !seenFinal {
+		t.Errorf("no progress callback observed completed==total; got %v", progresses)
+	}
+
+	for _, total := range totals {
+		if total != len(items) {
+			t.Errorf("progress callback got total=%d, want %d", total, len(items))
+		}
+	}
+}
+
+func TestMap_NilProgressIsSafe(t *testing.T) {
+	t.Parallel()
+
+	got := parmap.Map(
+		t.Context(),
+		2,
+		[]int{1, 2, 3},
+		nil,
+		func(_ context.Context, n int) int { return n },
+	)
+
+	if len(got) != 3 {
+		t.Fatalf("expected 3 results, got %d", len(got))
+	}
+}
+
+func TestMap_CancelledBeforeStart(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithCancel(t.Context())
+	cancel() // already done before Map is called
+
+	var ran atomic.Int64
+
+	got := parmap.Map(
+		ctx,
+		2,
+		[]int{1, 2, 3, 4, 5},
+		nil,
+		func(_ context.Context, n int) int {
+			ran.Add(1)
+
+			return n
+		},
+	)
+
+	if len(got) != 5 {
+		t.Fatalf("expected 5 results, got %d", len(got))
+	}
+
+	// With an already-cancelled context, the select on semaphore acquisition
+	// may pick either branch (semaphore has spare slots, ctx is done). The
+	// strict invariants are:
+	//   - every result that ran has Cancelled=false and a valid Value.
+	//   - every result that didn't run has Cancelled=true and zero Value.
+	for idx, result := range got {
+		if result.Cancelled && result.Value != 0 {
+			t.Errorf("item %d: cancelled but Value=%d (want zero)", idx, result.Value)
+		}
+
+		if !result.Cancelled && result.Value != idx+1 {
+			t.Errorf("item %d: ran but Value=%d (want %d)", idx, result.Value, idx+1)
+		}
+	}
+}
+
+func TestMap_CancelMidFlight(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+
+	const items = 100
+
+	inputs := make([]int, items)
+	for i := range inputs {
+		inputs[i] = i
+	}
+
+	// Cancel as soon as the first worker enters fn. With a small limit (2),
+	// only a handful of workers will ever acquire a slot; the rest must
+	// observe ctx.Done() at the semaphore select and surface Cancelled=true.
+	var firstOnce sync.Once
+
+	got := parmap.Map(
+		ctx,
+		2,
+		inputs,
+		nil,
+		func(workerCtx context.Context, num int) int {
+			firstOnce.Do(cancel)
+
+			// Workers that did acquire a slot must return promptly once ctx
+			// is done; if any worker hangs here Map.Wait() will block.
+			<-workerCtx.Done()
+
+			return num
+		},
+	)
+
+	if len(got) != items {
+		t.Fatalf("expected %d results, got %d", items, len(got))
+	}
+
+	var cancelledCount int
+
+	for _, r := range got {
+		if r.Cancelled {
+			cancelledCount++
+		}
+	}
+
+	if cancelledCount == 0 {
+		t.Fatalf("expected some items to be cancelled before starting; got 0")
+	}
+}
+
+func TestMap_FnSeesCancelledContext(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithCancel(t.Context())
+
+	var (
+		fnObservedCancel atomic.Bool
+		fnReached        = make(chan struct{}, 1)
+	)
+
+	go func() {
+		<-fnReached
+		cancel()
+	}()
+
+	parmap.Map(
+		ctx,
+		1,
+		[]int{42},
+		nil,
+		func(workerCtx context.Context, _ int) int {
+			fnReached <- struct{}{}
+
+			<-workerCtx.Done()
+
+			fnObservedCancel.Store(true)
+
+			return 0
+		},
+	)
+
+	if !fnObservedCancel.Load() {
+		t.Fatal("fn did not observe ctx cancellation")
+	}
+}


### PR DESCRIPTION
Introduce `internal/utils/parmap`, a thin wrapper around `golang.org/x/sync/errgroup` that adds per-item results and a 'didn't start' signal (`Result.Cancelled`) — the two things errgroup itself doesn't provide.

Migrate `component update`'s parallel source-identity resolution onto the helper:

- Replaces the hand-rolled semaphore + waitgroup + doneChan with a single `parmap.Map` call.
- Extracts the freshness pre-filter (cases 1/2 sync, case 3 parallel) into `classifyForResolution` for readability.
- Threads `context.Context` from the worker through `resolveAndRecordIdentity` -> `resolveOneSourceIdentity` instead of reaching back through `env.Context()`.
- Progress now also counts the synchronously-skipped components, so the progress bar accurately reflects total completion instead of capping below 100% when cases 1/2 are non-empty.

Promotes `golang.org/x/sync` from indirect to direct dep.

<!--
PR Title must follow Conventional Commits format. Available types:

- feat: A new feature
- fix: A bug fix
- docs: Documentation only changes
- style: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
- refactor: A code change that neither fixes a bug nor adds a feature
- perf: A code change that improves performance
- test: Adding missing tests or correcting existing tests
- build: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
- ci: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
- chore: Other changes that don't modify src or test files
- revert: Reverts a previous commit

Reference: https://www.conventionalcommits.org/en/v1.0.0/
-->
