### PR TITLE
fix: handle -- trigger terminator and -P flag in spec section header parsing

### DIFF
--- a/internal/rpm/spec/spec.go
+++ b/internal/rpm/spec/spec.go
@@ -548,25 +548,24 @@ func GetPackageNameFromSectionHeader(tokens []string) string {
 		token := tokens[index]
 
 		switch {
-		case strings.HasPrefix(token, "-"):
-			switch token {
-			case "-n":
-				index++
-				if index < len(tokens) {
-					fullName = tokens[index]
-					index++
-				}
-			case "-f":
-				index += 2
-			case "-p":
-				index += 2
-			case "-l":
-				index += 2
-			case "-q":
-				index++
-			default:
+		case token == "--":
+			// Trigger terminator: in %trigger* sections, `--` separates the
+			// owning sub-package from the trigger condition. Everything after
+			// `--` is the trigger condition, not the package name.
+			index = len(tokens)
+		case token == "-n":
+			// Absolute package name form: the next token is the full package name.
+			index++
+			if index < len(tokens) {
+				fullName = tokens[index]
 				index++
 			}
+		case token == "-f", token == "-p", token == "-l", token == "-P":
+			// Flags that consume the next token as their argument.
+			index += 2
+		case strings.HasPrefix(token, "-"):
+			// Other flags (e.g. -q, -e, or unknown): skip the flag itself.
+			index++
 		case nameSuffix == "":
 			nameSuffix = token
 			index++

--- a/internal/rpm/spec/spec_test.go
+++ b/internal/rpm/spec/spec_test.go
@@ -27,4 +27,21 @@ func TestGetPackageNameFromSectionHeader(t *testing.T) {
 	assert.Equal(t, "foo", spec.GetPackageNameFromSectionHeader([]string{"%description", "-l", "fr", "foo"}))
 	assert.Empty(t, spec.GetPackageNameFromSectionHeader([]string{"%description", "-l", "fr"}))
 	assert.Equal(t, "foo", spec.GetPackageNameFromSectionHeader([]string{"%description", "-l", "de", "-n", "foo"}))
+
+	// -- trigger terminator: everything after -- is the trigger condition, not the package name
+	assert.Empty(t, spec.GetPackageNameFromSectionHeader([]string{"%triggerin", "--", "devel"}))
+	assert.Equal(t, "devel",
+		spec.GetPackageNameFromSectionHeader([]string{"%triggerin", "devel", "--", "foo"}))
+	assert.Equal(t, "test-devel",
+		spec.GetPackageNameFromSectionHeader([]string{"%triggerin", "-n", "test-devel", "--", "foo"}))
+	assert.Empty(t,
+		spec.GetPackageNameFromSectionHeader([]string{"%triggerin", "-p", "/bin/sh", "--", "foo"}))
+	assert.Equal(t, "devel",
+		spec.GetPackageNameFromSectionHeader([]string{"%triggerin", "devel", "-p", "/bin/sh", "--", "foo"}))
+
+	// -P flag (file trigger priority) should be skipped
+	assert.Empty(t,
+		spec.GetPackageNameFromSectionHeader([]string{"%filetriggerin", "-P", "100", "--", "/usr/lib"}))
+	assert.Equal(t, "devel",
+		spec.GetPackageNameFromSectionHeader([]string{"%filetriggerin", "devel", "-P", "100", "--", "/usr/lib"}))
 }


### PR DESCRIPTION
`GetPackageNameFromSectionHeader` did not recognize '--' as a terminator in trigger section headers. In RPM trigger syntax, '--' separates the owning sub-package from the trigger condition (e.g. '%triggerin -- devel' means the main package triggers on devel, not that the trigger belongs to subpackage devel).

Also add '-P' flag handling for file trigger priority arguments.

Fixes #143
