### PR TITLE
test(e2e): add end-to-end scenario tests against real upstream repos

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -16,6 +16,7 @@ The `azldev-mage-builder` MCP server can run build commands without requesting p
 - `mage fix all` (NOT `golangci-lint run --fix`) - Auto-fixes formatting and simple linting issues
 - `mage check all` (NOT `golangci-lint run`) - Runs all quality checks
 - `mage scenario`  (NOT manual test commands) - Runs end-to-end tests (SLOW)
+- `mage e2e` - Runs the heavier `//go:build e2e` tests against real upstream repos (NOT run by `mage scenario`/`mage all`; intended for CI only)
 
 - `run-azldev-from-out-bin` MCP server **IF** available (NOT `go run ./cmd/azldev` or `./azldev`)
 

--- a/.github/instructions/testing.instructions.md
+++ b/.github/instructions/testing.instructions.md
@@ -15,6 +15,7 @@ if it uses memfs and mocks.
 |------|-------------|-----------|---------|
 | Unit | `mage unit` | (none) | Fast, isolated, in-memory |
 | Scenario | `mage scenario` | `//go:build scenario` | End-to-end CLI with snapshot validation |
+| E2E | `mage e2e` | `//go:build e2e` | Heavy end-to-end tests against real upstream repos (network + large clones); not run by `mage scenario` / `mage all` |
 
 ### Sub-Tiers Within `mage unit`
 
@@ -36,6 +37,16 @@ Live in `scenario/` with `//go:build scenario` tag. Two execution modes:
 - `InContainer()` — slow, full Docker isolation. For integration tests needing fs state.
 
 Use `mage scenarioUpdate` to update snapshots (review diffs — don't blindly accept).
+
+### E2E Tests
+
+Live in `scenario/` with `//go:build e2e` tag (the shared `setup_test.go` is
+widened to `//go:build scenario || e2e` so [TestMain] applies to both tiers).
+Run via `mage e2e` — they are intentionally excluded from `mage scenario`,
+`mage scenarioUpdate`, and `mage all` because they clone large upstream
+repositories (e.g. `microsoft/azurelinux`) and can be expensive. They reuse
+the same scenario container framework (`cmdtest`/`containertest`) but skip the
+in-memory project synthesis layer.
 
 ## Test Environment
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -62,3 +62,38 @@ jobs:
       - name: Run tests
         run: |
           mage -v scenario
+
+  e2e-tests:
+    name: "End-to-end tests"
+    # E2E tests are tagged separately from scenario tests (build tag 'e2e' vs.
+    # 'scenario') so they do not run as part of 'mage scenario' / 'mage all'.
+    # They clone large upstream repositories and exercise full mock pipelines,
+    # so they live in their own job and are gated on network access.
+    strategy:
+      matrix:
+        host: [ubuntu-latest]
+    runs-on: ${{ matrix.host }}
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+      - name: Get go tools
+        uses: ./.github/getgotools
+
+      - name: Disable unix_chkpwd policy
+        run: |
+          # We disable the unix-chkpwd AppArmor profile to avoid errors running
+          # containerized tests. We also need to purge a few packages to avoid
+          # profile conflicts.
+          set -euxo pipefail
+          sudo apt-get update
+          sudo apt-get purge firefox passt
+          sudo systemctl reload apparmor.service
+          sudo apt-get install apparmor-utils
+          sudo aa-disable /usr/sbin/unix_chkpwd
+
+      - name: Run tests
+        run: |
+          mage -v e2e

--- a/magefiles/magescenario/magescenario.go
+++ b/magefiles/magescenario/magescenario.go
@@ -43,10 +43,82 @@ func ScenarioUpdate() error {
 	return nil
 }
 
+// E2E runs the end-to-end tests. These are tagged with the `e2e` build tag
+// (separate from `scenario`) so that they do not run as part of `mage scenario`,
+// `mage scenarioUpdate`, or `mage all` — they are intentionally heavier
+// (network access, large clones, full mock pipelines) and meant to be run
+// from CI on a dedicated job.
+func E2E() error {
+	startTime := time.Now()
+
+	mageutil.MagePrintln(mageutil.MsgStart, "Starting end-to-end tests...")
+
+	err := runScenarioGoTest(scenarioGoTestOptions{
+		label: "end-to-end",
+		// Use the dedicated 'e2e' tag so that scenario tests are excluded.
+		buildTag: "e2e",
+		// E2E tests are individually long-running (clone hundreds of MB,
+		// invoke mock thousands of times). A full render against the
+		// upstream repo runs ~45m on default GitHub runners; give it
+		// roughly double for headroom.
+		timeout: "90m",
+		// Limit to './scenario' (not './scenario/...') so the framework's own
+		// internal-package tests — already covered by 'mage scenario' — are
+		// not duplicated here.
+		packagePattern: "./scenario",
+	})
+	if err != nil {
+		return err
+	}
+
+	mageutil.MagePrintf(mageutil.MsgSuccess, "End-to-end tests complete: %v.\n", time.Since(startTime))
+
+	return nil
+}
+
 func mageScenarioCommon(doSnapshotUpdate bool) error {
+	options := scenarioGoTestOptions{
+		label:            "scenario",
+		buildTag:         "scenario",
+		timeout:          "60m",
+		packagePattern:   "./scenario/...",
+		doSnapshotUpdate: doSnapshotUpdate,
+	}
+
+	if doSnapshotUpdate {
+		mageutil.MagePrintln(mageutil.MsgInfo, "Will update snapshots.")
+	}
+
+	return runScenarioGoTest(options)
+}
+
+// scenarioGoTestOptions parameterizes the shared 'go test' invocation used by
+// both [Scenario] / [ScenarioUpdate] and [E2E]. They run identical
+// build/test pipelines but differ in build tag, timeout, package pattern, and
+// snapshot-update behavior.
+type scenarioGoTestOptions struct {
+	// label is a short human-readable name for the tier ("scenario" or
+	// "end-to-end") used in progress and error messages so that CI logs
+	// clearly identify which suite is running/failed.
+	label string
+	// buildTag is the Go build tag passed via '-tags='. Files in the scenario
+	// package have either '//go:build scenario' or '//go:build e2e' (with
+	// 'setup_test.go' widened to 'scenario || e2e' so [TestMain] is shared).
+	buildTag string
+	// timeout is the value passed via '-timeout=' to 'go test'.
+	timeout string
+	// packagePattern is the package selector passed to 'go test', e.g.
+	// './scenario' or './scenario/...'.
+	packagePattern string
+	// doSnapshotUpdate, when true, sets the env var that puts the snapshot
+	// helper into update mode. Only meaningful for the scenario tier.
+	doSnapshotUpdate bool
+}
+
+func runScenarioGoTest(options scenarioGoTestOptions) error {
 	mg.SerialDeps(magebuild.Build)
 
-	mageutil.MagePrintln(mageutil.MsgStart, "Running scenario tests...")
+	mageutil.MagePrintf(mageutil.MsgStart, "Running %s tests...\n", options.label)
 
 	//nolint:lll // Can't really break up the long URI.
 	// Add workaround for go-snaps disablement of color based on $_.
@@ -60,25 +132,27 @@ func mageScenarioCommon(doSnapshotUpdate bool) error {
 		buildtestenv.TestingAzldevBinPathEnvVar: path.Join(mageutil.BinDir(), "azldev"),
 	}
 
-	// If we are updating the snapshots, set the environment variable to only run the snapshot tests, and configure
-	// the snapshotter into update mode.
-	if doSnapshotUpdate {
-		mageutil.MagePrintln(mageutil.MsgInfo, "Will update snapshots.")
-
+	if options.doSnapshotUpdate {
 		env[buildtestenv.TestingUpdateSnapshotsEnvVar] = buildtestenv.TestingUpdateSnapshotsEnvValue
 	}
 
 	// '-count=1' causes the cache to be ignored for scenario tests so they always re-run (it would only rebuild if
 	// we changed the test code itself, not the application code).
-	output, err := sh.OutputWith(env, mg.GoCmd(), "test", "-tags=scenario", "-timeout=60m", "-count=1", "./scenario/...")
+	output, err := sh.OutputWith(env, mg.GoCmd(), "test",
+		"-tags="+options.buildTag,
+		"-timeout="+options.timeout,
+		"-count=1",
+		options.packagePattern,
+	)
 	if err != nil {
-		mageutil.MagePrintln(mageutil.MsgError, "Scenario test failed; details follow.")
+		titledLabel := strings.ToUpper(options.label[:1]) + options.label[1:]
+		mageutil.MagePrintf(mageutil.MsgError, "%s test failed; details follow.\n", titledLabel)
 
 		for _, line := range strings.Split(output, "\n") {
 			mageutil.MagePrintln(mageutil.MsgInfo, line)
 		}
 
-		return mageutil.PrintAndReturnError("Scenario test failed (see diagnostic output above).", ErrScenario, err)
+		return mageutil.PrintAndReturnError(titledLabel+" test failed (see diagnostic output above).", ErrScenario, err)
 	}
 
 	return nil

--- a/scenario/component_e2e_test.go
+++ b/scenario/component_e2e_test.go
@@ -1,0 +1,224 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+//go:build e2e
+
+// Package scenario_tests — end-to-end (e2e) tests that exercise azldev against
+// real, large upstream repositories. These tests are heavier than the standard
+// scenario tests (they require network access, clone hundreds of MB of git
+// history, and may exercise mock chroots across thousands of components), so
+// they are gated behind the dedicated 'e2e' build tag and run from the
+// 'mage e2e' target rather than the default 'mage scenario'.
+//
+// They reuse the scenario framework (containerized cmdtest) but skip the
+// in-memory project synthesis layer because the project under test is the
+// upstream repository itself.
+package scenario_tests
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/kballard/go-shellquote"
+	"github.com/microsoft/azure-linux-dev-tools/scenario/internal/cmdtest"
+	"github.com/stretchr/testify/require"
+)
+
+const (
+	// azureLinuxRepoURL is the upstream microsoft/azurelinux git repo used as
+	// the substrate for the e2e idempotency tests. Pinned to a public HTTPS
+	// URL so no credentials are required.
+	azureLinuxRepoURL = "https://github.com/microsoft/azurelinux"
+
+	// azureLinuxBranch is the canonical azldev-managed branch in the upstream
+	// repo. HEAD of this branch is expected to be in a steady state with
+	// respect to 'azldev component update -a' and 'azldev component render -a
+	// --clean-stale': running either should be a no-op against a fresh clone.
+	// If these tests start failing, the most likely cause is that the upstream
+	// branch has drifted and needs a refresh — not an azldev regression — but
+	// the failure messages below help disambiguate.
+	azureLinuxBranch = "4.0"
+)
+
+// runAzureLinuxIdempotencyTest clones the upstream microsoft/azurelinux
+// repository at [azureLinuxBranch] inside a privileged, networked scenario
+// container, runs `azldev <azldevArgs...>` from the clone root, and asserts
+// that the working tree is clean afterwards (no modified, deleted, or
+// untracked files).
+//
+// The script also performs lightweight pre-flight sanity checks against the
+// upstream layout, prints the resolved upstream commit SHA for traceability,
+// and emits a verbose diagnostic block (full status, diff, untracked listing)
+// before exiting non-zero on failure. This makes the difference between an
+// azldev regression and an upstream-branch drift easy to spot in CI logs.
+//
+// fullHistory controls clone depth. 'azldev component render' walks the
+// project repo's git log to count lock-file fingerprint changes (used to
+// determine the synthetic-commit count and the Release-tag bump); a shallow
+// (--depth=1) clone hides that history and produces a smaller bump than the
+// upstream rendered output recorded, so render idempotency tests must clone
+// with full history. 'component update' does not walk history and is fine
+// with a shallow clone.
+func runAzureLinuxIdempotencyTest(t *testing.T, azldevArgs []string, fullHistory bool) {
+	t.Helper()
+
+	// Quote once so the argv ends up safely embedded in the bash script and
+	// also reproduced verbatim in the failure message.
+	azldevCmdLine := shellquote.Join(azldevArgs...)
+
+	// --single-branch keeps metadata minimal in either mode. The depth flag
+	// is conditional: render needs full history (see fullHistory doc above),
+	// update can take the much faster shallow path.
+	cloneDepthFlag := "--depth=1"
+	if fullHistory {
+		cloneDepthFlag = ""
+	}
+
+	script := fmt.Sprintf(`
+set -ex
+
+# Clone the upstream branch. See [runAzureLinuxIdempotencyTest] for why depth
+# differs between update and render tests.
+git clone %[4]s --single-branch --branch=%[1]s %[2]s azurelinux
+cd azurelinux
+
+echo "Resolved upstream commit:"
+git rev-parse HEAD
+
+# Pre-flight sanity checks: fail loudly with a clear message if the upstream
+# layout has drifted in a way that would otherwise produce a confusing
+# downstream azldev error.
+test -f azldev.toml         || { echo "FAIL: missing azldev.toml at clone root"; exit 1; }
+test -f base/project.toml   || { echo "FAIL: missing base/project.toml"; exit 1; }
+test -d specs               || { echo "FAIL: missing rendered-specs directory 'specs/'"; exit 1; }
+
+# Pre-create the build dir (azldev/mock will materialize work/logs subdirs
+# inside it). base/project.toml sets
+#   work-dir = 'build/work'   log-dir = 'build/logs'
+# which azldev resolves relative to the *defining* config file, so the
+# effective parent is base/build, NOT <repo-root>/build/. Note: this MUST be
+# a real directory, not a symlink to /var/lib/mock — git's .gitignore pattern
+# 'build/' (with trailing slash) only matches directories; a symlink is
+# treated as a file and would show up as untracked. azldev passes --rootdir
+# to mock so the chroot lives under base/build, no /var/lib/mock dependency.
+mkdir -p base/build
+
+# Run the command under test. 'set -e' above ensures a non-zero azldev exit
+# fails the test immediately.
+echo "Running: azldev %[3]s"
+azldev %[3]s
+
+# Check the worktree. --porcelain produces stable, machine-readable output and
+# includes untracked files by default. Anything reported here means the
+# command was not idempotent against a freshly-checked-out upstream.
+status_output=$(git status --porcelain)
+if [[ -n "$status_output" ]]; then
+	echo
+	echo "================================================================="
+	echo "FAILURE: 'azldev %[3]s' left the working tree dirty."
+	echo "================================================================="
+	echo "Most likely causes:"
+	echo "  1. azldev regression: the command is no longer idempotent."
+	echo "  2. Upstream drift: %[2]s @ %[1]s has fallen out of"
+	echo "     sync with what 'azldev %[3]s' produces. Refresh the upstream"
+	echo "     branch and try again."
+	echo
+	echo "--- git status --porcelain ---"
+	echo "$status_output"
+	echo
+	echo "--- git status (full) ---"
+	git status
+	echo
+	echo "--- git diff (tracked changes) ---"
+	git --no-pager diff
+	echo
+	echo "--- git diff --cached ---"
+	git --no-pager diff --cached
+	echo
+	echo "--- untracked files ---"
+	git ls-files --others --exclude-standard
+	exit 1
+fi
+
+echo "OK: working tree is clean after 'azldev %[3]s'"
+`, azureLinuxBranch, azureLinuxRepoURL, azldevCmdLine, cloneDepthFlag)
+
+	results, err := cmdtest.NewScenarioTest().
+		WithScript(strings.NewReader(script)).
+		InContainer().
+		WithPrivilege().
+		WithNetwork().
+		Run(t)
+
+	require.NoError(t, err)
+
+	t.Logf("Standard output:\n%s", results.Stdout)
+	t.Logf("Standard error:\n%s", results.Stderr)
+
+	results.AssertZeroExitCode(t)
+}
+
+// TestAzureLinuxComponentUpdateIsIdempotent verifies that running
+// 'azldev component update -a' against an upstream microsoft/azurelinux
+// checkout at HEAD of [azureLinuxBranch] leaves no modifications in the
+// working tree. In other words, the lock files committed in the upstream
+// branch are already fresh against the resolved upstream snapshots, and
+// 'update -a' is a no-op.
+//
+// Intentionally not parallel: see also [TestAzureLinuxComponentRenderIsIdempotent].
+// Both tests clone hundreds of MB and may exercise mock; running them
+// concurrently on a single GitHub runner doubles disk/network/mock pressure.
+func TestAzureLinuxComponentUpdateIsIdempotent(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping long test")
+	}
+
+	runAzureLinuxIdempotencyTest(t, []string{"component", "update", "-a"}, false)
+}
+
+// TestAzureLinuxComponentRenderSubsetIsIdempotent is a smaller, faster variant
+// of [TestAzureLinuxComponentRenderIsIdempotent] that uses --check-only over a
+// hand-picked subset of components. It is meant as a smoke test for the e2e
+// framework itself (clone, container, mock initialization, render plumbing)
+// and as a fast iteration target while diagnosing regressions: a single
+// failing component here will reproduce in seconds-to-a-minute rather than
+// the many minutes a full --all render across thousands of specs takes.
+//
+// --check-only renders into a staging area and exits non-zero on drift
+// without ever touching the working tree, so the post-run 'git status' check
+// inherited from [runAzureLinuxIdempotencyTest] still applies but is largely
+// redundant: the real failure signal comes from the azldev exit code.
+//
+// The component selection is deliberately small and stable (well-known core
+// packages: bash + curl). Adding more components is fine but each one
+// extends the runtime by another mock-render pass.
+func TestAzureLinuxComponentRenderSubsetIsIdempotent(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping long test")
+	}
+
+	// Render needs full history; see [runAzureLinuxIdempotencyTest].
+	runAzureLinuxIdempotencyTest(t,
+		[]string{"component", "render", "--check-only", "bash", "curl"},
+		true)
+}
+
+// TestAzureLinuxComponentRenderIsIdempotent verifies that running
+// 'azldev component render -a --clean-stale' against an upstream
+// microsoft/azurelinux checkout at HEAD of [azureLinuxBranch] leaves no
+// modifications in the working tree. In other words, the rendered specs
+// committed in the upstream branch match what 'render -a' would produce now
+// (and there are no orphan rendered-spec directories that --clean-stale would
+// prune).
+//
+// Intentionally not parallel — see [TestAzureLinuxComponentUpdateIsIdempotent].
+func TestAzureLinuxComponentRenderIsIdempotent(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping long test")
+	}
+
+	runAzureLinuxIdempotencyTest(t,
+		[]string{"component", "render", "-a", "--clean-stale"},
+		true)
+}

--- a/scenario/docker/Dockerfile
+++ b/scenario/docker/Dockerfile
@@ -28,11 +28,13 @@ RUN groupadd -f -g "${GID}" mock && \
 # Install additional dependencies
 #   * We require ca-certificates to be able to interact with standard https endpoints
 #   * We require mock to build packages
+#   * We require mock-rpmautospec to install rpmautospec support in mock
 #   * We require sudo to run commands as root after dropping to test user
 RUN tdnf -y install \
     ca-certificates \
     git \
     mock \
+    mock-rpmautospec \
     moby-containerd \
     moby-engine \
     docker-cli \

--- a/scenario/setup_test.go
+++ b/scenario/setup_test.go
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-//go:build scenario
+//go:build scenario || e2e
 
 package scenario_tests
 


### PR DESCRIPTION
Introduces a new `mage e2e` target and `//go:build e2e` suite that exercises `azldev component` commands against actual Azure Linux source repositories.

These tests are excluded from `mage scenario`/`mage all` and intended for CI.