### PR TITLE
feat: Add flag to source prep to skip downloading source tars

### DIFF
--- a/docs/user/reference/cli/azldev_component_prepare-sources.md
+++ b/docs/user/reference/cli/azldev_component_prepare-sources.md
@@ -41,6 +41,7 @@ azldev component prepare-sources [flags]
   -o, --output-dir string             output directory
       --skip-lock-validation          skip lock file consistency checks
       --skip-overlays                 skip applying overlays to prepared sources
+      --skip-sources                  skip downloading fetched sources when preparing the package (useful to extract dist-git metadata when source files are not needed)
   -s, --spec-path stringArray         Spec path
       --without-git                   Disable dist-git repository creation (enabled by default)
 ```

--- a/internal/app/azldev/cmds/component/preparesources.go
+++ b/internal/app/azldev/cmds/component/preparesources.go
@@ -24,6 +24,7 @@ type PrepareSourcesOptions struct {
 	WithoutGitRepo bool
 	Force          bool
 	AllowNoHashes  bool
+	SkipSources    bool
 }
 
 func prepareOnAppInit(_ *azldev.App, sourceCmd *cobra.Command) {
@@ -73,6 +74,9 @@ Only one component may be selected at a time.`,
 	cmd.Flags().BoolVar(&options.Force, "force", false, "delete and recreate the output directory if it already exists")
 	cmd.Flags().BoolVar(&options.AllowNoHashes, "allow-no-hashes", false,
 		"compute missing hashes by downloading source files from their origin")
+	cmd.Flags().BoolVar(&options.SkipSources, "skip-sources", false,
+		"skip downloading fetched sources when preparing the package (useful to extract "+
+			"dist-git metadata when source files are not needed)")
 
 	return cmd
 }
@@ -136,6 +140,10 @@ func PrepareComponentSources(env *azldev.Env, options *PrepareSourcesOptions) er
 
 	if options.AllowNoHashes {
 		preparerOpts = append(preparerOpts, sources.WithAllowNoHashes())
+	}
+
+	if options.SkipSources {
+		preparerOpts = append(preparerOpts, sources.WithSkipLookaside())
 	}
 
 	preparer, err := sources.NewPreparer(sourceManager, env.FS(), env, env, preparerOpts...)

--- a/internal/app/azldev/cmds/component/preparesources_test.go
+++ b/internal/app/azldev/cmds/component/preparesources_test.go
@@ -34,6 +34,11 @@ func TestNewPrepareSourcesCmd(t *testing.T) {
 	assert.Equal(t, "false", withoutGitFlag.DefValue, "dist-git flow should be enabled by default")
 	assert.Contains(t, withoutGitFlag.Usage, "dist-git")
 
+	skipSourcesFlag := cmd.Flags().Lookup("skip-sources")
+	require.NotNil(t, skipSourcesFlag, "--skip-sources flag should be registered")
+	assert.Equal(t, "false", skipSourcesFlag.DefValue)
+	assert.Contains(t, skipSourcesFlag.Usage, "skip downloading")
+
 	// Legacy --with-git flag must NOT exist.
 	withGitFlag := cmd.Flags().Lookup("with-git")
 	assert.Nil(t, withGitFlag, "--with-git flag must not be registered")


### PR DESCRIPTION
<!--
PR Title must follow Conventional Commits format. Available types:

- feat: A new feature
- fix: A bug fix
- docs: Documentation only changes
- style: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
- refactor: A code change that neither fixes a bug nor adds a feature
- perf: A code change that improves performance
- test: Adding missing tests or correcting existing tests
- build: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
- ci: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
- chore: Other changes that don't modify src or test files
- revert: Reverts a previous commit

Reference: https://www.conventionalcommits.org/en/v1.0.0/
-->
