### PR TITLE
feat(projectconfig): add RPM repo resources and repo-set templates

### DIFF
--- a/defaultconfigs/content/defaults.toml
+++ b/defaultconfigs/content/defaults.toml
@@ -3,3 +3,29 @@ default-author-email = "azurelinux@microsoft.com"
 
 [tools.imageCustomizer]
 containerTag = "mcr.microsoft.com/azurelinux/imagecustomizer:1"
+
+# A standard "channelized" layout with two channels (`base`, `sdk`) and three
+# kinds of sub-repo per channel (binary, debug, source). Pair this template
+# with one or more `[resources.rpm-repo-sets.*]` entries that set `base-uri`
+# to the URL prefix of a published tree.
+[resources.rpm-repo-set-templates.azl-standard]
+description = "Standard base/sdk x binary/debug/source layout"
+subrepos = [
+    { name = "base",       kind = "binary", subpath = "base/$basearch" },
+    { name = "base-debug", kind = "debug",  subpath = "base/debuginfo/$basearch" },
+    { name = "base-src",   kind = "source", subpath = "base/srpms" },
+    { name = "sdk",        kind = "binary", subpath = "sdk/$basearch" },
+    { name = "sdk-debug",  kind = "debug",  subpath = "sdk/debuginfo/$basearch" },
+    { name = "sdk-src",    kind = "source", subpath = "sdk/srpms" },
+]
+
+# Standard Koji dist-repo layout. dist-repos publish one rpm-md tree per
+# arch under `<arch>/`, a parallel `<arch>/debug/` tree for debuginfo
+# packages, and a single `src/` tree for SRPMs.
+[resources.rpm-repo-set-templates.koji-dist-repo]
+description = "Koji dist-repo layout: per-arch binary + debug trees plus a src/ tree"
+subrepos = [
+    { name = "binary", kind = "binary", subpath = "$basearch" },
+    { name = "debug",  kind = "debug",  subpath = "$basearch/debug" },
+    { name = "src",    kind = "source", subpath = "src" },
+]

--- a/docs/user/README.md
+++ b/docs/user/README.md
@@ -10,6 +10,7 @@
 ## Explanation
 
 - [Configuration System](./explanation/config-system.md) — how config files are loaded, merged, and how inheritance works
+- [RPM Repos & Repo Sets](./explanation/repos.md) — modeling RPM repositories and reusable layout templates
 
 ## Reference
 
@@ -18,6 +19,7 @@
 - [Config File Structure](./reference/config/config-file.md) — root config file layout and includes
 - [Project](./reference/config/project.md) — project metadata and directory configuration
 - [Distros](./reference/config/distros.md) — distro definitions, versions, and repositories
+- [Resources](./reference/config/resources.md) — RPM repos, repo-set templates, and repo sets
 - [Components](./reference/config/components.md) — component definitions, spec sources, build options, and source files
 - [Overlays](./reference/config/overlays.md) — spec and file overlays for modifying upstream sources
 - [Component Groups](./reference/config/component-groups.md) — grouping components with shared defaults

--- a/docs/user/explanation/repos.md
+++ b/docs/user/explanation/repos.md
@@ -1,0 +1,211 @@
+# RPM Repos & Repo Sets
+
+This page explains how azldev models RPM repositories: where they're defined, how reusable layout templates produce families of related repos, and how distro versions select which repos are exposed to RPM builds (mock) and image builds (kiwi).
+
+For field-level reference documentation, see:
+
+- [Resources](../reference/config/resources.md) — `[resources.rpm-repos.*]`, `[resources.rpm-repo-set-templates.*]`, `[resources.rpm-repo-sets.*]`
+- [Distros — Inputs](../reference/config/distros.md#inputs) — `[distros.<name>.versions.<v>.inputs]`
+
+## Why?
+
+Historically, RPM repository URLs were hard-coded in `mock` template files (`*.tpl`) and inside `.kiwi` files for local builds. That had several costs:
+
+- the **same** URL was duplicated across mock templates and kiwi configs;
+- swapping between staging and production trees required editing checked-in files;
+- there was no canonical place to list what repos a build pulls from, so `azldev config dump` could not answer "what repos does this distro version use?";
+- conventional layouts (the Standard Azure Linux layout, the Koji dist-repo layout) had no first-class representation, so each consumer had to know the layout itself.
+
+The configuration described here lets you define each repo (or layout) **once** in TOML and select it per-distro-version.
+
+## Concepts
+
+There are three layers, from concrete to abstract:
+
+```
+                     ┌─────────────────────────┐
+                     │  rpm-repo-set-templates │  reusable layouts (e.g. azl-standard)
+                     └────────────┬────────────┘
+                                  │ instantiated by
+                                  ▼
+┌──────────────┐         ┌─────────────────────┐
+│   rpm-repos  │         │     rpm-repo-sets   │  named bundle: layout + base-uri + gpg-key
+└──────┬───────┘         └──────────┬──────────┘
+       │                            │ expands at validation time
+       └─────────────┬──────────────┘
+                     ▼
+        union namespace of repos available to
+        [distros.<d>.versions.<v>.inputs]
+```
+
+### `rpm-repos`
+
+A flat map of named RPM repositories. Each entry has a `base-uri` (or `metalink`), GPG configuration, and optional arch filter. Use this for one-off repos that don't fit a layout template — e.g., a single upstream Fedora `Everything` repo.
+
+### `rpm-repo-set-templates`
+
+A *layout* template: an ordered list of sub-repos described as `(name, kind, subpath)`, where `subpath` is relative to the layout's base URL and may contain `$basearch`. Templates have **no** URLs of their own — they are pure structure.
+
+Sub-repo `kind` is a classification (`binary`, `debug`, or `source`) describing what the sub-repo carries. It's diagnostic — currently used only in synthesized descriptions — but reserved as a stable label for future filtering features.
+
+Two templates ship out of the box:
+
+- **`azl-standard`** — a "channelized" layout with two channels (`base`, `sdk`) and three kinds of sub-repo per channel: `binary`, `debug`, `source`. This is the layout used by Azure Linux's published trees.
+- **`koji-dist-repo`** — Koji dist-repo layout: per-arch binary tree at `<arch>/`, parallel debuginfo tree at `<arch>/debug/`, and a single `src/` tree for SRPMs.
+
+You can define your own templates if your deployment uses a different layout; they're just regular config that any project can author.
+
+### `rpm-repo-sets`
+
+A named *instantiation* of a template: it pairs a template with a deployment-specific `base-uri`, `name-prefix`, and shared GPG configuration. At validation time each set expands into one synthesized `rpm-repos` entry per included sub-repo, keyed `<name-prefix><subrepo.name>`.
+
+By default every sub-repo declared in the referenced template is instantiated. To take only some of them, list their names explicitly:
+
+```toml
+subrepos = ["base", "sdk"]   # allowlist; everything else is dropped
+```
+
+You can also scope the entire set to specific architectures:
+
+```toml
+arches = ["x86_64"]
+```
+
+### Distro version inputs
+
+Each distro version declares **per-use-case** input lists. Each entry references either an individual repo (`repo = "..."`) or a repo set (`set = "..."`); set entries expand inline at validation time:
+
+```toml
+[distros.mydistro.versions.'4.0'.inputs]
+rpm-build = [
+    { repo = "fedora-43-everything" },   # individual repo
+    { set  = "azl4-prod" },              # expanded into N synthesized repos
+]
+image-build = [
+    { repo = "fedora-43-everything" },
+    { set  = "azl4-prod" },
+]
+```
+
+The effective list is each entry expanded in declaration order. Duplicates (whether from a direct `repo` entry or two sets whose expansions overlap) are rejected with a clear error rather than silently de-duped.
+
+Why split RPM-build vs image-build? They have different security envelopes:
+
+- mock evaluates `gpg-key` URIs *inside* the chroot, so a local file path is invisible. azldev rejects local `gpg-key` values for `rpm-build` repos.
+- kiwi runs on the host, so any URI form works for `image-build`.
+
+## Load-time vs use-time
+
+Expansion is deterministic and happens once during `ProjectConfig.Validate()`, after **all** config files (project, user, `--config-file` extras) have been merged. This means:
+
+- a later config file can override an earlier set's `base-uri` or `gpg-key`;
+- the merged config in `azldev config dump` is round-trippable: what you see is what you authored, and re-loading the dumped TOML produces the same effective state;
+- consumers (mock, kiwi) call `ResourcesConfig.EffectiveRpmRepos()` to get the flat resolved map without re-parsing layouts.
+
+`gpg-key` paths follow the usual rule: bare paths are resolved relative to the directory of the file that defines them, then re-emitted as a `file` URI. URI-shaped values (an `http` or `https` URI, or a `file` URI with an absolute path) are passed through unchanged.
+
+## End-to-end example
+
+```toml
+# ─────────────────────────────────────────────────────────────────────────────
+# Layout template: a "channelized" base/sdk × binary/debug/source matrix.
+# (Already shipped under defaultconfigs/content/defaults.toml as `azl-standard`;
+# reproduced here for clarity. Project files can override it by re-defining the
+# same name.)
+# ─────────────────────────────────────────────────────────────────────────────
+[resources.rpm-repo-set-templates.azl-standard]
+description = "Standard base/sdk x binary/debug/source layout"
+subrepos = [
+    { name = "base",       kind = "binary", subpath = "base/$basearch" },
+    { name = "base-debug", kind = "debug",  subpath = "base/debuginfo/$basearch" },
+    { name = "base-src",   kind = "source", subpath = "base/srpms" },
+    { name = "sdk",        kind = "binary", subpath = "sdk/$basearch" },
+    { name = "sdk-debug",  kind = "debug",  subpath = "sdk/debuginfo/$basearch" },
+    { name = "sdk-src",    kind = "source", subpath = "sdk/srpms" },
+]
+
+# A custom layout for a Koji dist-repo (per-arch binary + debug trees plus a
+# `src/` tree). Also shipped as a built-in template.
+[resources.rpm-repo-set-templates.koji-dist-repo]
+description = "Koji dist-repo layout: per-arch binary + debug trees plus a src/ tree"
+subrepos = [
+    { name = "binary", kind = "binary", subpath = "$basearch" },
+    { name = "debug",  kind = "debug",  subpath = "$basearch/debug" },
+    { name = "src",    kind = "source", subpath = "src" },
+]
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Repo sets: concrete deployments of the layouts above.
+# ─────────────────────────────────────────────────────────────────────────────
+
+# Production AzL 4.0 build inputs. Take only the binary + source sub-repos.
+[resources.rpm-repo-sets.azl4-prod]
+description = "Production build inputs"
+template    = "azl-standard"
+base-uri    = "https://example.com/azl4"
+name-prefix = "azl4-"
+gpg-key     = "https://example.com/keys/RPM-GPG-KEY"
+subrepos    = ["base", "base-src", "sdk", "sdk-src"]
+
+# Same layout, different mirror — for staging / pre-prod testing.
+[resources.rpm-repo-sets.azl4-staging]
+description = "Staging mirror"
+template    = "azl-standard"
+base-uri    = "https://staging.example.com/azl4"
+name-prefix = "azl4-staging-"
+gpg-key     = "https://example.com/keys/RPM-GPG-KEY"
+
+# A Koji dist-repo we pull build deps from.
+[resources.rpm-repo-sets.koji-build-deps]
+description = "Build deps from the latest dist-repo"
+template    = "koji-dist-repo"
+base-uri    = "https://kojipkgs.example.com/repos/dist-azl4-build/latest"
+name-prefix = "koji-build-deps-"
+gpg-key     = "/etc/pki/build.gpg"   # local file: ok for image-build only
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Standalone repo: an upstream Fedora source we use for spec sources.
+# ─────────────────────────────────────────────────────────────────────────────
+[resources.rpm-repos.fedora-43-everything]
+description = "Fedora 43 Everything (binary)"
+base-uri    = "https://example.com/releases/43/Everything/$basearch/os/"
+gpg-key     = "https://example.com/keys/RPM-GPG-KEY-fedora-43-primary"
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Distro version: select which inputs each use-case sees.
+# ─────────────────────────────────────────────────────────────────────────────
+[distros.mydistro.versions.'4.0'.inputs]
+# RPM build: pull from production AzL + Fedora upstream.
+rpm-build = [
+    { repo = "fedora-43-everything" },
+    { set  = "azl4-prod" },
+]
+# Image build: same, plus the Koji dist-repo (only valid here because its
+# gpg-key is a local path, which mock can't resolve inside the chroot).
+image-build = [
+    { repo = "fedora-43-everything" },
+    { set  = "azl4-prod" },
+    { set  = "koji-build-deps" },
+]
+```
+
+Inspect the fully resolved configuration with:
+
+```sh
+azldev config dump -q -O json | jq '.resources, .distros.mydistro.versions["4.0"].inputs'
+```
+
+## Authoring tips
+
+- **Singular, one-off repos belong in `[resources.rpm-repos.*]`.** They don't need a template — reference them in inputs as `{ repo = "..." }`.
+- **Prefer repo sets over individual `rpm-repos` for layouts you'll deploy more than once.** Two mirrors of the same layout become two `rpm-repo-sets` entries that share a template instead of 12 hand-maintained `rpm-repos` entries that drift.
+- **Put the `gpg-key` on the *set* (not on each synthesized repo).** Sub-repos in a published tree always share a key.
+- **Use `name-prefix` to namespace deployments.** `azl4-`, `azl4-staging-`, `koji-build-deps-` make repo IDs self-describing in dnf logs and mock output.
+- **`subrepos = ["base", "base-src", "sdk", "sdk-src"]`** is a frequent allowlist for build inputs — dnf doesn't need debuginfo to resolve build dependencies, and skipping it makes refresh faster.
+- **Define new templates when your layout doesn't fit `azl-standard` or `koji-dist-repo`.** Templates are cheap; don't bend an existing one.
+
+## Related Resources
+
+- [Resources](../reference/config/resources.md) — field-level reference
+- [Distros — Inputs](../reference/config/distros.md#inputs) — wiring repos into distro versions
+- [Configuration System](config-system.md) — load order, merge rules

--- a/docs/user/reference/config/config-file.md
+++ b/docs/user/reference/config/config-file.md
@@ -18,6 +18,7 @@ All config files share the same schema — there is no distinction between a "ro
 | `tools` | object | Configuration for external tools used by azldev | [Tools](tools.md) |
 | `default-package-config` | object | Project-wide default applied to all binary packages | [Package Groups — Resolution Order](package-groups.md#resolution-order) |
 | `package-groups` | map of objects | Named groups of binary packages with shared config | [Package Groups](package-groups.md) |
+| `resources` | object | Reusable named resource definitions (RPM repos, repo-set templates, repo sets) | [Resources](resources.md) |
 
 ## Includes
 

--- a/docs/user/reference/config/distros.md
+++ b/docs/user/reference/config/distros.md
@@ -55,6 +55,7 @@ Each distro can define multiple versions under `[distros.<name>.versions.<versio
 | Mock config | `mock-config` | string | No | Path to the mock config file for this version (architecture-independent) |
 | Mock config (x86_64) | `mock-config-x86_64` | string | No | Path to the x86_64-specific mock config file |
 | Mock config (aarch64) | `mock-config-aarch64` | string | No | Path to the aarch64-specific mock config file |
+| Inputs | `inputs` | [DistroVersionInputs](#inputs) | No | Per-use-case input RPM repositories for this version |
 
 ### Default Component Config
 
@@ -68,6 +69,42 @@ spec = { type = "upstream", upstream-distro = { name = "fedora", version = "43",
 With this configuration, every component automatically uses specs from Fedora 43 (as they existed at the snapshot date) unless it specifies its own `spec` field.
 
 See [Configuration Inheritance](../../explanation/config-system.md#configuration-inheritance) for the full inheritance chain.
+
+### Inputs
+
+The `inputs` field selects which top-level [RPM repository resources](resources.md) (and [repo sets](resources.md#rpm-repo-set)) are made available to each build use-case for this distro version. Each list is an ordered sequence of typed entries; each entry references **either** an individual repo **or** a repo set (exactly one of `repo` / `set` must be present):
+
+| Field | TOML Key | Type | Description |
+|---|---|---|---|
+| RPM-build inputs | `rpm-build` | list of [DistroVersionInput](#distroversioninput) | Repos and repo sets made available to mock when building RPMs. |
+| Image-build inputs | `image-build` | list of [DistroVersionInput](#distroversioninput) | Repos and repo sets made available to kiwi when building images. |
+
+#### DistroVersionInput
+
+| Field | TOML Key | Type | Description |
+|---|---|---|---|
+| Repo | `repo` | string | Name of an entry under `[resources.rpm-repos]`. **Mutually exclusive** with `set`. |
+| Set | `set` | string | Name of an entry under `[resources.rpm-repo-sets]`; expanded inline at validation time. **Mutually exclusive** with `repo`. |
+
+Order is preserved when the list is projected into mock/kiwi config but is **not** treated as a priority hint — neither dnf nor kiwi guarantees ordering semantics across remote repos. Define explicit priorities at the consumer level if needed.
+
+The effective per-use-case list is each entry expanded in declaration order. Duplicates (whether from a direct `repo` entry or two sets whose expansions overlap) are reported as errors.
+
+`rpm-build` repos may not have a local (bare or `file://`) `gpg-key`: mock evaluates the URI inside the chroot, where the host path is invisible. Use an `http(s)://` URI, or only reference such a repo from `image-build`.
+
+```toml
+[distros.mydistro.versions.'4.0'.inputs]
+rpm-build = [
+    { repo = "fedora-43-everything" },
+    { set  = "azl4-prod" },
+]
+image-build = [
+    { repo = "fedora-43-everything" },
+    { set  = "azl4-prod" },
+]
+```
+
+See [RPM repos & repo sets overview](../../explanation/repos.md) for the bigger picture.
 
 ## Distro References
 

--- a/docs/user/reference/config/resources.md
+++ b/docs/user/reference/config/resources.md
@@ -1,0 +1,140 @@
+# RPM Repo Resources
+
+The `[resources]` section defines reusable, named resource definitions referenced from elsewhere in the configuration. Today this is RPM repositories — both individual repositories and **repo sets** that instantiate a layout template (e.g., a `base`/`sdk` × `binary`/`debug`/`source` matrix) for a specific deployment.
+
+For an end-to-end walkthrough that ties this together with distro versions and build inputs, see [RPM repos & repo sets overview](../../explanation/repos.md).
+
+## Top-Level Layout
+
+| TOML Key | Type | Description |
+|---|---|---|
+| `resources.rpm-repos` | map of [RpmRepoResource](#rpm-repo-resource) | Individually-defined RPM repositories, keyed by name |
+| `resources.rpm-repo-set-templates` | map of [RpmRepoSetTemplate](#rpm-repo-set-template) | Named layout templates that describe a fixed matrix of sub-repos |
+| `resources.rpm-repo-sets` | map of [RpmRepoSet](#rpm-repo-set) | Template instantiations that expand into a group of related repos |
+
+Repos defined under `rpm-repos` and repos synthesized by expanding `rpm-repo-sets` share a single namespace. The combined list is what distro version `inputs` (see [Distros — Inputs](distros.md#inputs)) refer to.
+
+## RPM Repo Resource
+
+Defined under `[resources.rpm-repos.<name>]`. The `<name>` is projected verbatim into dnf section headers and kiwi `--add-repo` arguments, so it must match `^[A-Za-z0-9][A-Za-z0-9_.:-]*$`.
+
+| Field | TOML Key | Type | Description |
+|---|---|---|---|
+| Description | `description` | string | Human-readable description (diagnostic only) |
+| Type | `type` | string | Access protocol; defaults to `rpm-md`. Currently the only supported value. |
+| Base URI | `base-uri` | string (http/https URL) | Repository base URL. **Mutually exclusive** with `metalink`. |
+| Metalink | `metalink` | string (http/https URL) | Repository metalink URL. **Mutually exclusive** with `base-uri`. |
+| Disable GPG check | `disable-gpg-check` | bool | Opt out of GPG verification. Default (`false`) means **GPG checking is enabled** — the safe default. |
+| GPG key | `gpg-key` | string | Path or URI to the GPG key. Accepted shapes: an `https` URI, an `http` URI, a `file` URI with absolute path, or a bare path resolved relative to the defining TOML file. Required unless `disable-gpg-check = true`. |
+| Arches | `arches` | list of string | Restrict to specific target architectures (e.g. `["x86_64"]`). Empty = all. |
+
+### URI placeholders
+
+`$basearch` and `$releasever` are passed through verbatim to the consumer (mock/dnf or kiwi), which expands them at use time.
+
+### `gpg-key` portability
+
+For repos referenced from `inputs.rpm-build`, `gpg-key` **must not** be a bare path or `file://` URI: mock evaluates the URI inside the chroot, where the host path is invisible. Image builds (kiwi, on the host) accept all forms but http(s) is the most portable.
+
+### Example
+
+```toml
+[resources.rpm-repos.fedora-43-everything]
+description = "Fedora 43 Everything (binary)"
+base-uri    = "https://example.com/releases/43/Everything/$basearch/os/"
+gpg-key     = "https://example.com/keys/RPM-GPG-KEY-fedora-43-primary"
+```
+
+## RPM Repo Set Template
+
+A template describes a fixed layout — the set of sub-repos hosted under a common URL prefix. Templates are reusable across deployments; pair a template with one or more [`rpm-repo-sets`](#rpm-repo-set) entries to produce concrete bundles of repos.
+
+Two templates ship out of the box:
+
+- **`azl-standard`** — a "channelized" layout: `base`/`sdk` channels × `binary`/`debug`/`source` kinds.
+- **`koji-dist-repo`** — Koji dist-repo layout: per-arch binary tree at `<arch>/`, parallel debuginfo tree at `<arch>/debug/`, and a single `src/` tree for SRPMs.
+
+Defined under `[resources.rpm-repo-set-templates.<name>]`.
+
+| Field | TOML Key | Type | Description |
+|---|---|---|---|
+| Description | `description` | string | Human-readable description |
+| Sub-repos | `subrepos` | list of [SubrepoSpec](#subrepospec) | Ordered list of sub-repo entries that make up the layout |
+
+### SubrepoSpec
+
+| Field | TOML Key | Type | Description |
+|---|---|---|---|
+| Name | `name` | string | Stable short identifier; combined with the set's `name-prefix` to form the resulting repo ID. Same grammar as a top-level repo name. |
+| Sub-path | `subpath` | string | Path relative to the set's `base-uri`. May contain `$basearch` (passed through verbatim). |
+| Kind | `kind` | string (`binary` \| `debug` \| `source`) | Classification of what the sub-repo carries: signed binary RPMs (`binary`), debuginfo/debugsource RPMs (`debug`), or SRPMs (`source`). Defaults to `binary`. Diagnostic only today; reserved for future filtering features. |
+
+### Example
+
+```toml
+[resources.rpm-repo-set-templates.azl-standard]
+description = "Standard base/sdk x binary/debug/source layout"
+subrepos = [
+    { name = "base",       kind = "binary", subpath = "base/$basearch" },
+    { name = "base-debug", kind = "debug",  subpath = "base/debuginfo/$basearch" },
+    { name = "base-src",   kind = "source", subpath = "base/srpms" },
+    { name = "sdk",        kind = "binary", subpath = "sdk/$basearch" },
+    { name = "sdk-debug",  kind = "debug",  subpath = "sdk/debuginfo/$basearch" },
+    { name = "sdk-src",    kind = "source", subpath = "sdk/srpms" },
+]
+```
+
+## RPM Repo Set
+
+A repo set instantiates a [template](#rpm-repo-set-template) for a specific deployment by supplying a base URL, name prefix, and shared GPG configuration. At validation time each set expands into one synthesized [`RpmRepoResource`](#rpm-repo-resource) per included sub-repo, keyed by `<name-prefix><subrepo.name>`.
+
+Defined under `[resources.rpm-repo-sets.<name>]`.
+
+| Field | TOML Key | Type | Description |
+|---|---|---|---|
+| Description | `description` | string | Human-readable description |
+| Template | `template` | string | **Required.** Name of the [`rpm-repo-set-templates`](#rpm-repo-set-template) entry to instantiate |
+| Base URI | `base-uri` | string (http/https URL) | **Required.** URL prefix under which the sub-repos live |
+| Name prefix | `name-prefix` | string | Prepended to each sub-repo's `name` to form the synthesized repo ID. May be empty. |
+| GPG key | `gpg-key` | string | Shared GPG key for sub-repos in this set; same shape rules as the per-repo `gpg-key` |
+| Disable GPG check | `disable-gpg-check` | bool | Opt out of GPG verification for sub-repos in this set |
+| Arches | `arches` | list of string | Restrict every synthesized repo in this set to specific architectures |
+| Sub-repos | `subrepos` | list of string | Allowlist of sub-repo names to include from the template. Empty/unset = include all sub-repos. Names must match entries in the referenced template. |
+
+### Sub-repo selection
+
+By default (`subrepos` unset or empty), every sub-repo in the referenced template is instantiated. Provide `subrepos = [...]` to take only a strict allowlist:
+
+```toml
+subrepos = ["base", "base-src", "sdk", "sdk-src"]   # skip debug for slim build inputs
+```
+
+Unknown names (and duplicates within the list) are rejected at load time.
+
+### Collisions
+
+Synthesized repo IDs (`<name-prefix><subrepo.name>`) must not collide with explicit `[resources.rpm-repos.…]` entries or with another set's expansion. The validator surfaces collisions with a clear error.
+
+### Example
+
+```toml
+[resources.rpm-repo-sets.azl4-prod]
+description = "Production build inputs"
+template    = "azl-standard"
+base-uri    = "https://example.com/azl4"
+name-prefix = "azl4-"
+gpg-key     = "https://example.com/keys/RPM-GPG-KEY"
+subrepos    = ["base", "base-src", "sdk", "sdk-src"]   # binary + sources, no debug
+```
+
+This expands into four `RpmRepoResource` entries: `azl4-base`, `azl4-base-src`, `azl4-sdk`, `azl4-sdk-src`.
+
+## Merging across files
+
+Like other top-level maps, `rpm-repos`, `rpm-repo-set-templates`, and `rpm-repo-sets` are merged across config files **by key with wholesale entry replacement**. A duplicate name in a later-loaded file fully replaces the earlier definition (including any zero-value fields). This makes `--config-file` overrides predictable: setting `disable-gpg-check = false` (the zero value) will override an earlier `true`.
+
+## Related Resources
+
+- [Distros — Inputs](distros.md#inputs) — wiring repos and repo-sets into per-version build inputs
+- [RPM repos & repo sets overview](../../explanation/repos.md) — end-to-end design rationale and full TOML example
+- [Configuration System](../../explanation/config-system.md) — load order and merge rules

--- a/internal/projectconfig/configfile.go
+++ b/internal/projectconfig/configfile.go
@@ -35,6 +35,10 @@ type ConfigFile struct {
 	// Definitions of distros.
 	Distros map[string]DistroDefinition `toml:"distros,omitempty" jsonschema:"title=Distros,description=Definitions of distros to build for or consume from"`
 
+	// Reusable resource definitions (e.g., RPM repositories) referenced from
+	// elsewhere in the configuration.
+	Resources *ResourcesConfig `toml:"resources,omitempty" jsonschema:"title=Resources,description=Reusable named resource definitions"`
+
 	// Definitions of component groups.
 	ComponentGroups map[string]ComponentGroupConfig `toml:"component-groups,omitempty" validate:"dive" jsonschema:"title=Component groups,description=Definitions of component groups for this project"`
 

--- a/internal/projectconfig/distro.go
+++ b/internal/projectconfig/distro.go
@@ -85,6 +85,41 @@ type DistroVersionDefinition struct {
 	MockConfigPath        string `toml:"mock-config,omitempty"         json:"mockConfig,omitempty"        validate:"omitempty,filepath" jsonschema:"title=Mock config file,description=Path to the mock config file for this version"`
 	MockConfigPathX86_64  string `toml:"mock-config-x86_64,omitempty"  json:"mockConfigX8664,omitempty"   validate:"omitempty,filepath" jsonschema:"title=Mock config file,description=Path to the x86_64 mock config file for this version"`
 	MockConfigPathAarch64 string `toml:"mock-config-aarch64,omitempty" json:"mockConfigAarch64,omitempty" validate:"omitempty,filepath" jsonschema:"title=Mock config file,description=Path to the aarch64 mock config file for this version"`
+
+	// Inputs maps build use-cases ("rpm-build", "image-build") to ordered lists
+	// of input references. Each entry references either a [RpmRepoResource] or
+	// a [RpmRepoSet]; sets are expanded at validation time.
+	Inputs DistroVersionInputs `toml:"inputs,omitempty" json:"inputs,omitempty" jsonschema:"title=Inputs,description=Per-use-case input repositories"`
+}
+
+// DistroVersionInputs maps build use-cases to ordered lists of input references.
+// Each [DistroVersionInput] entry references either a [RpmRepoResource] (by
+// `repo`) or a [RpmRepoSet] (by `set`); sets are expanded at validation time
+// into their constituent repo names. The final, deduplicated effective list is
+// what consumers (mock, kiwi) see.
+type DistroVersionInputs struct {
+	// RpmBuild is the ordered list of inputs made available when building RPMs
+	// (the mock/comp build path). Order is preserved on emission but not
+	// interpreted as priority by dnf.
+	RpmBuild []DistroVersionInput `toml:"rpm-build,omitempty" json:"rpmBuild,omitempty" jsonschema:"title=RPM-build inputs,description=Repos and repo-sets made available to mock when building RPMs"`
+
+	// ImageBuild is the ordered list of inputs made available when building
+	// images (the kiwi/image build path). Order is preserved on emission but
+	// not interpreted as priority by kiwi.
+	ImageBuild []DistroVersionInput `toml:"image-build,omitempty" json:"imageBuild,omitempty" jsonschema:"title=Image-build inputs,description=Repos and repo-sets made available to kiwi when building images"`
+}
+
+// DistroVersionInput is a single entry in a [DistroVersionInputs] list. Exactly
+// one of `Repo` or `Set` must be set; the validator rejects entries that set
+// neither or both.
+type DistroVersionInput struct {
+	// Repo names a top-level [ResourcesConfig.RpmRepos] entry. Mutually
+	// exclusive with `Set`.
+	Repo string `toml:"repo,omitempty" json:"repo,omitempty" jsonschema:"title=Repo,description=Name of an entry under [resources.rpm-repos]; mutually exclusive with set"`
+
+	// Set names a top-level [ResourcesConfig.RpmRepoSets] entry. Mutually
+	// exclusive with `Repo`.
+	Set string `toml:"set,omitempty" json:"set,omitempty" jsonschema:"title=Set,description=Name of an entry under [resources.rpm-repo-sets]; mutually exclusive with repo"`
 }
 
 // MergeUpdatesFrom mutates the distro definition, updating it with overrides present in other.

--- a/internal/projectconfig/loader.go
+++ b/internal/projectconfig/loader.go
@@ -136,6 +136,28 @@ func mergeConfigFile(resolvedCfg *ProjectConfig, loadedCfg *ConfigFile) error {
 		return err
 	}
 
+	if err := mergeResources(resolvedCfg, loadedCfg); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// mergeResources merges the [ResourcesConfig] from a loaded config file into the resolved
+// config. Map-keyed entries (e.g., rpm-repos by name) are overlaid: a duplicate name in
+// a later-loaded file replaces the earlier definition (matching the policy applied to
+// other top-level resource collections).
+func mergeResources(resolvedCfg *ProjectConfig, loadedCfg *ConfigFile) error {
+	if loadedCfg.Resources == nil {
+		return nil
+	}
+
+	resolved := loadedCfg.Resources.WithAbsolutePaths(loadedCfg.dir)
+
+	if err := resolvedCfg.Resources.MergeUpdatesFrom(resolved); err != nil {
+		return fmt.Errorf("failed to merge resources from %#q:\n%w", loadedCfg.SourcePath(), err)
+	}
+
 	return nil
 }
 

--- a/internal/projectconfig/loader.go
+++ b/internal/projectconfig/loader.go
@@ -153,10 +153,7 @@ func mergeResources(resolvedCfg *ProjectConfig, loadedCfg *ConfigFile) error {
 	}
 
 	resolved := loadedCfg.Resources.WithAbsolutePaths(loadedCfg.dir)
-
-	if err := resolvedCfg.Resources.MergeUpdatesFrom(resolved); err != nil {
-		return fmt.Errorf("failed to merge resources from %#q:\n%w", loadedCfg.SourcePath(), err)
-	}
+	resolvedCfg.Resources.MergeUpdatesFrom(resolved)
 
 	return nil
 }

--- a/internal/projectconfig/project.go
+++ b/internal/projectconfig/project.go
@@ -25,6 +25,9 @@ type ProjectConfig struct {
 	Images map[string]ImageConfig `toml:"images,omitempty" json:"images,omitempty" jsonschema:"title=Images,description=Mapping of image names to configurations"`
 	// Definitions of distros.
 	Distros map[string]DistroDefinition `toml:"distros,omitempty" json:"distros,omitempty" jsonschema:"title=Distros,description=Mapping of distro names to their definitions"`
+	// Reusable resource definitions (e.g., RPM repositories) referenced from
+	// elsewhere in the configuration.
+	Resources ResourcesConfig `toml:"resources,omitempty" json:"resources,omitempty" jsonschema:"title=Resources,description=Reusable named resource definitions"`
 	// Configuration for tools used by azldev.
 	Tools ToolsConfig `toml:"tools,omitempty" json:"tools,omitempty" jsonschema:"title=Tools configuration,description=Configuration for tools used by azldev"`
 
@@ -58,6 +61,7 @@ func NewProjectConfig() ProjectConfig {
 		Components:        make(map[string]ComponentConfig),
 		Images:            make(map[string]ImageConfig),
 		Distros:           make(map[string]DistroDefinition),
+		Resources:         ResourcesConfig{RpmRepos: make(map[string]RpmRepoResource)},
 		GroupsByComponent: make(map[string][]string),
 		PackageGroups:     make(map[string]PackageGroupConfig),
 		TestSuites:        make(map[string]TestSuiteConfig),
@@ -81,6 +85,130 @@ func (cfg *ProjectConfig) Validate() error {
 
 	if err := validateImageTestReferences(cfg.Images, cfg.TestSuites); err != nil {
 		return err
+	}
+
+	if err := validateRpmRepos(cfg.Resources.RpmRepos); err != nil {
+		return err
+	}
+
+	if err := validateRpmRepoSetTemplates(cfg.Resources.RpmRepoSetTemplates); err != nil {
+		return err
+	}
+
+	if err := validateRpmRepoSets(cfg.Resources.RpmRepoSets); err != nil {
+		return err
+	}
+
+	// Expand sets into the effective flat map and surface any structural / collision
+	// errors. We rebuild the effective map once here for use by the input validator.
+	effectiveRepos, err := cfg.Resources.EffectiveRpmRepos()
+	if err != nil {
+		return err
+	}
+
+	if err := validateDistroVersionInputs(cfg.Distros, &cfg.Resources, effectiveRepos); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// validateRpmRepos checks each RPM repo definition for structural validity,
+// including the map key.
+func validateRpmRepos(repos map[string]RpmRepoResource) error {
+	for name, repo := range repos {
+		if err := validateRpmRepoName(name); err != nil {
+			return fmt.Errorf("rpm-repo:\n%w", err)
+		}
+
+		if err := validateRpmRepo(name, &repo); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// validateRpmRepoSetTemplates checks each repo-set template definition for
+// structural validity, including the map key.
+func validateRpmRepoSetTemplates(templates map[string]RpmRepoSetTemplate) error {
+	for name, tmpl := range templates {
+		if err := validateRpmRepoName(name); err != nil {
+			return fmt.Errorf("rpm-repo-set-template:\n%w", err)
+		}
+
+		if err := validateRpmRepoSetTemplate(name, &tmpl); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// validateRpmRepoSets checks the structural validity of each set's map key. The
+// per-set body (template reference, base-uri, etc.) is validated lazily during
+// expansion in [ResourcesConfig.EffectiveRpmRepos].
+func validateRpmRepoSets(sets map[string]RpmRepoSet) error {
+	for name := range sets {
+		if err := validateRpmRepoName(name); err != nil {
+			return fmt.Errorf("rpm-repo-set:\n%w", err)
+		}
+	}
+
+	return nil
+}
+
+// validateDistroVersionInputs verifies that every repo or repo-set name referenced
+// from a distro version's [DistroVersionDefinition.Inputs] resolves, that no
+// effective repo is produced more than once, and that the effective rpm-build
+// list does not include repos with a local `gpg-key` (which mock cannot resolve
+// inside the chroot).
+func validateDistroVersionInputs(
+	distros map[string]DistroDefinition,
+	resources *ResourcesConfig,
+	effectiveRepos map[string]RpmRepoResource,
+) error {
+	for distroName, distro := range distros {
+		for versionName, version := range distro.Versions {
+			rpmBuild, err := version.EffectiveRpmBuildRepos(resources)
+			if err != nil {
+				return fmt.Errorf("distro %q version %q:\n%w", distroName, versionName, err)
+			}
+
+			for _, name := range rpmBuild {
+				repo, ok := effectiveRepos[name]
+				if !ok {
+					return fmt.Errorf(
+						"distro %q version %q inputs.rpm-build references undefined rpm-repo %q",
+						distroName, versionName, name,
+					)
+				}
+
+				if repo.IsLocalGPGKey() {
+					return fmt.Errorf(
+						"distro %q version %q inputs.rpm-build references rpm-repo %q which has a local "+
+							"`gpg-key` (%q); local keys are not yet supported for mock builds (mock would "+
+							"evaluate the path inside the chroot) — use an http(s) URI, or only reference "+
+							"this repo from inputs.image-build",
+						distroName, versionName, name, repo.GPGKey,
+					)
+				}
+			}
+
+			imageBuild, err := version.EffectiveImageBuildRepos(resources)
+			if err != nil {
+				return fmt.Errorf("distro %q version %q:\n%w", distroName, versionName, err)
+			}
+
+			for _, name := range imageBuild {
+				if _, ok := effectiveRepos[name]; !ok {
+					return fmt.Errorf(
+						"distro %q version %q inputs.image-build references undefined rpm-repo %q",
+						distroName, versionName, name,
+					)
+				}
+			}
+		}
 	}
 
 	return nil

--- a/internal/projectconfig/resources.go
+++ b/internal/projectconfig/resources.go
@@ -100,9 +100,9 @@ func (ResourcesConfig) JSONSchemaExtend(schema *jsonschema.Schema) {
 // be the Go zero value in the new entry. This avoids subtle bugs where, e.g., a
 // later config file intentionally setting `disable-gpg-check = false` (the zero
 // value) would otherwise fail to override an earlier `true`.
-func (r *ResourcesConfig) MergeUpdatesFrom(other *ResourcesConfig) error {
+func (r *ResourcesConfig) MergeUpdatesFrom(other *ResourcesConfig) {
 	if other == nil {
-		return nil
+		return
 	}
 
 	if len(other.RpmRepos) > 0 && r.RpmRepos == nil {
@@ -128,8 +128,6 @@ func (r *ResourcesConfig) MergeUpdatesFrom(other *ResourcesConfig) error {
 	for name, set := range other.RpmRepoSets {
 		r.RpmRepoSets[name] = set
 	}
-
-	return nil
 }
 
 // RpmRepoResource describes a single reusable RPM repository. Per-distro-version
@@ -889,6 +887,14 @@ func joinSetBaseURI(setName, baseURI, subpath string) (string, error) {
 		}
 	}
 
+	if strings.ContainsAny(subpath, "?#") {
+		return "", fmt.Errorf(
+			"rpm-repo-set %#q template `subpath` %#q must not contain a query string or fragment "+
+				"(no `?` or `#`)",
+			setName, subpath,
+		)
+	}
+
 	parsed, err := url.Parse(baseURI)
 	if err != nil {
 		return "", fmt.Errorf("rpm-repo-set %#q `base-uri` is not a valid URI:\n%w", setName, err)
@@ -952,7 +958,7 @@ func validateRpmRepoSetTemplate(name string, tmpl *RpmRepoSetTemplate) error {
 		sub := &tmpl.Subrepos[i]
 
 		if err := validateRpmRepoName(sub.Name); err != nil {
-			return fmt.Errorf("rpm-repo-set-template %#q sub-repo %d:\n%w", name, i, err)
+			return fmt.Errorf("rpm-repo-set-template %#q sub-repo %d:\n%w", name, i+1, err)
 		}
 
 		if seen[sub.Name] {

--- a/internal/projectconfig/resources.go
+++ b/internal/projectconfig/resources.go
@@ -1,0 +1,1110 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+package projectconfig
+
+import (
+	"errors"
+	"fmt"
+	"net/url"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"strings"
+
+	"github.com/brunoga/deep"
+	"github.com/invopop/jsonschema"
+)
+
+// RpmRepoType is the type discriminator for an [RpmRepoResource]. New types may be added
+// in the future (e.g., "rpm-dir" for unindexed directories of RPMs, or "oci" for delta-RPM
+// repos hosted in container registries). For now, only "rpm-md" is supported.
+type RpmRepoType string
+
+const (
+	// RpmRepoTypeRpmMd designates a standard rpm-md (dnf) repository accessed via a
+	// `base-uri` or `metalink`. This is the default when [RpmRepoResource.Type] is unset.
+	RpmRepoTypeRpmMd RpmRepoType = "rpm-md"
+)
+
+// IsValid reports whether the given RpmRepoType is a value the loader currently understands.
+func (t RpmRepoType) IsValid() bool {
+	switch t {
+	case "", RpmRepoTypeRpmMd:
+		return true
+	default:
+		return false
+	}
+}
+
+// ResourcesConfig is a top-level container for reusable, named resource definitions
+// referenced from elsewhere in the configuration (e.g., from a distro version's
+// [DistroVersionDefinition.Inputs]).
+//
+// The container is intentionally namespaced (e.g., resources.rpm-repos rather than
+// rpm-repos) so that future sibling resource types (container registries, signing
+// keys, etc.) can live under the same top-level key without crowding the schema.
+//
+// JSONSchemaExtend uses a value receiver because the invopop/jsonschema library
+// only invokes value-receiver methods when reflecting on the type; the rest of
+// the methods use pointer receivers because they mutate.
+//
+//nolint:recvcheck // intentional mixed receivers (see comment above).
+type ResourcesConfig struct {
+	// RpmRepos is the set of reusable RPM repository definitions, keyed by name.
+	RpmRepos map[string]RpmRepoResource `toml:"rpm-repos,omitempty" json:"rpmRepos,omitempty" jsonschema:"title=RPM repositories,description=Reusable named RPM repository definitions"`
+
+	// RpmRepoSetTemplates defines named layout templates that describe a fixed
+	// matrix of sub-repos (e.g., the standard Azure Linux base/sdk x main/debuginfo/srpms
+	// matrix, or a Koji dist-repo layout). Templates are instantiated by [RpmRepoSet]
+	// entries.
+	RpmRepoSetTemplates map[string]RpmRepoSetTemplate `toml:"rpm-repo-set-templates,omitempty" json:"rpmRepoSetTemplates,omitempty" jsonschema:"title=RPM repo set templates,description=Named layout templates that describe a fixed matrix of sub-repos"`
+
+	// RpmRepoSets instantiates a [RpmRepoSetTemplate] for a specific deployment by
+	// supplying a base URI and shared GPG configuration. Each set expands at validation
+	// time into one or more synthesized [RpmRepoResource] entries; consumers reach the
+	// expanded repos via [ResourcesConfig.EffectiveRpmRepos].
+	RpmRepoSets map[string]RpmRepoSet `toml:"rpm-repo-sets,omitempty" json:"rpmRepoSets,omitempty" jsonschema:"title=RPM repo sets,description=Template instantiations that expand to a group of related RPM repos"`
+}
+
+// IsEmpty reports whether the ResourcesConfig contains no entries.
+func (r *ResourcesConfig) IsEmpty() bool {
+	return r == nil || (len(r.RpmRepos) == 0 && len(r.RpmRepoSetTemplates) == 0 && len(r.RpmRepoSets) == 0)
+}
+
+// JSONSchemaExtend tightens the generated schema for the resources maps so editors
+// can flag invalid names at edit time. The runtime validator ([validateRpmRepoName])
+// is the source of truth; this keeps the schema in sync.
+func (ResourcesConfig) JSONSchemaExtend(schema *jsonschema.Schema) {
+	if schema.Properties == nil {
+		return
+	}
+
+	for _, key := range []string{"rpm-repos", "rpm-repo-set-templates", "rpm-repo-sets"} {
+		prop, ok := schema.Properties.Get(key)
+		if !ok || prop == nil {
+			continue
+		}
+
+		prop.PropertyNames = &jsonschema.Schema{
+			Type:        "string",
+			Pattern:     rpmRepoNameRE.String(),
+			Description: "Name; projected verbatim into dnf section headers and kiwi --add-repo arguments.",
+		}
+	}
+}
+
+// MergeUpdatesFrom mutates r, updating it with overrides present in other. Maps are
+// merged by key with **wholesale replacement** at the entry level: a duplicate name
+// in `other` fully replaces the existing entry, including any fields that happen to
+// be the Go zero value in the new entry. This avoids subtle bugs where, e.g., a
+// later config file intentionally setting `disable-gpg-check = false` (the zero
+// value) would otherwise fail to override an earlier `true`.
+func (r *ResourcesConfig) MergeUpdatesFrom(other *ResourcesConfig) error {
+	if other == nil {
+		return nil
+	}
+
+	if len(other.RpmRepos) > 0 && r.RpmRepos == nil {
+		r.RpmRepos = make(map[string]RpmRepoResource, len(other.RpmRepos))
+	}
+
+	for name, repo := range other.RpmRepos {
+		r.RpmRepos[name] = repo
+	}
+
+	if len(other.RpmRepoSetTemplates) > 0 && r.RpmRepoSetTemplates == nil {
+		r.RpmRepoSetTemplates = make(map[string]RpmRepoSetTemplate, len(other.RpmRepoSetTemplates))
+	}
+
+	for name, tmpl := range other.RpmRepoSetTemplates {
+		r.RpmRepoSetTemplates[name] = tmpl
+	}
+
+	if len(other.RpmRepoSets) > 0 && r.RpmRepoSets == nil {
+		r.RpmRepoSets = make(map[string]RpmRepoSet, len(other.RpmRepoSets))
+	}
+
+	for name, set := range other.RpmRepoSets {
+		r.RpmRepoSets[name] = set
+	}
+
+	return nil
+}
+
+// RpmRepoResource describes a single reusable RPM repository. Per-distro-version
+// configuration ([DistroVersionDefinition.Inputs]) selects which repos are made
+// available to which build use-cases (rpm-build, image-build).
+//
+// dnf-side variables ($basearch, $releasever) in `base-uri`/`metalink`/`gpg-key`
+// fields are passed through verbatim and expanded by the consuming tool (mock/dnf
+// or kiwi).
+//
+// **GPG checking defaults to enabled** (the safe default). Set
+// `disable-gpg-check = true` to opt out. A repo with GPG checking enabled and no
+// `gpg-key` is invalid; load-time validation rejects it.
+//
+// JSONSchemaExtend uses a value receiver because the invopop/jsonschema library
+// only invokes value-receiver methods when reflecting on the type; the rest of
+// the methods use pointer receivers because they read shared state.
+//
+//nolint:recvcheck // intentional mixed receivers (see comment above).
+type RpmRepoResource struct {
+	// Description is a human-readable description of the repository. Used only
+	// for `azldev config dump` and similar diagnostics; not projected into dnf
+	// or kiwi configuration (avoids newline/encoding pitfalls).
+	Description string `toml:"description,omitempty" json:"description,omitempty" jsonschema:"title=Description,description=Human-readable description (diagnostic only)"`
+
+	// Type discriminates the repository's access protocol. Defaults to "rpm-md" when unset.
+	Type RpmRepoType `toml:"type,omitempty" json:"type,omitempty" jsonschema:"title=Type,description=Repository access protocol; defaults to rpm-md,enum=rpm-md"`
+
+	// BaseURI is the repository base URI (dnf's `baseurl`). Mutually exclusive with
+	// [RpmRepoResource.Metalink]. Either BaseURI or Metalink must be set for type "rpm-md".
+	BaseURI string `toml:"base-uri,omitempty" json:"baseUri,omitempty" jsonschema:"format=uri,pattern=^https?://[^\\s]+$,title=Base URI,description=Repository base URI (dnf baseurl). Mutually exclusive with metalink. Must be an http(s) URL."`
+
+	// Metalink is the repository metalink URL. Mutually exclusive with [RpmRepoResource.BaseURI].
+	Metalink string `toml:"metalink,omitempty" json:"metalink,omitempty" jsonschema:"format=uri,pattern=^https?://[^\\s]+$,title=Metalink,description=Repository metalink URL. Mutually exclusive with base-uri. Must be an http(s) URL."`
+
+	// DisableGPGCheck disables GPG signature verification for this repo. The zero
+	// value (false) means GPG checking is *enabled* — the safe default. Setting
+	// this to true is an explicit opt-out and load-time validation requires either
+	// `disable-gpg-check = true` or a non-empty `gpg-key`.
+	DisableGPGCheck bool `toml:"disable-gpg-check,omitempty" json:"disableGpgCheck,omitempty" jsonschema:"title=Disable GPG check,description=Opt out of GPG signature verification for this repo (zero value = checking enabled)"`
+
+	// GPGKey is a path or URI to the GPG key used to verify signatures.
+	//
+	// Accepted forms:
+	//   * `https://...` or `http://...` URI: passed through verbatim to both consumers.
+	//   * `file:///absolute/path`: passed through verbatim. Note that mock evaluates this
+	//     *inside* the chroot, while kiwi evaluates it on the host. Prefer http(s)://
+	//     for portability across consumers.
+	//   * Bare path: resolved at TOML-load time relative to the directory containing the
+	//     defining TOML file, then emitted to consumers as a `file://` URI.
+	GPGKey string `toml:"gpg-key,omitempty" json:"gpgKey,omitempty" jsonschema:"pattern=^\\S+$,title=GPG key,description=Path or URI to the GPG key file. Accepted URI schemes: http\\, https\\, file. Bare paths are resolved relative to the defining TOML file."`
+
+	// Arches optionally restricts the repository to a specific list of target architectures
+	// (e.g., ["x86_64"]). When empty, the repository is available for all architectures.
+	Arches []string `toml:"arches,omitempty" json:"arches,omitempty" jsonschema:"title=Arches,description=Restrict to specific target architectures; empty = all"`
+}
+
+// EffectiveType returns the repository type, applying the rpm-md default when [RpmRepoResource.Type]
+// is unset.
+func (r *RpmRepoResource) EffectiveType() RpmRepoType {
+	if r.Type == "" {
+		return RpmRepoTypeRpmMd
+	}
+
+	return r.Type
+}
+
+// JSONSchemaExtend tightens the generated schema for an [RpmRepoResource] so that
+// editors can flag invalid TOML at edit time. Mirrors the runtime constraints in
+// [validateRpmRepo]:
+//
+//   - exactly one of `base-uri` / `metalink` must be set;
+//   - `gpg-key` must be a bare path or an `http://` / `https://` / `file://` URI.
+//
+// The runtime validator is the source of truth; this keeps the schema in sync.
+func (RpmRepoResource) JSONSchemaExtend(schema *jsonschema.Schema) {
+	// Exactly one of base-uri/metalink. Encoded as oneOf with `required` on each.
+	schema.OneOf = []*jsonschema.Schema{
+		{Required: []string{"base-uri"}, Not: &jsonschema.Schema{Required: []string{"metalink"}}},
+		{Required: []string{"metalink"}, Not: &jsonschema.Schema{Required: []string{"base-uri"}}},
+	}
+
+	// gpg-key: bare path OR http(s)/file URI. The struct tag pattern is just
+	// "no whitespace"; this tightens it to one of the supported shapes.
+	if schema.Properties != nil {
+		if gpg, ok := schema.Properties.Get("gpg-key"); ok && gpg != nil {
+			gpg.Pattern = `^((https?|file)://\S+|[^\s:]\S*)$`
+		}
+	}
+}
+
+// IsAvailableForArch reports whether the repository is available for the given target
+// architecture. A repository with no [RpmRepoResource.Arches] restriction is available
+// for all architectures.
+func (r *RpmRepoResource) IsAvailableForArch(arch string) bool {
+	if len(r.Arches) == 0 {
+		return true
+	}
+
+	for _, a := range r.Arches {
+		if a == arch {
+			return true
+		}
+	}
+
+	return false
+}
+
+// validateRpmRepo checks the structural validity of an [RpmRepoResource] in isolation.
+// Cross-resource and cross-section validation (e.g., that names referenced from
+// [DistroVersionDefinition.Inputs] resolve, or that bare gpg-key paths are not used
+// for rpm-build inputs) is performed elsewhere.
+func validateRpmRepo(name string, repo *RpmRepoResource) error {
+	if err := validateRpmRepoName(name); err != nil {
+		return err
+	}
+
+	if !repo.EffectiveType().IsValid() {
+		return fmt.Errorf("rpm-repo %#q has unsupported type %#q", name, repo.Type)
+	}
+
+	if err := validateNoUnsafeChars("rpm-repo", "description", name, repo.Description); err != nil {
+		return err
+	}
+
+	if err := validateRpmRepoSource(name, repo); err != nil {
+		return err
+	}
+
+	return validateRpmRepoGPG(name, repo)
+}
+
+// validateRpmRepoSource validates the source-defining fields of a repo (`base-uri`
+// and `metalink`) for the active [RpmRepoResource.EffectiveType].
+func validateRpmRepoSource(name string, repo *RpmRepoResource) error {
+	if repo.EffectiveType() == RpmRepoTypeRpmMd {
+		if repo.BaseURI == "" && repo.Metalink == "" {
+			return fmt.Errorf("rpm-repo %#q must specify exactly one of `base-uri` or `metalink`", name)
+		}
+
+		if repo.BaseURI != "" && repo.Metalink != "" {
+			return fmt.Errorf("rpm-repo %#q must not specify both `base-uri` and `metalink`", name)
+		}
+	}
+
+	if repo.BaseURI != "" {
+		if err := validateRemoteURI("rpm-repo", "base-uri", name, repo.BaseURI); err != nil {
+			return err
+		}
+	}
+
+	if repo.Metalink != "" {
+		if err := validateRemoteURI("rpm-repo", "metalink", name, repo.Metalink); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// validateRpmRepoGPG validates the GPG-related fields (`disable-gpg-check`, `gpg-key`).
+func validateRpmRepoGPG(name string, repo *RpmRepoResource) error {
+	if !repo.DisableGPGCheck && repo.GPGKey == "" {
+		return fmt.Errorf(
+			"rpm-repo %#q has GPG checking enabled (the default) but no `gpg-key`; "+
+				"either set `gpg-key = \"...\"` or opt out with `disable-gpg-check = true`",
+			name,
+		)
+	}
+
+	if repo.GPGKey != "" {
+		if err := validateGPGKey("rpm-repo", name, repo.GPGKey); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// rpmRepoNameRE is the canonical grammar for repo IDs. Conservative: must start with an
+// alphanumeric, then a mix of [A-Za-z0-9_.:-]. This is a strict subset of what dnf/kiwi
+// accept, but keeps generated config files (dnf section headers, kiwi comma-delimited
+// arguments) unambiguous and free of escaping concerns.
+var rpmRepoNameRE = regexp.MustCompile(`^[A-Za-z0-9][A-Za-z0-9_.:-]*$`)
+
+// URI scheme constants used by the validators.
+const (
+	schemeHTTP  = "http"
+	schemeHTTPS = "https"
+	schemeFile  = "file"
+)
+
+func validateRpmRepoName(name string) error {
+	if name == "" {
+		return errors.New("rpm-repo name must not be empty")
+	}
+
+	if !rpmRepoNameRE.MatchString(name) {
+		return fmt.Errorf(
+			"rpm-repo name %#q is invalid; must match %s "+
+				"(repo names are projected verbatim into dnf section headers and kiwi --add-repo arguments)",
+			name, rpmRepoNameRE.String(),
+		)
+	}
+
+	return nil
+}
+
+// validateNoUnsafeChars rejects values containing characters that, if projected into
+// generated dnf/kiwi/python config, would corrupt the surrounding syntax. This is a
+// defense-in-depth check: even for trusted TOML sources, unsanitized newlines or NUL
+// bytes here produce baffling downstream failures.
+func validateNoUnsafeChars(objKind, field, name, value string) error {
+	for byteIndex, char := range value {
+		switch char {
+		case '\r', '\n':
+			return fmt.Errorf(
+				"%s %#q `%s` must be a single line (no embedded CR/LF at byte %d)",
+				objKind, name, field, byteIndex)
+		case 0:
+			return fmt.Errorf(
+				"%s %#q `%s` must not contain NUL bytes (at byte %d)",
+				objKind, name, field, byteIndex)
+		case '\u2028', '\u2029':
+			return fmt.Errorf(
+				"%s %#q `%s` must not contain Unicode line separators (at byte %d)",
+				objKind, name, field, byteIndex)
+		}
+	}
+
+	return nil
+}
+
+// validateRemoteURI ensures a base-uri/metalink value is a syntactically valid URI with
+// an http or https scheme. Local schemes (file://) are deliberately disallowed for the
+// repo source: kiwi.AddRemoteRepo only handles remote URIs, and supporting file:// here
+// would require split-by-consumer staging that we don't do today.
+//
+// Also rejects opaque (non-hierarchical) URIs like `https:example.com` (no `//`) and
+// requires a non-empty `Host`, so the value is always something downstream tools will
+// recognize as `http(s)://...`.
+func validateRemoteURI(objKind, field, name, raw string) error {
+	if err := validateNoUnsafeChars(objKind, field, name, raw); err != nil {
+		return err
+	}
+
+	parsed, err := url.Parse(raw)
+	if err != nil {
+		return fmt.Errorf("%s %#q `%s` is not a valid URI:\n%w", objKind, name, field, err)
+	}
+
+	switch strings.ToLower(parsed.Scheme) {
+	case "":
+		return fmt.Errorf("%s %#q `%s` is missing a scheme (expected an http or https URL)", objKind, name, field)
+	case schemeHTTP, schemeHTTPS:
+		// fall through to hierarchical-form checks below.
+	default:
+		return fmt.Errorf(
+			"%s %#q `%s` uses unsupported scheme %q; only http and https are accepted",
+			objKind, name, field, parsed.Scheme,
+		)
+	}
+
+	if parsed.Opaque != "" {
+		return fmt.Errorf(
+			"%s %#q `%s` must use the `scheme://host/path` form (got opaque URI %q)",
+			objKind, name, field, raw,
+		)
+	}
+
+	if parsed.Host == "" {
+		return fmt.Errorf("%s %#q `%s` must include a host (got %q)", objKind, name, field, raw)
+	}
+
+	return nil
+}
+
+// validateGPGKey checks the in-isolation form of a `gpg-key` value. A bare path is
+// allowed at this stage (resolved to an absolute file:// URI by [WithAbsolutePaths]);
+// rejection of bare paths for rpm-build consumers happens in
+// [validateDistroVersionInputs], not here.
+//
+// For URI-shaped values, the supported schemes are `http`, `https`, and `file`. We
+// require hierarchical (`scheme://...`) forms — opaque URIs like `file:relative` or
+// `https:example.com` are rejected since they wouldn't behave the way callers expect.
+// `http(s)` requires a non-empty `Host`; `file` requires an empty `Host` and an absolute
+// `Path` (so it really is a `file:///abs/path` reference rather than e.g.
+// `file://server/share`).
+func validateGPGKey(objKind, name, raw string) error {
+	if err := validateNoUnsafeChars(objKind, "gpg-key", name, raw); err != nil {
+		return err
+	}
+
+	if !hasURIScheme(raw) {
+		// Bare path; will be resolved relative to the defining TOML directory.
+		return nil
+	}
+
+	parsed, err := url.Parse(raw)
+	if err != nil {
+		return fmt.Errorf("%s %#q `gpg-key` is not a valid URI:\n%w", objKind, name, err)
+	}
+
+	scheme := strings.ToLower(parsed.Scheme)
+	switch scheme {
+	case schemeHTTP, schemeHTTPS, schemeFile:
+		// fall through to per-scheme shape checks.
+	default:
+		return fmt.Errorf(
+			"%s %#q `gpg-key` uses unsupported scheme %q; expected http, https, or file",
+			objKind, name, parsed.Scheme,
+		)
+	}
+
+	if parsed.Opaque != "" {
+		return fmt.Errorf(
+			"%s %#q `gpg-key` must use the `scheme://...` form (got opaque URI %q)",
+			objKind, name, raw,
+		)
+	}
+
+	switch scheme {
+	case schemeHTTP, schemeHTTPS:
+		if parsed.Host == "" {
+			return fmt.Errorf("%s %#q `gpg-key` must include a host (got %q)", objKind, name, raw)
+		}
+	case schemeFile:
+		if parsed.Host != "" {
+			return fmt.Errorf(
+				"%s %#q `gpg-key` must be of the form `file:///absolute/path` (got host %q in %q)",
+				objKind, name, parsed.Host, raw,
+			)
+		}
+
+		if !filepath.IsAbs(parsed.Path) {
+			return fmt.Errorf(
+				"%s %#q `gpg-key` must be an absolute `file://` path (got %q)",
+				objKind, name, raw,
+			)
+		}
+	}
+
+	return nil
+}
+
+// IsLocalGPGKey reports whether the repo's gpg-key (if any) refers to a local filesystem
+// path (either bare or via a `file://` URI). This is the form that does NOT work for
+// rpm-build (mock) consumers because mock evaluates the URI inside the chroot.
+func (r *RpmRepoResource) IsLocalGPGKey() bool {
+	if r.GPGKey == "" {
+		return false
+	}
+
+	if !hasURIScheme(r.GPGKey) {
+		return true
+	}
+
+	parsed, err := url.Parse(r.GPGKey)
+	if err != nil {
+		return false
+	}
+
+	return strings.EqualFold(parsed.Scheme, schemeFile)
+}
+
+// WithAbsolutePaths returns a copy of the ResourcesConfig with relative path-shaped
+// fields (currently only `gpg-key`) resolved relative to referenceDir and re-emitted
+// as absolute `file://` URIs. URI-shaped fields are returned unchanged.
+//
+// This runs at TOML load time, so the consumers (mock / kiwi) only ever see absolute
+// references — no working-directory ambiguity at run time.
+func (r *ResourcesConfig) WithAbsolutePaths(referenceDir string) *ResourcesConfig {
+	if r == nil {
+		return nil
+	}
+
+	result := deep.MustCopy(r)
+
+	for name, repo := range result.RpmRepos {
+		if repo.GPGKey != "" {
+			repo.GPGKey = absolutizeKeyPath(repo.GPGKey, referenceDir)
+			result.RpmRepos[name] = repo
+		}
+	}
+
+	for name, set := range result.RpmRepoSets {
+		if set.GPGKey != "" {
+			set.GPGKey = absolutizeKeyPath(set.GPGKey, referenceDir)
+			result.RpmRepoSets[name] = set
+		}
+	}
+
+	return result
+}
+
+// absolutizeKeyPath resolves a TOML-supplied gpg-key value to a portable form.
+// URI-shaped values (with a scheme) are returned unchanged. Bare paths are joined
+// against referenceDir (when not already absolute) and emitted as `file://` URIs.
+func absolutizeKeyPath(key, referenceDir string) string {
+	if hasURIScheme(key) {
+		return key
+	}
+
+	abs := key
+	if !filepath.IsAbs(abs) {
+		abs = filepath.Join(referenceDir, abs)
+	}
+
+	abs = filepath.Clean(abs)
+
+	return (&url.URL{Scheme: schemeFile, Path: abs}).String()
+}
+
+// hasURIScheme reports whether s starts with "<alpha>[<alphanumeric>+-.]*:".
+// Cheap and dependency-free; we don't need full RFC 3986 here.
+func hasURIScheme(s string) bool {
+	for i, char := range s {
+		if i == 0 {
+			if (char < 'a' || char > 'z') && (char < 'A' || char > 'Z') {
+				return false
+			}
+
+			continue
+		}
+
+		switch {
+		case char >= 'a' && char <= 'z',
+			char >= 'A' && char <= 'Z',
+			char >= '0' && char <= '9',
+			char == '+', char == '-', char == '.':
+			continue
+		case char == ':':
+			return true
+		default:
+			return false
+		}
+	}
+
+	return false
+}
+
+// SubrepoKind classifies a sub-repo within an [RpmRepoSetTemplate] by the type
+// of RPMs it carries. Consumers (and authors of allowlist filters) use the kind
+// when reasoning about a sub-repo's role in a build.
+type SubrepoKind string
+
+const (
+	// SubrepoKindBinary identifies a sub-repo carrying ordinary binary RPMs.
+	// This is the default when [SubrepoSpec.Kind] is unset.
+	SubrepoKindBinary SubrepoKind = "binary"
+	// SubrepoKindDebug identifies a sub-repo carrying debuginfo / debugsource RPMs.
+	SubrepoKindDebug SubrepoKind = "debug"
+	// SubrepoKindSource identifies a sub-repo carrying source RPMs (SRPMs).
+	SubrepoKindSource SubrepoKind = "source"
+)
+
+// IsValid reports whether the given SubrepoKind is one this loader understands.
+func (k SubrepoKind) IsValid() bool {
+	switch k {
+	case "", SubrepoKindBinary, SubrepoKindDebug, SubrepoKindSource:
+		return true
+	default:
+		return false
+	}
+}
+
+// Default returns the kind, defaulting to [SubrepoKindBinary] when unset.
+func (k SubrepoKind) Default() SubrepoKind {
+	if k == "" {
+		return SubrepoKindBinary
+	}
+
+	return k
+}
+
+// SubrepoSpec describes one sub-repo entry within an [RpmRepoSetTemplate]. The
+// `subpath` is appended to a [RpmRepoSet]'s `base-uri` to form the synthesized
+// repo's `base-uri`. `$basearch` (and any other dnf-side variables) are passed
+// through verbatim and expanded by the consuming tool.
+type SubrepoSpec struct {
+	// Name is a stable short identifier for this sub-repo within the template
+	// (e.g., "base", "base-debug"). Combined with the [RpmRepoSet]'s
+	// `name-prefix` it forms the synthesized repo's ID, so it must satisfy the
+	// same grammar as [RpmRepoResource] names.
+	Name string `toml:"name" json:"name" jsonschema:"required,title=Name,description=Stable short identifier; combined with the set's name-prefix to form the repo ID"`
+
+	// Subpath is the relative path (under the set's base URI) that hosts the
+	// sub-repo's repodata. May contain dnf-side variables such as `$basearch`,
+	// which are passed through verbatim.
+	Subpath string `toml:"subpath" json:"subpath" jsonschema:"required,title=Sub-path,description=Relative path under the set's base URI; may contain $basearch"`
+
+	// Kind classifies the sub-repo (binary, debug, source). Defaults to "binary".
+	// Authors of [RpmRepoSet] entries can filter by kind only indirectly, by
+	// listing specific sub-repo names in `subrepos`.
+	Kind SubrepoKind `toml:"kind,omitempty" json:"kind,omitempty" jsonschema:"title=Kind,description=Sub-repo classification; defaults to binary,enum=binary,enum=debug,enum=source"`
+}
+
+// RpmRepoSetTemplate is a named layout that describes a fixed set of sub-repos
+// hosted under a common URL prefix. Templates are reusable across deployments;
+// pair a template with a [RpmRepoSet] to produce a concrete bundle of repos.
+type RpmRepoSetTemplate struct {
+	// Description is a human-readable description of the layout (diagnostic only).
+	Description string `toml:"description,omitempty" json:"description,omitempty" jsonschema:"title=Description,description=Human-readable description (diagnostic only)"`
+
+	// Subrepos is the ordered list of sub-repo entries that make up the layout.
+	Subrepos []SubrepoSpec `toml:"subrepos" json:"subrepos" jsonschema:"required,title=Sub-repos,description=Ordered list of sub-repos in the layout"`
+}
+
+// RpmRepoSet instantiates an [RpmRepoSetTemplate] for a specific deployment by
+// supplying a base URI and shared GPG configuration. At validation time each set
+// expands into one synthesized [RpmRepoResource] per included sub-repo, keyed by
+// `<name-prefix><subrepo.name>`.
+type RpmRepoSet struct {
+	// Description is a human-readable description (diagnostic only).
+	Description string `toml:"description,omitempty" json:"description,omitempty" jsonschema:"title=Description,description=Human-readable description (diagnostic only)"`
+
+	// Template is the name of the [RpmRepoSetTemplate] to instantiate. Must
+	// resolve to a defined template at validation time.
+	Template string `toml:"template" json:"template" jsonschema:"required,title=Template,description=Name of the rpm-repo-set-template to instantiate"`
+
+	// BaseURI is the URL prefix under which all sub-repos for this deployment
+	// live. The synthesized repo's `base-uri` is `BaseURI/<subrepo.subpath>`.
+	BaseURI string `toml:"base-uri" json:"baseUri" jsonschema:"required,format=uri,pattern=^https?://[^\\s]+$,title=Base URI,description=URL prefix under which all sub-repos in this set live"`
+
+	// NamePrefix is prepended to each sub-repo's `name` to form the synthesized
+	// repo ID. May be empty, in which case bare sub-repo names are used (only
+	// safe when no other set or explicit repo collides with those names).
+	NamePrefix string `toml:"name-prefix,omitempty" json:"namePrefix,omitempty" jsonschema:"title=Name prefix,description=Prepended to each sub-repo's name to form the repo ID"`
+
+	// GPGKey is the shared GPG key for sub-repos in this set; same shape rules
+	// as [RpmRepoResource.GPGKey] apply.
+	GPGKey string `toml:"gpg-key,omitempty" json:"gpgKey,omitempty" jsonschema:"pattern=^\\S+$,title=GPG key,description=Path or URI to the GPG key file. Accepted URI schemes: http\\, https\\, file. Bare paths are resolved relative to the defining TOML file."`
+
+	// DisableGPGCheck opts out of GPG signature verification for sub-repos in
+	// this set; same default semantics as [RpmRepoResource.DisableGPGCheck].
+	DisableGPGCheck bool `toml:"disable-gpg-check,omitempty" json:"disableGpgCheck,omitempty" jsonschema:"title=Disable GPG check,description=Opt out of GPG signature verification for repos in this set"`
+
+	// Arches optionally restricts every synthesized repo in this set to a
+	// specific list of target architectures. Empty = all.
+	Arches []string `toml:"arches,omitempty" json:"arches,omitempty" jsonschema:"title=Arches,description=Restrict to specific target architectures; empty = all"`
+
+	// Subrepos is an optional allowlist of sub-repo names from the referenced
+	// template to instantiate. When unset (or empty), every sub-repo in the
+	// template is instantiated. When non-empty, only the listed sub-repos are
+	// instantiated. Listed names must match a sub-repo declared in the
+	// referenced template.
+	Subrepos []string `toml:"subrepos,omitempty" json:"subrepos,omitempty" jsonschema:"title=Sub-repos,description=Allowlist of template sub-repos to instantiate (default: all)"`
+}
+
+// EffectiveRpmRepos returns the union of explicitly-defined [RpmRepoResource]
+// entries and the entries synthesized by expanding each [RpmRepoSet]. Conflicts
+// are reported as errors.
+//
+// Path-typed inputs (e.g. relative `gpg-key` values) must already be absolutized
+// before calling this method — that happens during config load/merge via
+// [WithAbsolutePaths]. This method itself only joins each set's `base-uri` with
+// each sub-repo's `subpath` and validates the result; it does not resolve any
+// remaining relative paths.
+//
+// Validation rules applied during expansion:
+//   - Every set's `template` must resolve to a defined [RpmRepoSetTemplate].
+//   - Every name in `subrepos` (the set's allowlist) must match a sub-repo in
+//     the referenced template.
+//   - Synthesized repo IDs (`<name-prefix><subrepo.name>`) must satisfy the
+//     same grammar as explicit repo names, and must not collide with explicit
+//     [RpmRepoResource] entries or with other sets' expansions.
+//   - The set's `base-uri` must be an http(s) URL; sub-repo subpaths must be
+//     relative (no leading `/`, no `..` segments).
+func (r *ResourcesConfig) EffectiveRpmRepos() (map[string]RpmRepoResource, error) {
+	if r == nil {
+		return map[string]RpmRepoResource{}, nil
+	}
+
+	effective := make(map[string]RpmRepoResource, len(r.RpmRepos))
+
+	for name, repo := range r.RpmRepos {
+		effective[name] = repo
+	}
+
+	// Stable expansion order for deterministic error reporting.
+	setNames := make([]string, 0, len(r.RpmRepoSets))
+	for name := range r.RpmRepoSets {
+		setNames = append(setNames, name)
+	}
+
+	sort.Strings(setNames)
+
+	for _, setName := range setNames {
+		set := r.RpmRepoSets[setName]
+
+		expanded, err := expandRpmRepoSet(setName, &set, r.RpmRepoSetTemplates)
+		if err != nil {
+			return nil, err
+		}
+
+		for _, entry := range expanded {
+			if _, ok := effective[entry.Name]; ok {
+				return nil, fmt.Errorf(
+					"rpm-repo-set %#q expansion produced repo name %#q which already exists "+
+						"(either as an explicit entry under `[resources.rpm-repos]` or from "+
+						"another set's expansion); choose a different `name-prefix` or rename "+
+						"the colliding entry",
+					setName, entry.Name,
+				)
+			}
+
+			effective[entry.Name] = entry.Repo
+		}
+	}
+
+	return effective, nil
+}
+
+// expandedRepo is one entry in a [RpmRepoSet] expansion. The slice form preserves
+// the template's declared sub-repo order, which both gives deterministic output and
+// avoids a second template lookup at the call sites that need it.
+type expandedRepo struct {
+	Name string
+	Repo RpmRepoResource
+}
+
+// expandRpmRepoSet expands a single [RpmRepoSet] into its synthesized
+// [RpmRepoResource] entries in template-declared order.
+func expandRpmRepoSet(
+	setName string, set *RpmRepoSet, templates map[string]RpmRepoSetTemplate,
+) ([]expandedRepo, error) {
+	if err := validateRpmRepoSet(setName, set); err != nil {
+		return nil, err
+	}
+
+	tmpl, ok := templates[set.Template]
+	if !ok {
+		return nil, fmt.Errorf(
+			"rpm-repo-set %#q references undefined `template` %#q; "+
+				"define a matching key under `[resources.rpm-repo-set-templates]`",
+			setName, set.Template,
+		)
+	}
+
+	allowlist, err := buildSubrepoAllowlist(setName, set, &tmpl)
+	if err != nil {
+		return nil, err
+	}
+
+	out := make([]expandedRepo, 0, len(tmpl.Subrepos))
+
+	for i := range tmpl.Subrepos {
+		sub := &tmpl.Subrepos[i]
+
+		if allowlist != nil {
+			if _, ok := allowlist[sub.Name]; !ok {
+				continue
+			}
+		}
+
+		baseURI, err := joinSetBaseURI(setName, set.BaseURI, sub.Subpath)
+		if err != nil {
+			return nil, err
+		}
+
+		repoID := set.NamePrefix + sub.Name
+		if err := validateRpmRepoName(repoID); err != nil {
+			return nil, fmt.Errorf(
+				"rpm-repo-set %#q would synthesize an invalid repo ID %#q "+
+					"(combining `name-prefix` %#q with sub-repo name %#q):\n%w",
+				setName, repoID, set.NamePrefix, sub.Name, err,
+			)
+		}
+
+		out = append(out, expandedRepo{
+			Name: repoID,
+			Repo: RpmRepoResource{
+				Description:     expandedDescription(set, sub),
+				Type:            RpmRepoTypeRpmMd,
+				BaseURI:         baseURI,
+				DisableGPGCheck: set.DisableGPGCheck,
+				GPGKey:          set.GPGKey,
+				Arches:          append([]string(nil), set.Arches...),
+			},
+		})
+	}
+
+	return out, nil
+}
+
+// expandedDescription preserves the user-supplied set description (if any) and
+// annotates it with the originating set/subrepo for diagnostics.
+func expandedDescription(set *RpmRepoSet, sub *SubrepoSpec) string {
+	if set.Description != "" {
+		return fmt.Sprintf("%s — subrepo %q (kind=%s)", set.Description, sub.Name, sub.Kind.Default())
+	}
+
+	return fmt.Sprintf("expanded from rpm-repo-set, subrepo %q (kind=%s)", sub.Name, sub.Kind.Default())
+}
+
+// buildSubrepoAllowlist resolves the set's optional `subrepos` allowlist into a
+// lookup keyed by sub-repo name. Returns (nil, nil) when the allowlist is unset
+// or empty (= include every sub-repo from the template).
+func buildSubrepoAllowlist(
+	setName string, set *RpmRepoSet, tmpl *RpmRepoSetTemplate,
+) (map[string]struct{}, error) {
+	if len(set.Subrepos) == 0 {
+		return nil, nil //nolint:nilnil // nil = "no allowlist"
+	}
+
+	known := make(map[string]struct{}, len(tmpl.Subrepos))
+	for i := range tmpl.Subrepos {
+		known[tmpl.Subrepos[i].Name] = struct{}{}
+	}
+
+	allowlist := make(map[string]struct{}, len(set.Subrepos))
+
+	for _, name := range set.Subrepos {
+		if _, ok := known[name]; !ok {
+			return nil, fmt.Errorf(
+				"rpm-repo-set %#q `subrepos` allowlist references %#q "+
+					"which is not a sub-repo of template %#q",
+				setName, name, set.Template,
+			)
+		}
+
+		if _, dup := allowlist[name]; dup {
+			return nil, fmt.Errorf(
+				"rpm-repo-set %#q `subrepos` allowlist lists %#q more than once",
+				setName, name,
+			)
+		}
+
+		allowlist[name] = struct{}{}
+	}
+
+	return allowlist, nil
+}
+
+// joinSetBaseURI joins a set's base-uri with a sub-repo's subpath, validating
+// that the subpath is relative and well-formed and that the base-uri carries no
+// query string or fragment (which would otherwise produce a syntactically
+// invalid URL when path segments were appended).
+func joinSetBaseURI(setName, baseURI, subpath string) (string, error) {
+	if subpath == "" {
+		return "", fmt.Errorf("rpm-repo-set %#q template has an empty `subpath`", setName)
+	}
+
+	if strings.HasPrefix(subpath, "/") {
+		return "", fmt.Errorf(
+			"rpm-repo-set %#q template `subpath` %#q must be relative (no leading slash)",
+			setName, subpath,
+		)
+	}
+
+	for _, segment := range strings.Split(subpath, "/") {
+		if segment == ".." {
+			return "", fmt.Errorf(
+				"rpm-repo-set %#q template `subpath` %#q must not contain `..` segments",
+				setName, subpath,
+			)
+		}
+	}
+
+	parsed, err := url.Parse(baseURI)
+	if err != nil {
+		return "", fmt.Errorf("rpm-repo-set %#q `base-uri` is not a valid URI:\n%w", setName, err)
+	}
+
+	if parsed.RawQuery != "" || parsed.Fragment != "" {
+		return "", fmt.Errorf(
+			"rpm-repo-set %#q `base-uri` must not contain a query string or fragment (got %q)",
+			setName, baseURI,
+		)
+	}
+
+	return strings.TrimRight(baseURI, "/") + "/" + subpath, nil
+}
+
+// validateRpmRepoSet performs structural validation of a single set definition
+// (independent of whether the referenced template exists).
+func validateRpmRepoSet(name string, set *RpmRepoSet) error {
+	if set.Template == "" {
+		return fmt.Errorf("rpm-repo-set %#q is missing `template`", name)
+	}
+
+	if set.BaseURI == "" {
+		return fmt.Errorf("rpm-repo-set %#q is missing `base-uri`", name)
+	}
+
+	if err := validateRemoteURI("rpm-repo-set", "base-uri", name, set.BaseURI); err != nil {
+		return err
+	}
+
+	// Each synthesized repo ID (`name-prefix + sub.Name`) is validated against
+	// the repo-name grammar in [expandRpmRepoSet] when the set actually expands;
+	// no per-prefix structural check here is correct or strict enough on its own.
+
+	if !set.DisableGPGCheck && set.GPGKey == "" {
+		return fmt.Errorf(
+			"rpm-repo-set %#q has GPG checking enabled (the default) but no `gpg-key`; "+
+				"either set `gpg-key = \"...\"` or opt out with `disable-gpg-check = true`",
+			name,
+		)
+	}
+
+	if set.GPGKey != "" {
+		if err := validateGPGKey("rpm-repo-set", name, set.GPGKey); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// validateRpmRepoSetTemplate performs structural validation of a single template.
+func validateRpmRepoSetTemplate(name string, tmpl *RpmRepoSetTemplate) error {
+	if len(tmpl.Subrepos) == 0 {
+		return fmt.Errorf("rpm-repo-set-template %#q must define at least one entry in `subrepos`", name)
+	}
+
+	seen := make(map[string]bool, len(tmpl.Subrepos))
+
+	for i := range tmpl.Subrepos {
+		sub := &tmpl.Subrepos[i]
+
+		if err := validateRpmRepoName(sub.Name); err != nil {
+			return fmt.Errorf("rpm-repo-set-template %#q sub-repo %d:\n%w", name, i, err)
+		}
+
+		if seen[sub.Name] {
+			return fmt.Errorf(
+				"rpm-repo-set-template %#q has duplicate sub-repo name %#q", name, sub.Name,
+			)
+		}
+
+		seen[sub.Name] = true
+
+		if !sub.Kind.IsValid() {
+			return fmt.Errorf(
+				"rpm-repo-set-template %#q sub-repo %#q has invalid `kind` %#q "+
+					"(expected one of: binary, debug, source)",
+				name, sub.Name, sub.Kind,
+			)
+		}
+
+		if sub.Subpath == "" {
+			return fmt.Errorf(
+				"rpm-repo-set-template %#q sub-repo %#q is missing `subpath`",
+				name, sub.Name,
+			)
+		}
+
+		if strings.HasPrefix(sub.Subpath, "/") {
+			return fmt.Errorf(
+				"rpm-repo-set-template %#q sub-repo %#q `subpath` must be relative (no leading slash)",
+				name, sub.Name,
+			)
+		}
+
+		if err := validateNoUnsafeChars("rpm-repo-set-template", "subpath", sub.Name, sub.Subpath); err != nil {
+			return fmt.Errorf("rpm-repo-set-template %#q:\n%w", name, err)
+		}
+	}
+
+	return nil
+}
+
+// EffectiveRpmBuildRepos returns the deduplicated, ordered list of effective
+// repo names exposed to the rpm-build use-case for this distro version. The
+// `inputs.rpm-build` list is processed entry-by-entry in declaration order:
+// `repo` entries contribute their name, `set` entries expand into the names of
+// every sub-repo the set instantiates. Duplicates across the resulting list
+// (whether two direct repos with the same name or a direct repo named the same
+// as a set's expansion) are reported as errors so that consumers do not have
+// to dedupe.
+//
+// This method does NOT verify that direct `repo = "..."` entries reference an
+// existing [RpmRepoResource]; doing so requires a fully-built effective repo
+// map (the union of `[resources.rpm-repos]` and every set's expansion), which
+// is constructed once at the project level. Cross-reference validation against
+// [ResourcesConfig.EffectiveRpmRepos] happens in [ProjectConfig.Validate] via
+// validateDistroVersionInputs.
+func (v DistroVersionDefinition) EffectiveRpmBuildRepos(resources *ResourcesConfig) ([]string, error) {
+	return effectiveInputRepos("rpm-build", v.Inputs.RpmBuild, resources)
+}
+
+// EffectiveImageBuildRepos returns the deduplicated, ordered list of effective
+// repo names exposed to the image-build use-case for this distro version. Same
+// semantics as [DistroVersionDefinition.EffectiveRpmBuildRepos].
+func (v DistroVersionDefinition) EffectiveImageBuildRepos(resources *ResourcesConfig) ([]string, error) {
+	return effectiveInputRepos("image-build", v.Inputs.ImageBuild, resources)
+}
+
+func effectiveInputRepos(
+	useCase string, inputs []DistroVersionInput, resources *ResourcesConfig,
+) ([]string, error) {
+	out := make([]string, 0, len(inputs))
+	seen := make(map[string]bool, cap(out))
+
+	emit := func(repoName, source string) error {
+		if seen[repoName] {
+			return fmt.Errorf(
+				"`inputs.%s` produces repo %#q more than once (most recently from %s); "+
+					"remove the duplicate to disambiguate",
+				useCase, repoName, source,
+			)
+		}
+
+		seen[repoName] = true
+		out = append(out, repoName)
+
+		return nil
+	}
+
+	for idx, entry := range inputs {
+		// Report indices as 1-based in error messages so they line up with how
+		// users count TOML list entries.
+		entryNum := idx + 1
+
+		if err := validateDistroVersionInput(useCase, entryNum, &entry); err != nil {
+			return nil, err
+		}
+
+		switch {
+		case entry.Repo != "":
+			if err := emit(entry.Repo, fmt.Sprintf("repo %#q", entry.Repo)); err != nil {
+				return nil, err
+			}
+
+		case entry.Set != "":
+			if resources == nil {
+				return nil, fmt.Errorf(
+					"`inputs.%s` entry %d references rpm-repo-set %#q but no [resources] section is defined",
+					useCase, entryNum, entry.Set,
+				)
+			}
+
+			set, ok := resources.RpmRepoSets[entry.Set]
+			if !ok {
+				return nil, fmt.Errorf(
+					"`inputs.%s` entry %d references undefined rpm-repo-set %#q", useCase, entryNum, entry.Set,
+				)
+			}
+
+			expanded, err := expandRpmRepoSet(entry.Set, &set, resources.RpmRepoSetTemplates)
+			if err != nil {
+				return nil, err
+			}
+
+			for _, exp := range expanded {
+				if err := emit(exp.Name, fmt.Sprintf("set %#q", entry.Set)); err != nil {
+					return nil, err
+				}
+			}
+		}
+	}
+
+	return out, nil
+}
+
+// validateDistroVersionInput rejects entries that set neither or both of `repo`
+// and `set`. The TOML schema cannot express XOR cleanly, so we enforce it here.
+// `entryNum` is reported verbatim in error messages and should be 1-based.
+func validateDistroVersionInput(useCase string, entryNum int, entry *DistroVersionInput) error {
+	hasRepo := entry.Repo != ""
+	hasSet := entry.Set != ""
+
+	switch {
+	case !hasRepo && !hasSet:
+		return fmt.Errorf(
+			"`inputs.%s` entry %d sets neither `repo` nor `set`; exactly one is required",
+			useCase, entryNum,
+		)
+	case hasRepo && hasSet:
+		return fmt.Errorf(
+			"`inputs.%s` entry %d sets both `repo` (%#q) and `set` (%#q); exactly one is required",
+			useCase, entryNum, entry.Repo, entry.Set,
+		)
+	}
+
+	return nil
+}

--- a/internal/projectconfig/resources.go
+++ b/internal/projectconfig/resources.go
@@ -237,14 +237,11 @@ func (r *RpmRepoResource) IsAvailableForArch(arch string) bool {
 }
 
 // validateRpmRepo checks the structural validity of an [RpmRepoResource] in isolation.
-// Cross-resource and cross-section validation (e.g., that names referenced from
+// The map key (repo name) is validated by the caller via [validateRpmRepoName];
+// cross-resource and cross-section validation (e.g., that names referenced from
 // [DistroVersionDefinition.Inputs] resolve, or that bare gpg-key paths are not used
 // for rpm-build inputs) is performed elsewhere.
 func validateRpmRepo(name string, repo *RpmRepoResource) error {
-	if err := validateRpmRepoName(name); err != nil {
-		return err
-	}
-
 	if !repo.EffectiveType().IsValid() {
 		return fmt.Errorf("rpm-repo %#q has unsupported type %#q", name, repo.Type)
 	}

--- a/internal/projectconfig/resources_internal_test.go
+++ b/internal/projectconfig/resources_internal_test.go
@@ -1,0 +1,503 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+package projectconfig
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestValidateRpmRepo(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name    string
+		repo    RpmRepoResource
+		wantErr string // substring; empty = expect no error
+	}{
+		{
+			name:    "ok base-uri with disable-gpg-check",
+			repo:    RpmRepoResource{BaseURI: "https://x/", DisableGPGCheck: true},
+			wantErr: "",
+		},
+		{
+			name:    "ok base-uri with gpg-key",
+			repo:    RpmRepoResource{BaseURI: "https://x/", GPGKey: "https://x/key"},
+			wantErr: "",
+		},
+		{
+			name:    "ok metalink",
+			repo:    RpmRepoResource{Metalink: "https://x/ml", DisableGPGCheck: true},
+			wantErr: "",
+		},
+		{
+			name:    "missing source",
+			repo:    RpmRepoResource{DisableGPGCheck: true},
+			wantErr: "exactly one of `base-uri` or `metalink`",
+		},
+		{
+			name:    "both base-uri and metalink",
+			repo:    RpmRepoResource{BaseURI: "https://x/", Metalink: "https://x/ml", DisableGPGCheck: true},
+			wantErr: "must not specify both",
+		},
+		{
+			name:    "gpg-check enabled with no key",
+			repo:    RpmRepoResource{BaseURI: "https://x/"},
+			wantErr: "GPG checking enabled",
+		},
+		{
+			name:    "newline in description",
+			repo:    RpmRepoResource{BaseURI: "https://x/", DisableGPGCheck: true, Description: "a\nb"},
+			wantErr: "single line",
+		},
+		{
+			name:    "unsupported type",
+			repo:    RpmRepoResource{Type: "weird", BaseURI: "https://x/", DisableGPGCheck: true},
+			wantErr: "unsupported type",
+		},
+		{
+			name:    "opaque base-uri rejected",
+			repo:    RpmRepoResource{BaseURI: "https:example.com", DisableGPGCheck: true},
+			wantErr: "opaque URI",
+		},
+		{
+			name:    "base-uri with empty host rejected",
+			repo:    RpmRepoResource{BaseURI: "https:///path", DisableGPGCheck: true},
+			wantErr: "must include a host",
+		},
+		{
+			name:    "opaque metalink rejected",
+			repo:    RpmRepoResource{Metalink: "https:example.com/ml", DisableGPGCheck: true},
+			wantErr: "opaque URI",
+		},
+		{
+			name:    "opaque gpg-key https rejected",
+			repo:    RpmRepoResource{BaseURI: "https://x/", GPGKey: "https:example.com/key"},
+			wantErr: "opaque URI",
+		},
+		{
+			name:    "opaque gpg-key file rejected",
+			repo:    RpmRepoResource{BaseURI: "https://x/", GPGKey: "file:relative.gpg"},
+			wantErr: "opaque URI",
+		},
+		{
+			name:    "file gpg-key with host rejected",
+			repo:    RpmRepoResource{BaseURI: "https://x/", GPGKey: "file://server/share/key.gpg"},
+			wantErr: "file:///absolute/path",
+		},
+		{
+			name:    "https gpg-key with no host rejected",
+			repo:    RpmRepoResource{BaseURI: "https://x/", GPGKey: "https:///path/key.gpg"},
+			wantErr: "must include a host",
+		},
+	}
+
+	for _, testCase := range cases {
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+
+			err := validateRpmRepo("test", &testCase.repo)
+			if testCase.wantErr == "" {
+				assert.NoError(t, err)
+			} else {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), testCase.wantErr)
+			}
+		})
+	}
+}
+
+func TestWithAbsolutePaths_GPGKey(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{name: "https passthrough", in: "https://example.com/key", want: "https://example.com/key"},
+		{name: "file uri passthrough", in: "file:///etc/pki/key", want: "file:///etc/pki/key"},
+		{name: "bare relative", in: "keys/local.gpg", want: "file:///ref/keys/local.gpg"},
+		{name: "bare absolute", in: "/etc/pki/key", want: "file:///etc/pki/key"},
+	}
+
+	for _, testCase := range cases {
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+
+			cfg := &ResourcesConfig{
+				RpmRepos: map[string]RpmRepoResource{
+					"r": {BaseURI: "https://x/", GPGKey: testCase.in},
+				},
+			}
+			got := cfg.WithAbsolutePaths("/ref")
+			assert.Equal(t, testCase.want, got.RpmRepos["r"].GPGKey)
+			// Original must be untouched (deep copy semantics).
+			assert.Equal(t, testCase.in, cfg.RpmRepos["r"].GPGKey)
+		})
+	}
+}
+
+func TestMergeUpdatesFrom_WholesaleReplace(t *testing.T) {
+	t.Parallel()
+
+	earlier := &ResourcesConfig{
+		RpmRepos: map[string]RpmRepoResource{
+			"r": {BaseURI: "https://old/", DisableGPGCheck: true, Description: "old"},
+		},
+	}
+	later := &ResourcesConfig{
+		RpmRepos: map[string]RpmRepoResource{
+			// disable-gpg-check is the zero value; must still take effect.
+			"r":  {BaseURI: "https://new/", GPGKey: "https://new/key"},
+			"r2": {BaseURI: "https://r2/", DisableGPGCheck: true},
+		},
+	}
+
+	require.NoError(t, earlier.MergeUpdatesFrom(later))
+
+	got := earlier.RpmRepos["r"]
+	assert.Equal(t, "https://new/", got.BaseURI)
+	assert.False(t, got.DisableGPGCheck, "zero value must override true")
+	assert.Empty(t, got.Description, "wholesale replace must drop old description")
+	assert.Equal(t, "https://new/key", got.GPGKey)
+	// New entry preserved.
+	assert.Equal(t, "https://r2/", earlier.RpmRepos["r2"].BaseURI)
+}
+
+func TestMergeUpdatesFrom_NilOther(t *testing.T) {
+	t.Parallel()
+
+	cfg := &ResourcesConfig{}
+	require.NoError(t, cfg.MergeUpdatesFrom(nil))
+	assert.Empty(t, cfg.RpmRepos)
+}
+
+func TestRpmRepoResource_IsAvailableForArch(t *testing.T) {
+	t.Parallel()
+
+	repo := RpmRepoResource{}
+	assert.True(t, repo.IsAvailableForArch("x86_64"))
+	assert.True(t, repo.IsAvailableForArch("aarch64"))
+
+	repo.Arches = []string{"x86_64"}
+	assert.True(t, repo.IsAvailableForArch("x86_64"))
+	assert.False(t, repo.IsAvailableForArch("aarch64"))
+}
+
+func TestHasURIScheme(t *testing.T) {
+	t.Parallel()
+
+	cases := map[string]bool{
+		"https://x":     true,
+		"file:///x":     true,
+		"foo+bar.baz:x": true,
+		"/abs/path":     false,
+		"rel/path":      false,
+		"":              false,
+		":nope":         false,
+		"1abc:nope":     false, // must start with alpha
+	}
+
+	for in, want := range cases {
+		got := hasURIScheme(in)
+		assert.Equalf(t, want, got, "hasURIScheme(%q)", in)
+	}
+}
+
+// Sanity-check that the rendered TOML field tags match documented schema names
+// (these are what users type in TOML files).
+func TestRpmRepoResource_TOMLFieldNames(t *testing.T) {
+	t.Parallel()
+
+	typ := reflect.TypeOf(RpmRepoResource{})
+
+	cases := map[string]string{
+		"BaseURI":         "base-uri,omitempty",
+		"DisableGPGCheck": "disable-gpg-check,omitempty",
+		"GPGKey":          "gpg-key,omitempty",
+		"Metalink":        "metalink,omitempty",
+	}
+
+	for fieldName, wantTag := range cases {
+		f, ok := typ.FieldByName(fieldName)
+		require.True(t, ok, "missing field %s", fieldName)
+		assert.Equal(t, wantTag, f.Tag.Get("toml"), "field %s", fieldName)
+	}
+}
+
+func TestEffectiveRpmRepos_ExpandSets(t *testing.T) {
+	t.Parallel()
+
+	cfg := &ResourcesConfig{
+		RpmRepoSetTemplates: map[string]RpmRepoSetTemplate{
+			"azl-standard": {
+				Subrepos: []SubrepoSpec{
+					{Name: "base", Kind: SubrepoKindBinary, Subpath: "base/$basearch"},
+					{Name: "base-debug", Kind: SubrepoKindDebug, Subpath: "base/debuginfo/$basearch"},
+					{Name: "base-src", Kind: SubrepoKindSource, Subpath: "base/srpms"},
+					{Name: "sdk", Kind: SubrepoKindBinary, Subpath: "sdk/$basearch"},
+					{Name: "sdk-debug", Kind: SubrepoKindDebug, Subpath: "sdk/debuginfo/$basearch"},
+					{Name: "sdk-src", Kind: SubrepoKindSource, Subpath: "sdk/srpms"},
+				},
+			},
+		},
+		RpmRepoSets: map[string]RpmRepoSet{
+			"azl4": {
+				Template:        "azl-standard",
+				BaseURI:         "https://example.com/azl4",
+				NamePrefix:      "azl4-",
+				DisableGPGCheck: true,
+				// Allowlist: take only the binary + source channels (drop debug).
+				Subrepos: []string{"base", "base-src", "sdk", "sdk-src"},
+			},
+		},
+	}
+
+	effective, err := cfg.EffectiveRpmRepos()
+	require.NoError(t, err)
+
+	assert.Len(t, effective, 4)
+	assert.Equal(t, "https://example.com/azl4/base/$basearch", effective["azl4-base"].BaseURI)
+	assert.Equal(t, "https://example.com/azl4/base/srpms", effective["azl4-base-src"].BaseURI)
+	assert.Equal(t, "https://example.com/azl4/sdk/$basearch", effective["azl4-sdk"].BaseURI)
+	assert.NotContains(t, effective, "azl4-base-debug")
+	assert.NotContains(t, effective, "azl4-sdk-debug")
+}
+
+func TestEffectiveRpmRepos_DefaultIncludesAllSubrepos(t *testing.T) {
+	t.Parallel()
+
+	cfg := &ResourcesConfig{
+		RpmRepoSetTemplates: map[string]RpmRepoSetTemplate{
+			"t": {
+				Subrepos: []SubrepoSpec{
+					{Name: "a", Subpath: "a"},
+					{Name: "b", Subpath: "b"},
+					{Name: "c", Subpath: "c"},
+				},
+			},
+		},
+		RpmRepoSets: map[string]RpmRepoSet{
+			"s": {Template: "t", BaseURI: "https://x/", NamePrefix: "s-", DisableGPGCheck: true},
+		},
+	}
+
+	effective, err := cfg.EffectiveRpmRepos()
+	require.NoError(t, err)
+	assert.Len(t, effective, 3)
+	assert.Contains(t, effective, "s-a")
+	assert.Contains(t, effective, "s-b")
+	assert.Contains(t, effective, "s-c")
+}
+
+func TestEffectiveRpmRepos_SubreposAllowlist(t *testing.T) {
+	t.Parallel()
+
+	cfg := &ResourcesConfig{
+		RpmRepoSetTemplates: map[string]RpmRepoSetTemplate{
+			"t": {
+				Subrepos: []SubrepoSpec{
+					{Name: "a", Subpath: "a"},
+					{Name: "b", Subpath: "b"},
+					{Name: "c", Subpath: "c"},
+				},
+			},
+		},
+		RpmRepoSets: map[string]RpmRepoSet{
+			"s": {
+				Template:        "t",
+				BaseURI:         "https://x/",
+				NamePrefix:      "s-",
+				DisableGPGCheck: true,
+				Subrepos:        []string{"a", "c"},
+			},
+		},
+	}
+
+	effective, err := cfg.EffectiveRpmRepos()
+	require.NoError(t, err)
+	assert.Len(t, effective, 2)
+	assert.Contains(t, effective, "s-a")
+	assert.Contains(t, effective, "s-c")
+	assert.NotContains(t, effective, "s-b")
+}
+
+func TestEffectiveRpmRepos_CollisionWithExplicit(t *testing.T) {
+	t.Parallel()
+
+	cfg := &ResourcesConfig{
+		RpmRepos: map[string]RpmRepoResource{
+			"s-a": {BaseURI: "https://other/", DisableGPGCheck: true},
+		},
+		RpmRepoSetTemplates: map[string]RpmRepoSetTemplate{
+			"t": {Subrepos: []SubrepoSpec{{Name: "a", Subpath: "a"}}},
+		},
+		RpmRepoSets: map[string]RpmRepoSet{
+			"s": {Template: "t", BaseURI: "https://x/", NamePrefix: "s-", DisableGPGCheck: true},
+		},
+	}
+
+	_, err := cfg.EffectiveRpmRepos()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "already exists")
+}
+
+func TestEffectiveRpmRepos_UndefinedTemplate(t *testing.T) {
+	t.Parallel()
+
+	cfg := &ResourcesConfig{
+		RpmRepoSets: map[string]RpmRepoSet{
+			"s": {Template: "missing", BaseURI: "https://x/", DisableGPGCheck: true},
+		},
+	}
+
+	_, err := cfg.EffectiveRpmRepos()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "undefined `template`")
+}
+
+func TestEffectiveRpmRepos_BadAllowlist(t *testing.T) {
+	t.Parallel()
+
+	cfg := &ResourcesConfig{
+		RpmRepoSetTemplates: map[string]RpmRepoSetTemplate{
+			"t": {Subrepos: []SubrepoSpec{{Name: "a", Subpath: "a"}}},
+		},
+		RpmRepoSets: map[string]RpmRepoSet{
+			"s": {
+				Template: "t", BaseURI: "https://x/", DisableGPGCheck: true,
+				Subrepos: []string{"nonesuch"},
+			},
+		},
+	}
+
+	_, err := cfg.EffectiveRpmRepos()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "subrepos")
+}
+
+func TestEffectiveRpmRepos_RejectsInvalidSynthesizedID(t *testing.T) {
+	t.Parallel()
+
+	cfg := &ResourcesConfig{
+		RpmRepoSetTemplates: map[string]RpmRepoSetTemplate{
+			"t": {Subrepos: []SubrepoSpec{{Name: "a", Subpath: "a"}}},
+		},
+		RpmRepoSets: map[string]RpmRepoSet{
+			"s": {
+				Template:        "t",
+				BaseURI:         "https://x/",
+				NamePrefix:      "-bad",
+				DisableGPGCheck: true,
+			},
+		},
+	}
+
+	_, err := cfg.EffectiveRpmRepos()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid repo ID")
+}
+
+func TestJoinSetBaseURI(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		base, sub, want, err string
+	}{
+		{base: "https://x", sub: "a/b", want: "https://x/a/b"},
+		{base: "https://x/", sub: "a/b", want: "https://x/a/b"},
+		{base: "https://x/", sub: "/abs", err: "relative"},
+		{base: "https://x/", sub: "../escape", err: ".."},
+		{base: "https://x/", sub: "", err: "empty"},
+		{base: "https://x?token=1", sub: "a", err: "query string or fragment"},
+		{base: "https://x#frag", sub: "a", err: "query string or fragment"},
+	}
+
+	for _, testCase := range cases {
+		got, err := joinSetBaseURI("s", testCase.base, testCase.sub)
+		if testCase.err == "" {
+			require.NoError(t, err, testCase.sub)
+			assert.Equal(t, testCase.want, got)
+		} else {
+			require.Error(t, err, testCase.sub)
+			assert.Contains(t, err.Error(), testCase.err)
+		}
+	}
+}
+
+func TestEffectiveInputRepos_ExpandsAndDedupes(t *testing.T) {
+	t.Parallel()
+
+	resources := &ResourcesConfig{
+		RpmRepos: map[string]RpmRepoResource{
+			"explicit": {BaseURI: "https://e/", DisableGPGCheck: true},
+		},
+		RpmRepoSetTemplates: map[string]RpmRepoSetTemplate{
+			"t": {
+				Subrepos: []SubrepoSpec{
+					{Name: "binary", Subpath: "main/$basearch"},
+					{Name: "src", Kind: SubrepoKindSource, Subpath: "src"},
+				},
+			},
+		},
+		RpmRepoSets: map[string]RpmRepoSet{
+			"s": {Template: "t", BaseURI: "https://x/", NamePrefix: "s-", DisableGPGCheck: true},
+		},
+	}
+
+	version := &DistroVersionDefinition{
+		Inputs: DistroVersionInputs{
+			RpmBuild: []DistroVersionInput{
+				{Repo: "explicit"},
+				{Set: "s"},
+			},
+		},
+	}
+
+	got, err := version.EffectiveRpmBuildRepos(resources)
+	require.NoError(t, err)
+	assert.Equal(t, []string{"explicit", "s-binary", "s-src"}, got)
+
+	// Introduce a duplicate (direct repo whose name matches a set's expansion).
+	version.Inputs.RpmBuild = []DistroVersionInput{
+		{Repo: "s-binary"},
+		{Set: "s"},
+	}
+	_, err = version.EffectiveRpmBuildRepos(resources)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "more than once")
+}
+
+func TestEffectiveInputRepos_RejectsAmbiguousEntry(t *testing.T) {
+	t.Parallel()
+
+	resources := &ResourcesConfig{}
+
+	cases := []struct {
+		name  string
+		entry DistroVersionInput
+		want  string
+	}{
+		{name: "both repo and set", entry: DistroVersionInput{Repo: "r", Set: "s"}, want: "exactly one"},
+		{name: "neither repo nor set", entry: DistroVersionInput{}, want: "exactly one"},
+	}
+
+	for _, testCase := range cases {
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+
+			version := &DistroVersionDefinition{
+				Inputs: DistroVersionInputs{RpmBuild: []DistroVersionInput{testCase.entry}},
+			}
+
+			_, err := version.EffectiveRpmBuildRepos(resources)
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), testCase.want)
+		})
+	}
+}

--- a/internal/projectconfig/resources_internal_test.go
+++ b/internal/projectconfig/resources_internal_test.go
@@ -158,7 +158,7 @@ func TestMergeUpdatesFrom_WholesaleReplace(t *testing.T) {
 		},
 	}
 
-	require.NoError(t, earlier.MergeUpdatesFrom(later))
+	earlier.MergeUpdatesFrom(later)
 
 	got := earlier.RpmRepos["r"]
 	assert.Equal(t, "https://new/", got.BaseURI)
@@ -173,7 +173,7 @@ func TestMergeUpdatesFrom_NilOther(t *testing.T) {
 	t.Parallel()
 
 	cfg := &ResourcesConfig{}
-	require.NoError(t, cfg.MergeUpdatesFrom(nil))
+	cfg.MergeUpdatesFrom(nil)
 	assert.Empty(t, cfg.RpmRepos)
 }
 
@@ -416,6 +416,8 @@ func TestJoinSetBaseURI(t *testing.T) {
 		{base: "https://x/", sub: "", err: "empty"},
 		{base: "https://x?token=1", sub: "a", err: "query string or fragment"},
 		{base: "https://x#frag", sub: "a", err: "query string or fragment"},
+		{base: "https://x/", sub: "a?token=1", err: "query string or fragment"},
+		{base: "https://x/", sub: "a#frag", err: "query string or fragment"},
 	}
 
 	for _, testCase := range cases {

--- a/scenario/__snapshots__/TestSnapshotsContainer_config_generate-schema_stdout_1.snap
+++ b/scenario/__snapshots__/TestSnapshotsContainer_config_generate-schema_stdout_1.snap
@@ -344,6 +344,11 @@
           "title": "Distros",
           "description": "Definitions of distros to build for or consume from"
         },
+        "resources": {
+          "$ref": "#/$defs/ResourcesConfig",
+          "title": "Resources",
+          "description": "Reusable named resource definitions"
+        },
         "component-groups": {
           "additionalProperties": {
             "$ref": "#/$defs/ComponentGroupConfig"
@@ -513,6 +518,11 @@
           "type": "string",
           "title": "Mock config file",
           "description": "Path to the aarch64 mock config file for this version"
+        },
+        "inputs": {
+          "$ref": "#/$defs/DistroVersionInputs",
+          "title": "Inputs",
+          "description": "Per-use-case input repositories"
         }
       },
       "additionalProperties": false,
@@ -520,6 +530,44 @@
       "required": [
         "release-ver"
       ]
+    },
+    "DistroVersionInput": {
+      "properties": {
+        "repo": {
+          "type": "string",
+          "title": "Repo",
+          "description": "Name of an entry under [resources.rpm-repos]; mutually exclusive with set"
+        },
+        "set": {
+          "type": "string",
+          "title": "Set",
+          "description": "Name of an entry under [resources.rpm-repo-sets]; mutually exclusive with repo"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object"
+    },
+    "DistroVersionInputs": {
+      "properties": {
+        "rpm-build": {
+          "items": {
+            "$ref": "#/$defs/DistroVersionInput"
+          },
+          "type": "array",
+          "title": "RPM-build inputs",
+          "description": "Repos and repo-sets made available to mock when building RPMs"
+        },
+        "image-build": {
+          "items": {
+            "$ref": "#/$defs/DistroVersionInput"
+          },
+          "type": "array",
+          "title": "Image-build inputs",
+          "description": "Repos and repo-sets made available to kiwi when building images"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object"
     },
     "ImageCapabilities": {
       "properties": {
@@ -846,6 +894,206 @@
       "additionalProperties": false,
       "type": "object"
     },
+    "ResourcesConfig": {
+      "properties": {
+        "rpm-repos": {
+          "additionalProperties": {
+            "$ref": "#/$defs/RpmRepoResource"
+          },
+          "propertyNames": {
+            "type": "string",
+            "pattern": "^[A-Za-z0-9][A-Za-z0-9_.:-]*$",
+            "description": "Name; projected verbatim into dnf section headers and kiwi --add-repo arguments."
+          },
+          "type": "object",
+          "title": "RPM repositories",
+          "description": "Reusable named RPM repository definitions"
+        },
+        "rpm-repo-set-templates": {
+          "additionalProperties": {
+            "$ref": "#/$defs/RpmRepoSetTemplate"
+          },
+          "propertyNames": {
+            "type": "string",
+            "pattern": "^[A-Za-z0-9][A-Za-z0-9_.:-]*$",
+            "description": "Name; projected verbatim into dnf section headers and kiwi --add-repo arguments."
+          },
+          "type": "object",
+          "title": "RPM repo set templates",
+          "description": "Named layout templates that describe a fixed matrix of sub-repos"
+        },
+        "rpm-repo-sets": {
+          "additionalProperties": {
+            "$ref": "#/$defs/RpmRepoSet"
+          },
+          "propertyNames": {
+            "type": "string",
+            "pattern": "^[A-Za-z0-9][A-Za-z0-9_.:-]*$",
+            "description": "Name; projected verbatim into dnf section headers and kiwi --add-repo arguments."
+          },
+          "type": "object",
+          "title": "RPM repo sets",
+          "description": "Template instantiations that expand to a group of related RPM repos"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object"
+    },
+    "RpmRepoResource": {
+      "oneOf": [
+        {
+          "not": {
+            "required": [
+              "metalink"
+            ]
+          },
+          "required": [
+            "base-uri"
+          ]
+        },
+        {
+          "not": {
+            "required": [
+              "base-uri"
+            ]
+          },
+          "required": [
+            "metalink"
+          ]
+        }
+      ],
+      "properties": {
+        "description": {
+          "type": "string",
+          "title": "Description",
+          "description": "Human-readable description (diagnostic only)"
+        },
+        "type": {
+          "type": "string",
+          "enum": [
+            "rpm-md"
+          ],
+          "title": "Type",
+          "description": "Repository access protocol; defaults to rpm-md"
+        },
+        "base-uri": {
+          "type": "string",
+          "pattern": "^https?://[^\\s]+$",
+          "format": "uri",
+          "title": "Base URI",
+          "description": "Repository base URI (dnf baseurl). Mutually exclusive with metalink. Must be an http(s) URL."
+        },
+        "metalink": {
+          "type": "string",
+          "pattern": "^https?://[^\\s]+$",
+          "format": "uri",
+          "title": "Metalink",
+          "description": "Repository metalink URL. Mutually exclusive with base-uri. Must be an http(s) URL."
+        },
+        "disable-gpg-check": {
+          "type": "boolean",
+          "title": "Disable GPG check",
+          "description": "Opt out of GPG signature verification for this repo (zero value = checking enabled)"
+        },
+        "gpg-key": {
+          "type": "string",
+          "pattern": "^((https?|file)://\\S+|[^\\s:]\\S*)$",
+          "title": "GPG key",
+          "description": "Path or URI to the GPG key file. Accepted URI schemes: http, https, file. Bare paths are resolved relative to the defining TOML file."
+        },
+        "arches": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array",
+          "title": "Arches",
+          "description": "Restrict to specific target architectures; empty = all"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object"
+    },
+    "RpmRepoSet": {
+      "properties": {
+        "description": {
+          "type": "string",
+          "title": "Description",
+          "description": "Human-readable description (diagnostic only)"
+        },
+        "template": {
+          "type": "string",
+          "title": "Template",
+          "description": "Name of the rpm-repo-set-template to instantiate"
+        },
+        "base-uri": {
+          "type": "string",
+          "pattern": "^https?://[^\\s]+$",
+          "format": "uri",
+          "title": "Base URI",
+          "description": "URL prefix under which all sub-repos in this set live"
+        },
+        "name-prefix": {
+          "type": "string",
+          "title": "Name prefix",
+          "description": "Prepended to each sub-repo's name to form the repo ID"
+        },
+        "gpg-key": {
+          "type": "string",
+          "pattern": "^\\S+$",
+          "title": "GPG key",
+          "description": "Path or URI to the GPG key file. Accepted URI schemes: http, https, file. Bare paths are resolved relative to the defining TOML file."
+        },
+        "disable-gpg-check": {
+          "type": "boolean",
+          "title": "Disable GPG check",
+          "description": "Opt out of GPG signature verification for repos in this set"
+        },
+        "arches": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array",
+          "title": "Arches",
+          "description": "Restrict to specific target architectures; empty = all"
+        },
+        "subrepos": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array",
+          "title": "Sub-repos",
+          "description": "Allowlist of template sub-repos to instantiate (default: all)"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "template",
+        "base-uri"
+      ]
+    },
+    "RpmRepoSetTemplate": {
+      "properties": {
+        "description": {
+          "type": "string",
+          "title": "Description",
+          "description": "Human-readable description (diagnostic only)"
+        },
+        "subrepos": {
+          "items": {
+            "$ref": "#/$defs/SubrepoSpec"
+          },
+          "type": "array",
+          "title": "Sub-repos",
+          "description": "Ordered list of sub-repos in the layout"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "subrepos"
+      ]
+    },
     "SourceFileReference": {
       "properties": {
         "filename": {
@@ -932,6 +1180,36 @@
       "type": "object",
       "required": [
         "type"
+      ]
+    },
+    "SubrepoSpec": {
+      "properties": {
+        "name": {
+          "type": "string",
+          "title": "Name",
+          "description": "Stable short identifier; combined with the set's name-prefix to form the repo ID"
+        },
+        "subpath": {
+          "type": "string",
+          "title": "Sub-path",
+          "description": "Relative path under the set's base URI; may contain $basearch"
+        },
+        "kind": {
+          "type": "string",
+          "enum": [
+            "binary",
+            "debug",
+            "source"
+          ],
+          "title": "Kind",
+          "description": "Sub-repo classification; defaults to binary"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "name",
+        "subpath"
       ]
     },
     "TestSuiteConfig": {

--- a/scenario/__snapshots__/TestSnapshots_config_generate-schema_stdout_1.snap
+++ b/scenario/__snapshots__/TestSnapshots_config_generate-schema_stdout_1.snap
@@ -344,6 +344,11 @@
           "title": "Distros",
           "description": "Definitions of distros to build for or consume from"
         },
+        "resources": {
+          "$ref": "#/$defs/ResourcesConfig",
+          "title": "Resources",
+          "description": "Reusable named resource definitions"
+        },
         "component-groups": {
           "additionalProperties": {
             "$ref": "#/$defs/ComponentGroupConfig"
@@ -513,6 +518,11 @@
           "type": "string",
           "title": "Mock config file",
           "description": "Path to the aarch64 mock config file for this version"
+        },
+        "inputs": {
+          "$ref": "#/$defs/DistroVersionInputs",
+          "title": "Inputs",
+          "description": "Per-use-case input repositories"
         }
       },
       "additionalProperties": false,
@@ -520,6 +530,44 @@
       "required": [
         "release-ver"
       ]
+    },
+    "DistroVersionInput": {
+      "properties": {
+        "repo": {
+          "type": "string",
+          "title": "Repo",
+          "description": "Name of an entry under [resources.rpm-repos]; mutually exclusive with set"
+        },
+        "set": {
+          "type": "string",
+          "title": "Set",
+          "description": "Name of an entry under [resources.rpm-repo-sets]; mutually exclusive with repo"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object"
+    },
+    "DistroVersionInputs": {
+      "properties": {
+        "rpm-build": {
+          "items": {
+            "$ref": "#/$defs/DistroVersionInput"
+          },
+          "type": "array",
+          "title": "RPM-build inputs",
+          "description": "Repos and repo-sets made available to mock when building RPMs"
+        },
+        "image-build": {
+          "items": {
+            "$ref": "#/$defs/DistroVersionInput"
+          },
+          "type": "array",
+          "title": "Image-build inputs",
+          "description": "Repos and repo-sets made available to kiwi when building images"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object"
     },
     "ImageCapabilities": {
       "properties": {
@@ -846,6 +894,206 @@
       "additionalProperties": false,
       "type": "object"
     },
+    "ResourcesConfig": {
+      "properties": {
+        "rpm-repos": {
+          "additionalProperties": {
+            "$ref": "#/$defs/RpmRepoResource"
+          },
+          "propertyNames": {
+            "type": "string",
+            "pattern": "^[A-Za-z0-9][A-Za-z0-9_.:-]*$",
+            "description": "Name; projected verbatim into dnf section headers and kiwi --add-repo arguments."
+          },
+          "type": "object",
+          "title": "RPM repositories",
+          "description": "Reusable named RPM repository definitions"
+        },
+        "rpm-repo-set-templates": {
+          "additionalProperties": {
+            "$ref": "#/$defs/RpmRepoSetTemplate"
+          },
+          "propertyNames": {
+            "type": "string",
+            "pattern": "^[A-Za-z0-9][A-Za-z0-9_.:-]*$",
+            "description": "Name; projected verbatim into dnf section headers and kiwi --add-repo arguments."
+          },
+          "type": "object",
+          "title": "RPM repo set templates",
+          "description": "Named layout templates that describe a fixed matrix of sub-repos"
+        },
+        "rpm-repo-sets": {
+          "additionalProperties": {
+            "$ref": "#/$defs/RpmRepoSet"
+          },
+          "propertyNames": {
+            "type": "string",
+            "pattern": "^[A-Za-z0-9][A-Za-z0-9_.:-]*$",
+            "description": "Name; projected verbatim into dnf section headers and kiwi --add-repo arguments."
+          },
+          "type": "object",
+          "title": "RPM repo sets",
+          "description": "Template instantiations that expand to a group of related RPM repos"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object"
+    },
+    "RpmRepoResource": {
+      "oneOf": [
+        {
+          "not": {
+            "required": [
+              "metalink"
+            ]
+          },
+          "required": [
+            "base-uri"
+          ]
+        },
+        {
+          "not": {
+            "required": [
+              "base-uri"
+            ]
+          },
+          "required": [
+            "metalink"
+          ]
+        }
+      ],
+      "properties": {
+        "description": {
+          "type": "string",
+          "title": "Description",
+          "description": "Human-readable description (diagnostic only)"
+        },
+        "type": {
+          "type": "string",
+          "enum": [
+            "rpm-md"
+          ],
+          "title": "Type",
+          "description": "Repository access protocol; defaults to rpm-md"
+        },
+        "base-uri": {
+          "type": "string",
+          "pattern": "^https?://[^\\s]+$",
+          "format": "uri",
+          "title": "Base URI",
+          "description": "Repository base URI (dnf baseurl). Mutually exclusive with metalink. Must be an http(s) URL."
+        },
+        "metalink": {
+          "type": "string",
+          "pattern": "^https?://[^\\s]+$",
+          "format": "uri",
+          "title": "Metalink",
+          "description": "Repository metalink URL. Mutually exclusive with base-uri. Must be an http(s) URL."
+        },
+        "disable-gpg-check": {
+          "type": "boolean",
+          "title": "Disable GPG check",
+          "description": "Opt out of GPG signature verification for this repo (zero value = checking enabled)"
+        },
+        "gpg-key": {
+          "type": "string",
+          "pattern": "^((https?|file)://\\S+|[^\\s:]\\S*)$",
+          "title": "GPG key",
+          "description": "Path or URI to the GPG key file. Accepted URI schemes: http, https, file. Bare paths are resolved relative to the defining TOML file."
+        },
+        "arches": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array",
+          "title": "Arches",
+          "description": "Restrict to specific target architectures; empty = all"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object"
+    },
+    "RpmRepoSet": {
+      "properties": {
+        "description": {
+          "type": "string",
+          "title": "Description",
+          "description": "Human-readable description (diagnostic only)"
+        },
+        "template": {
+          "type": "string",
+          "title": "Template",
+          "description": "Name of the rpm-repo-set-template to instantiate"
+        },
+        "base-uri": {
+          "type": "string",
+          "pattern": "^https?://[^\\s]+$",
+          "format": "uri",
+          "title": "Base URI",
+          "description": "URL prefix under which all sub-repos in this set live"
+        },
+        "name-prefix": {
+          "type": "string",
+          "title": "Name prefix",
+          "description": "Prepended to each sub-repo's name to form the repo ID"
+        },
+        "gpg-key": {
+          "type": "string",
+          "pattern": "^\\S+$",
+          "title": "GPG key",
+          "description": "Path or URI to the GPG key file. Accepted URI schemes: http, https, file. Bare paths are resolved relative to the defining TOML file."
+        },
+        "disable-gpg-check": {
+          "type": "boolean",
+          "title": "Disable GPG check",
+          "description": "Opt out of GPG signature verification for repos in this set"
+        },
+        "arches": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array",
+          "title": "Arches",
+          "description": "Restrict to specific target architectures; empty = all"
+        },
+        "subrepos": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array",
+          "title": "Sub-repos",
+          "description": "Allowlist of template sub-repos to instantiate (default: all)"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "template",
+        "base-uri"
+      ]
+    },
+    "RpmRepoSetTemplate": {
+      "properties": {
+        "description": {
+          "type": "string",
+          "title": "Description",
+          "description": "Human-readable description (diagnostic only)"
+        },
+        "subrepos": {
+          "items": {
+            "$ref": "#/$defs/SubrepoSpec"
+          },
+          "type": "array",
+          "title": "Sub-repos",
+          "description": "Ordered list of sub-repos in the layout"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "subrepos"
+      ]
+    },
     "SourceFileReference": {
       "properties": {
         "filename": {
@@ -932,6 +1180,36 @@
       "type": "object",
       "required": [
         "type"
+      ]
+    },
+    "SubrepoSpec": {
+      "properties": {
+        "name": {
+          "type": "string",
+          "title": "Name",
+          "description": "Stable short identifier; combined with the set's name-prefix to form the repo ID"
+        },
+        "subpath": {
+          "type": "string",
+          "title": "Sub-path",
+          "description": "Relative path under the set's base URI; may contain $basearch"
+        },
+        "kind": {
+          "type": "string",
+          "enum": [
+            "binary",
+            "debug",
+            "source"
+          ],
+          "title": "Kind",
+          "description": "Sub-repo classification; defaults to binary"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "name",
+        "subpath"
       ]
     },
     "TestSuiteConfig": {

--- a/schemas/azldev.schema.json
+++ b/schemas/azldev.schema.json
@@ -344,6 +344,11 @@
           "title": "Distros",
           "description": "Definitions of distros to build for or consume from"
         },
+        "resources": {
+          "$ref": "#/$defs/ResourcesConfig",
+          "title": "Resources",
+          "description": "Reusable named resource definitions"
+        },
         "component-groups": {
           "additionalProperties": {
             "$ref": "#/$defs/ComponentGroupConfig"
@@ -513,6 +518,11 @@
           "type": "string",
           "title": "Mock config file",
           "description": "Path to the aarch64 mock config file for this version"
+        },
+        "inputs": {
+          "$ref": "#/$defs/DistroVersionInputs",
+          "title": "Inputs",
+          "description": "Per-use-case input repositories"
         }
       },
       "additionalProperties": false,
@@ -520,6 +530,44 @@
       "required": [
         "release-ver"
       ]
+    },
+    "DistroVersionInput": {
+      "properties": {
+        "repo": {
+          "type": "string",
+          "title": "Repo",
+          "description": "Name of an entry under [resources.rpm-repos]; mutually exclusive with set"
+        },
+        "set": {
+          "type": "string",
+          "title": "Set",
+          "description": "Name of an entry under [resources.rpm-repo-sets]; mutually exclusive with repo"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object"
+    },
+    "DistroVersionInputs": {
+      "properties": {
+        "rpm-build": {
+          "items": {
+            "$ref": "#/$defs/DistroVersionInput"
+          },
+          "type": "array",
+          "title": "RPM-build inputs",
+          "description": "Repos and repo-sets made available to mock when building RPMs"
+        },
+        "image-build": {
+          "items": {
+            "$ref": "#/$defs/DistroVersionInput"
+          },
+          "type": "array",
+          "title": "Image-build inputs",
+          "description": "Repos and repo-sets made available to kiwi when building images"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object"
     },
     "ImageCapabilities": {
       "properties": {
@@ -846,6 +894,206 @@
       "additionalProperties": false,
       "type": "object"
     },
+    "ResourcesConfig": {
+      "properties": {
+        "rpm-repos": {
+          "additionalProperties": {
+            "$ref": "#/$defs/RpmRepoResource"
+          },
+          "propertyNames": {
+            "type": "string",
+            "pattern": "^[A-Za-z0-9][A-Za-z0-9_.:-]*$",
+            "description": "Name; projected verbatim into dnf section headers and kiwi --add-repo arguments."
+          },
+          "type": "object",
+          "title": "RPM repositories",
+          "description": "Reusable named RPM repository definitions"
+        },
+        "rpm-repo-set-templates": {
+          "additionalProperties": {
+            "$ref": "#/$defs/RpmRepoSetTemplate"
+          },
+          "propertyNames": {
+            "type": "string",
+            "pattern": "^[A-Za-z0-9][A-Za-z0-9_.:-]*$",
+            "description": "Name; projected verbatim into dnf section headers and kiwi --add-repo arguments."
+          },
+          "type": "object",
+          "title": "RPM repo set templates",
+          "description": "Named layout templates that describe a fixed matrix of sub-repos"
+        },
+        "rpm-repo-sets": {
+          "additionalProperties": {
+            "$ref": "#/$defs/RpmRepoSet"
+          },
+          "propertyNames": {
+            "type": "string",
+            "pattern": "^[A-Za-z0-9][A-Za-z0-9_.:-]*$",
+            "description": "Name; projected verbatim into dnf section headers and kiwi --add-repo arguments."
+          },
+          "type": "object",
+          "title": "RPM repo sets",
+          "description": "Template instantiations that expand to a group of related RPM repos"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object"
+    },
+    "RpmRepoResource": {
+      "oneOf": [
+        {
+          "not": {
+            "required": [
+              "metalink"
+            ]
+          },
+          "required": [
+            "base-uri"
+          ]
+        },
+        {
+          "not": {
+            "required": [
+              "base-uri"
+            ]
+          },
+          "required": [
+            "metalink"
+          ]
+        }
+      ],
+      "properties": {
+        "description": {
+          "type": "string",
+          "title": "Description",
+          "description": "Human-readable description (diagnostic only)"
+        },
+        "type": {
+          "type": "string",
+          "enum": [
+            "rpm-md"
+          ],
+          "title": "Type",
+          "description": "Repository access protocol; defaults to rpm-md"
+        },
+        "base-uri": {
+          "type": "string",
+          "pattern": "^https?://[^\\s]+$",
+          "format": "uri",
+          "title": "Base URI",
+          "description": "Repository base URI (dnf baseurl). Mutually exclusive with metalink. Must be an http(s) URL."
+        },
+        "metalink": {
+          "type": "string",
+          "pattern": "^https?://[^\\s]+$",
+          "format": "uri",
+          "title": "Metalink",
+          "description": "Repository metalink URL. Mutually exclusive with base-uri. Must be an http(s) URL."
+        },
+        "disable-gpg-check": {
+          "type": "boolean",
+          "title": "Disable GPG check",
+          "description": "Opt out of GPG signature verification for this repo (zero value = checking enabled)"
+        },
+        "gpg-key": {
+          "type": "string",
+          "pattern": "^((https?|file)://\\S+|[^\\s:]\\S*)$",
+          "title": "GPG key",
+          "description": "Path or URI to the GPG key file. Accepted URI schemes: http, https, file. Bare paths are resolved relative to the defining TOML file."
+        },
+        "arches": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array",
+          "title": "Arches",
+          "description": "Restrict to specific target architectures; empty = all"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object"
+    },
+    "RpmRepoSet": {
+      "properties": {
+        "description": {
+          "type": "string",
+          "title": "Description",
+          "description": "Human-readable description (diagnostic only)"
+        },
+        "template": {
+          "type": "string",
+          "title": "Template",
+          "description": "Name of the rpm-repo-set-template to instantiate"
+        },
+        "base-uri": {
+          "type": "string",
+          "pattern": "^https?://[^\\s]+$",
+          "format": "uri",
+          "title": "Base URI",
+          "description": "URL prefix under which all sub-repos in this set live"
+        },
+        "name-prefix": {
+          "type": "string",
+          "title": "Name prefix",
+          "description": "Prepended to each sub-repo's name to form the repo ID"
+        },
+        "gpg-key": {
+          "type": "string",
+          "pattern": "^\\S+$",
+          "title": "GPG key",
+          "description": "Path or URI to the GPG key file. Accepted URI schemes: http, https, file. Bare paths are resolved relative to the defining TOML file."
+        },
+        "disable-gpg-check": {
+          "type": "boolean",
+          "title": "Disable GPG check",
+          "description": "Opt out of GPG signature verification for repos in this set"
+        },
+        "arches": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array",
+          "title": "Arches",
+          "description": "Restrict to specific target architectures; empty = all"
+        },
+        "subrepos": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array",
+          "title": "Sub-repos",
+          "description": "Allowlist of template sub-repos to instantiate (default: all)"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "template",
+        "base-uri"
+      ]
+    },
+    "RpmRepoSetTemplate": {
+      "properties": {
+        "description": {
+          "type": "string",
+          "title": "Description",
+          "description": "Human-readable description (diagnostic only)"
+        },
+        "subrepos": {
+          "items": {
+            "$ref": "#/$defs/SubrepoSpec"
+          },
+          "type": "array",
+          "title": "Sub-repos",
+          "description": "Ordered list of sub-repos in the layout"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "subrepos"
+      ]
+    },
     "SourceFileReference": {
       "properties": {
         "filename": {
@@ -932,6 +1180,36 @@
       "type": "object",
       "required": [
         "type"
+      ]
+    },
+    "SubrepoSpec": {
+      "properties": {
+        "name": {
+          "type": "string",
+          "title": "Name",
+          "description": "Stable short identifier; combined with the set's name-prefix to form the repo ID"
+        },
+        "subpath": {
+          "type": "string",
+          "title": "Sub-path",
+          "description": "Relative path under the set's base URI; may contain $basearch"
+        },
+        "kind": {
+          "type": "string",
+          "enum": [
+            "binary",
+            "debug",
+            "source"
+          ],
+          "title": "Kind",
+          "description": "Sub-repo classification; defaults to binary"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "name",
+        "subpath"
       ]
     },
     "TestSuiteConfig": {


### PR DESCRIPTION
Introduce a [resources] section that lets projects declare RPM repos and reusable layout templates in TOML, replacing per-consumer URL hard-coding. Distro versions select inputs per use-case (rpm-build vs image-build), with sets expanded lazily during validation.

Ship two built-in templates: azl-standard (base/sdk x main/debuginfo/srpms) and koji-dist-repo (per-arch trees + src). Adds reference + explanation docs with an end-to-end TOML example, regenerates the JSON schema, and rejects local gpg-key paths for rpm-build (mock evaluates URIs inside the chroot).

_NOTE: This does not wire up any *consumers* of the new data; this is primarily focused on the schema extension and being able to process the new data._