### PR TITLE
feat(projectconfig): validate component group membership

### DIFF
--- a/internal/projectconfig/component.go
+++ b/internal/projectconfig/component.go
@@ -4,6 +4,7 @@
 package projectconfig
 
 import (
+	"errors"
 	"fmt"
 	"slices"
 	"sort"
@@ -14,6 +15,10 @@ import (
 	"github.com/microsoft/azure-linux-dev-tools/internal/rpm"
 	"github.com/microsoft/azure-linux-dev-tools/internal/utils/fileutils"
 )
+
+// ErrUndefinedComponent is returned when a component group references a component name
+// that is not defined in the project's top-level components map.
+var ErrUndefinedComponent = errors.New("undefined component reference")
 
 const (
 	// HashTypeSHA256 represents the SHA-256 hash algorithm.

--- a/internal/projectconfig/component_test.go
+++ b/internal/projectconfig/component_test.go
@@ -934,3 +934,55 @@ func TestResolvePackagePublishChannel_FullScenario(t *testing.T) {
 
 	assert.Equal(t, "rpms-sdk-srpm", pythonResolved.Publish.SRPMChannel)
 }
+
+func TestValidateComponentGroupMembership(t *testing.T) {
+	t.Run("group member references undefined component", func(t *testing.T) {
+		cfg := projectconfig.NewProjectConfig()
+		cfg.ComponentGroups["my-group"] = projectconfig.ComponentGroupConfig{
+			Components: []string{"missing-component"},
+		}
+
+		err := cfg.Validate()
+		require.Error(t, err)
+		require.ErrorIs(t, err, projectconfig.ErrUndefinedComponent)
+		assert.Contains(t, err.Error(), "my-group")
+		assert.Contains(t, err.Error(), "missing-component")
+	})
+
+	t.Run("group member references defined component is valid", func(t *testing.T) {
+		cfg := projectconfig.NewProjectConfig()
+		cfg.Components["real-component"] = projectconfig.ComponentConfig{Name: "real-component"}
+		cfg.ComponentGroups["my-group"] = projectconfig.ComponentGroupConfig{
+			Components: []string{"real-component"},
+		}
+
+		assert.NoError(t, cfg.Validate())
+	})
+
+	t.Run("group with only spec patterns is valid", func(t *testing.T) {
+		cfg := projectconfig.NewProjectConfig()
+		cfg.ComponentGroups["my-group"] = projectconfig.ComponentGroupConfig{
+			SpecPathPatterns: []string{"SPECS/**/*.spec"},
+		}
+
+		assert.NoError(t, cfg.Validate())
+	})
+
+	t.Run("reports all undefined references together", func(t *testing.T) {
+		cfg := projectconfig.NewProjectConfig()
+		cfg.Components["real-component"] = projectconfig.ComponentConfig{Name: "real-component"}
+		cfg.ComponentGroups["group-a"] = projectconfig.ComponentGroupConfig{
+			Components: []string{"missing-1", "real-component", "missing-2"},
+		}
+		cfg.ComponentGroups["group-b"] = projectconfig.ComponentGroupConfig{
+			Components: []string{"missing-3"},
+		}
+
+		err := cfg.Validate()
+		require.Error(t, err)
+		require.ErrorIs(t, err, projectconfig.ErrUndefinedComponent)
+		assert.Contains(t, err.Error(), "missing-1")
+		assert.Contains(t, err.Error(), "missing-2")
+		assert.Contains(t, err.Error(), "missing-3")
+	})
+}

--- a/internal/projectconfig/loader_test.go
+++ b/internal/projectconfig/loader_test.go
@@ -430,6 +430,9 @@ func TestLoadAndResolveProjectConfig_DuplicateComponentsAcrossFiles(t *testing.T
 
 func TestLoadAndResolveProjectConfig_ComponentGroupWithMembers(t *testing.T) {
 	const configContents = `
+[components.foo]
+[components.bar]
+
 [component-groups.core]
 components = ["foo", "bar"]
 description = "Core components"
@@ -467,6 +470,10 @@ func TestLoadAndResolveProjectConfig_GroupsByComponent_MultipleGroups(t *testing
 		{testConfigPath, `
 includes = ["extra.toml"]
 
+[components.shared]
+[components.only-alpha]
+[components.only-beta]
+
 [component-groups.alpha]
 components = ["shared", "only-alpha"]
 `},
@@ -497,6 +504,8 @@ components = ["shared", "only-beta"]
 
 func TestLoadAndResolveProjectConfig_ComponentGroupWithDefaultConfig(t *testing.T) {
 	const configContents = `
+[components.foo]
+
 [component-groups.core]
 components = ["foo"]
 

--- a/internal/projectconfig/project.go
+++ b/internal/projectconfig/project.go
@@ -4,7 +4,9 @@
 package projectconfig
 
 import (
+	"errors"
 	"fmt"
+	"sort"
 
 	"dario.cat/mergo"
 	"github.com/brunoga/deep"
@@ -69,6 +71,10 @@ func (cfg *ProjectConfig) Validate() error {
 		return fmt.Errorf("config error:\n%w", err)
 	}
 
+	if err := validateComponentGroupMembership(cfg.ComponentGroups, cfg.Components); err != nil {
+		return err
+	}
+
 	if err := validatePackageGroupMembership(cfg.PackageGroups); err != nil {
 		return err
 	}
@@ -78,6 +84,37 @@ func (cfg *ProjectConfig) Validate() error {
 	}
 
 	return nil
+}
+
+// validateComponentGroupMembership checks that every component name listed in a component
+// group's explicit [ComponentGroupConfig.Components] member refers to a component defined
+// in the project's top-level components map. All offending references are reported together.
+func validateComponentGroupMembership(
+	groups map[string]ComponentGroupConfig, components map[string]ComponentConfig,
+) error {
+	// Iterate in sorted order for deterministic error reporting.
+	groupNames := make([]string, 0, len(groups))
+	for name := range groups {
+		groupNames = append(groupNames, name)
+	}
+
+	sort.Strings(groupNames)
+
+	var errs []error
+
+	for _, groupName := range groupNames {
+		group := groups[groupName]
+		for _, member := range group.Components {
+			if _, ok := components[member]; !ok {
+				errs = append(errs, fmt.Errorf(
+					"%w: component group %#q references component %#q, which is not defined in [components]",
+					ErrUndefinedComponent, groupName, member,
+				))
+			}
+		}
+	}
+
+	return errors.Join(errs...)
 }
 
 // validatePackageGroupMembership checks that no binary package name appears in more than one


### PR DESCRIPTION
Fails project config loading if any component group's explicit `components` list references a name not defined under `[components]`.

All undefined references are collected and reported together via `errors.Join`, so a single run surfaces every issue instead of forcing a fix-run-repeat loop.

Slots in alongside the existing `validatePackageGroupMembership` and `validateImageTestReferences` checks in `ProjectConfig.Validate()`. New sentinel `ErrUndefinedComponent` follows the `ErrUndefinedTestSuite` pattern.

Tests cover: undefined member, defined member, spec-pattern-only group, and the aggregate-reporting case.