### PR TITLE
fix: handle -l flag in spec section header package name extraction

### DIFF
--- a/internal/rpm/spec/spec.go
+++ b/internal/rpm/spec/spec.go
@@ -560,6 +560,8 @@ func GetPackageNameFromSectionHeader(tokens []string) string {
 				index += 2
 			case "-p":
 				index += 2
+			case "-l":
+				index += 2
 			case "-q":
 				index++
 			default:

--- a/internal/rpm/spec/spec_test.go
+++ b/internal/rpm/spec/spec_test.go
@@ -22,4 +22,9 @@ func TestGetPackageNameFromSectionHeader(t *testing.T) {
 	assert.Equal(t,
 		"foo",
 		spec.GetPackageNameFromSectionHeader([]string{"%package", "-n", "foo"}))
+
+	// -l flag (localized descriptions) should be skipped, not treated as package name
+	assert.Equal(t, "foo", spec.GetPackageNameFromSectionHeader([]string{"%description", "-l", "fr", "foo"}))
+	assert.Empty(t, spec.GetPackageNameFromSectionHeader([]string{"%description", "-l", "fr"}))
+	assert.Equal(t, "foo", spec.GetPackageNameFromSectionHeader([]string{"%description", "-l", "de", "-n", "foo"}))
 }


### PR DESCRIPTION
[GetPackageNameFromSectionHeader] did not recognize the '-l' flag used in localized %description sections (e.g. '%description -l fr subpkg'). The language code was incorrectly parsed as the package name suffix, causing [RemoveSubpackage] to miss localized description sections when removing a subpackage.

Add '-l' to the flag switch with 'index += 2' to skip both the flag and the language code, matching the behavior of '-f' and '-p'.

Fixes #142 

<!--
PR Title must follow Conventional Commits format. Available types:

- feat: A new feature
- fix: A bug fix
- docs: Documentation only changes
- style: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
- refactor: A code change that neither fixes a bug nor adds a feature
- perf: A code change that improves performance
- test: Adding missing tests or correcting existing tests
- build: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
- ci: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
- chore: Other changes that don't modify src or test files
- revert: Reverts a previous commit

Reference: https://www.conventionalcommits.org/en/v1.0.0/
-->
