### PR TITLE
test: add negative tests and harden input validation

### DIFF
--- a/internal/app/azldev/core/components/resolver_test.go
+++ b/internal/app/azldev/core/components/resolver_test.go
@@ -984,3 +984,30 @@ func TestFindComponents_PinDiffersFromLock(t *testing.T) {
 	assert.Equal(t, "lock-commit-bbb", comp2.GetConfig().Locked.UpstreamCommit,
 		"suppression doesn't change the populated data, only the warning emission")
 }
+
+func TestComponentFilter_HasNoCriteria(t *testing.T) {
+	t.Run("empty filter has no criteria", func(t *testing.T) {
+		filter := components.ComponentFilter{}
+		assert.True(t, filter.HasNoCriteria())
+	})
+
+	t.Run("all-components set means criteria exist", func(t *testing.T) {
+		filter := components.ComponentFilter{IncludeAllComponents: true}
+		assert.False(t, filter.HasNoCriteria())
+	})
+
+	t.Run("group names set means criteria exist", func(t *testing.T) {
+		filter := components.ComponentFilter{ComponentGroupNames: []string{"core"}}
+		assert.False(t, filter.HasNoCriteria())
+	})
+
+	t.Run("name patterns set means criteria exist", func(t *testing.T) {
+		filter := components.ComponentFilter{ComponentNamePatterns: []string{"curl"}}
+		assert.False(t, filter.HasNoCriteria())
+	})
+
+	t.Run("spec paths set means criteria exist", func(t *testing.T) {
+		filter := components.ComponentFilter{SpecPaths: []string{"/specs/test.spec"}}
+		assert.False(t, filter.HasNoCriteria())
+	})
+}

--- a/internal/app/azldev/core/sources/overlays_test.go
+++ b/internal/app/azldev/core/sources/overlays_test.go
@@ -1353,3 +1353,96 @@ Main.
 		assert.Contains(t, err.Error(), "not found")
 	})
 }
+
+func TestApplySpecOverlay_InvalidRegex(t *testing.T) {
+	specContent := `Name: test
+Version: 1.0
+
+%build
+make
+`
+	overlay := projectconfig.ComponentOverlay{
+		Type:        projectconfig.ComponentOverlaySearchAndReplaceInSpec,
+		Regex:       `(?P<invalid`,
+		Replacement: "replaced",
+	}
+
+	_, err := applyOverlayToSpecContents(t, overlay, specContent)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "search and replace")
+}
+
+func TestApplyNonSpecOverlay_InvalidRegex(t *testing.T) {
+	ctx := testctx.NewCtx()
+	testFS := ctx.FS()
+
+	// Write source files to the destination directory.
+	const destDir = "/dest"
+	require.NoError(t, testFS.MkdirAll(destDir, fileperms.PublicDir))
+	require.NoError(t, fileutils.WriteFile(testFS, destDir+"/config.txt",
+		[]byte("DEBUG=false\n"), fileperms.PublicFile))
+
+	overlay := projectconfig.ComponentOverlay{
+		Type:        projectconfig.ComponentOverlaySearchAndReplaceInFile,
+		Filename:    "config.txt",
+		Regex:       `(?P<invalid`,
+		Replacement: "replaced",
+	}
+
+	err := sources.ApplyOverlayToSources(ctx, testFS, overlay, destDir, "")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "regex")
+}
+
+func TestApplyNonSpecOverlay_MissingSourceFile(t *testing.T) {
+	ctx := testctx.NewCtx()
+	testFS := ctx.FS()
+
+	const destDir = "/dest"
+	require.NoError(t, testFS.MkdirAll(destDir, fileperms.PublicDir))
+
+	overlay := projectconfig.ComponentOverlay{
+		Type:     projectconfig.ComponentOverlayAddFile,
+		Filename: "extra.txt",
+		Source:   "/nonexistent/path/extra.txt",
+	}
+
+	err := sources.ApplyOverlayToSources(ctx, testFS, overlay, destDir, "")
+	require.Error(t, err)
+}
+
+func TestApplyNonSpecOverlay_SearchReplaceOnNonexistentFile(t *testing.T) {
+	ctx := testctx.NewCtx()
+	testFS := ctx.FS()
+
+	const destDir = "/dest"
+	require.NoError(t, testFS.MkdirAll(destDir, fileperms.PublicDir))
+
+	overlay := projectconfig.ComponentOverlay{
+		Type:        projectconfig.ComponentOverlaySearchAndReplaceInFile,
+		Filename:    "nonexistent.txt",
+		Regex:       `pattern`,
+		Replacement: "replaced",
+	}
+
+	err := sources.ApplyOverlayToSources(ctx, testFS, overlay, destDir, "")
+	require.Error(t, err)
+}
+
+func TestApplyAddPatchOverlay_MissingPatchFile(t *testing.T) {
+	ctx := testctx.NewCtx()
+	testFS := ctx.FS()
+
+	const destDir = "/dest"
+	require.NoError(t, testFS.MkdirAll(destDir, fileperms.PublicDir))
+	require.NoError(t, fileutils.WriteFile(testFS, destDir+"/test.spec",
+		[]byte("Name: test\nVersion: 1.0\n"), fileperms.PublicFile))
+
+	overlay := projectconfig.ComponentOverlay{
+		Type:   projectconfig.ComponentOverlayAddPatch,
+		Source: "/nonexistent/fix.patch",
+	}
+
+	err := sources.ApplyOverlayToSources(ctx, testFS, overlay, destDir, destDir+"/test.spec")
+	require.Error(t, err)
+}

--- a/internal/app/azldev/core/sources/synthistory_test.go
+++ b/internal/app/azldev/core/sources/synthistory_test.go
@@ -246,10 +246,11 @@ func TestCommitInterleavedHistory_MultipleCyclesAutoreleaseLifecycle(t *testing.
 	require.NoError(t, err)
 
 	// Upstream commit 1 (initial import).
-	f, err := memFS.Create("package.spec")
+	specFile, err := memFS.Create("package.spec")
 	require.NoError(t, err)
-	_, _ = f.Write([]byte("Name: package\nVersion: 1.0\nRelease: %autorelease\n"))
-	require.NoError(t, f.Close())
+
+	_, _ = specFile.Write([]byte("Name: package\nVersion: 1.0\nRelease: %autorelease\n"))
+	require.NoError(t, specFile.Close())
 
 	_, err = worktree.Add("package.spec")
 	require.NoError(t, err)
@@ -263,10 +264,11 @@ func TestCommitInterleavedHistory_MultipleCyclesAutoreleaseLifecycle(t *testing.
 	require.NoError(t, err)
 
 	// Upstream commit 2 (version bump).
-	f, err = memFS.Create("package.spec")
+	specFile, err = memFS.Create("package.spec")
 	require.NoError(t, err)
-	_, _ = f.Write([]byte("Name: package\nVersion: 2.0\nRelease: %autorelease\n"))
-	require.NoError(t, f.Close())
+
+	_, _ = specFile.Write([]byte("Name: package\nVersion: 2.0\nRelease: %autorelease\n"))
+	require.NoError(t, specFile.Close())
 
 	_, err = worktree.Add("package.spec")
 	require.NoError(t, err)
@@ -280,10 +282,11 @@ func TestCommitInterleavedHistory_MultipleCyclesAutoreleaseLifecycle(t *testing.
 	require.NoError(t, err)
 
 	// Working tree state after all overlays (latest content).
-	f, err = memFS.Create("package.spec")
+	specFile, err = memFS.Create("package.spec")
 	require.NoError(t, err)
-	_, _ = f.Write([]byte("Name: package\nVersion: 2.0\nRelease: %autorelease\n# v2 overlay\n"))
-	require.NoError(t, f.Close())
+
+	_, _ = specFile.Write([]byte("Name: package\nVersion: 2.0\nRelease: %autorelease\n# v2 overlay\n"))
+	require.NoError(t, specFile.Close())
 
 	changes := []sources.FingerprintChange{
 		{
@@ -334,11 +337,11 @@ func TestCommitInterleavedHistory_MultipleCyclesAutoreleaseLifecycle(t *testing.
 
 	require.Len(t, logCommits, 5, "2 upstream + 3 synthetic")
 
-	assert.Contains(t, logCommits[0].Message, "Add config overlay for v2.0")     // us₃ (top)
-	assert.Contains(t, logCommits[1].Message, "upstream: v2.0")                  // replayed upstream₂
-	assert.Contains(t, logCommits[2].Message, "Bump release for mass rebuild")   // us₂ (interleaved)
-	assert.Contains(t, logCommits[3].Message, "Apply CVE patch for v1.0")        // us₁ (interleaved)
-	assert.Contains(t, logCommits[4].Message, "upstream: v1.0")                  // import-commit
+	assert.Contains(t, logCommits[0].Message, "Add config overlay for v2.0")   // us₃ (top)
+	assert.Contains(t, logCommits[1].Message, "upstream: v2.0")                // replayed upstream₂
+	assert.Contains(t, logCommits[2].Message, "Bump release for mass rebuild") // us₂ (interleaved)
+	assert.Contains(t, logCommits[3].Message, "Apply CVE patch for v1.0")      // us₁ (interleaved)
+	assert.Contains(t, logCommits[4].Message, "upstream: v1.0")                // import-commit
 
 	assert.Equal(t, "Carol", logCommits[0].Author.Name)
 	assert.Equal(t, "Bob", logCommits[2].Author.Name)

--- a/internal/app/azldev/core/sources/synthistory_test.go
+++ b/internal/app/azldev/core/sources/synthistory_test.go
@@ -231,6 +231,132 @@ func TestCommitInterleavedHistory_Interleaved(t *testing.T) {
 	assert.Contains(t, logCommits[3].Message, "upstream: v1.0") // import-commit (kept)
 }
 
+func TestCommitInterleavedHistory_MultipleCyclesAutoreleaseLifecycle(t *testing.T) {
+	// Simulates a realistic autorelease/autochangelog lifecycle:
+	//   upstream₁ → us₁(overlay) → us₂(manual-bump) → upstream₂ → us₃(overlay)
+	// Three fingerprint changes across two upstream commits, exercising
+	// multiple interleaved changes on the same older upstream before a rebase.
+	memFS := memfs.New()
+	storer := memory.NewStorage()
+
+	repo, err := gogit.Init(storer, memFS)
+	require.NoError(t, err)
+
+	worktree, err := repo.Worktree()
+	require.NoError(t, err)
+
+	// Upstream commit 1 (initial import).
+	f, err := memFS.Create("package.spec")
+	require.NoError(t, err)
+	_, _ = f.Write([]byte("Name: package\nVersion: 1.0\nRelease: %autorelease\n"))
+	require.NoError(t, f.Close())
+
+	_, err = worktree.Add("package.spec")
+	require.NoError(t, err)
+
+	upstream1, err := worktree.Commit("upstream: v1.0", &gogit.CommitOptions{
+		Author: &object.Signature{
+			Name: "Upstream", Email: "upstream@fedora.org",
+			When: time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC),
+		},
+	})
+	require.NoError(t, err)
+
+	// Upstream commit 2 (version bump).
+	f, err = memFS.Create("package.spec")
+	require.NoError(t, err)
+	_, _ = f.Write([]byte("Name: package\nVersion: 2.0\nRelease: %autorelease\n"))
+	require.NoError(t, f.Close())
+
+	_, err = worktree.Add("package.spec")
+	require.NoError(t, err)
+
+	upstream2, err := worktree.Commit("upstream: v2.0", &gogit.CommitOptions{
+		Author: &object.Signature{
+			Name: "Upstream", Email: "upstream@fedora.org",
+			When: time.Date(2024, 6, 1, 0, 0, 0, 0, time.UTC),
+		},
+	})
+	require.NoError(t, err)
+
+	// Working tree state after all overlays (latest content).
+	f, err = memFS.Create("package.spec")
+	require.NoError(t, err)
+	_, _ = f.Write([]byte("Name: package\nVersion: 2.0\nRelease: %autorelease\n# v2 overlay\n"))
+	require.NoError(t, f.Close())
+
+	changes := []sources.FingerprintChange{
+		{
+			CommitMetadata: sources.CommitMetadata{
+				Hash: "proj-aaa", Author: "Alice", AuthorEmail: "alice@example.com",
+				Timestamp: time.Date(2024, 2, 1, 0, 0, 0, 0, time.UTC).Unix(),
+				Message:   "Apply CVE patch for v1.0",
+			},
+			UpstreamCommit: upstream1.String(),
+		},
+		{
+			CommitMetadata: sources.CommitMetadata{
+				Hash: "proj-bbb", Author: "Bob", AuthorEmail: "bob@example.com",
+				Timestamp: time.Date(2024, 4, 1, 0, 0, 0, 0, time.UTC).Unix(),
+				Message:   "Bump release for mass rebuild",
+			},
+			UpstreamCommit: upstream1.String(), // still on v1.0.
+		},
+		{
+			CommitMetadata: sources.CommitMetadata{
+				Hash: "proj-ccc", Author: "Carol", AuthorEmail: "carol@example.com",
+				Timestamp: time.Date(2024, 8, 1, 0, 0, 0, 0, time.UTC).Unix(),
+				Message:   "Add config overlay for v2.0",
+			},
+			UpstreamCommit: upstream2.String(),
+		},
+	}
+
+	err = sources.CommitInterleavedHistory(repo, changes, upstream1.String())
+	require.NoError(t, err)
+
+	// Expected order (newest first):
+	//   us₃(Carol)  ← upstream₂  ← us₂(Bob)  ← us₁(Alice)  ← upstream₁
+	head, err := repo.Head()
+	require.NoError(t, err)
+
+	commitIter, err := repo.Log(&gogit.LogOptions{From: head.Hash()})
+	require.NoError(t, err)
+
+	var logCommits []*object.Commit
+
+	err = commitIter.ForEach(func(c *object.Commit) error {
+		logCommits = append(logCommits, c)
+
+		return nil
+	})
+	require.NoError(t, err)
+
+	require.Len(t, logCommits, 5, "2 upstream + 3 synthetic")
+
+	assert.Contains(t, logCommits[0].Message, "Add config overlay for v2.0")     // us₃ (top)
+	assert.Contains(t, logCommits[1].Message, "upstream: v2.0")                  // replayed upstream₂
+	assert.Contains(t, logCommits[2].Message, "Bump release for mass rebuild")   // us₂ (interleaved)
+	assert.Contains(t, logCommits[3].Message, "Apply CVE patch for v1.0")        // us₁ (interleaved)
+	assert.Contains(t, logCommits[4].Message, "upstream: v1.0")                  // import-commit
+
+	assert.Equal(t, "Carol", logCommits[0].Author.Name)
+	assert.Equal(t, "Bob", logCommits[2].Author.Name)
+	assert.Equal(t, "Alice", logCommits[3].Author.Name)
+
+	// Verify overlay content reached the top synthetic commit.
+	tree, err := logCommits[0].Tree()
+	require.NoError(t, err)
+
+	entry, err := tree.File("package.spec")
+	require.NoError(t, err)
+
+	content, err := entry.Contents()
+	require.NoError(t, err)
+	assert.Contains(t, content, "# v2 overlay")
+	assert.Contains(t, content, "%autorelease")
+}
+
 func TestCommitInterleavedHistory_SingleCommit(t *testing.T) {
 	memFS := memfs.New()
 	storer := memory.NewStorage()

--- a/internal/fingerprint/fingerprint_test.go
+++ b/internal/fingerprint/fingerprint_test.go
@@ -835,3 +835,40 @@ func TestComputeResolutionHash_BaseURIChangeAffectsHash(t *testing.T) {
 	assert.NotEqual(t, hashBefore, hashAfter,
 		"dist-git base URI change must change resolution hash")
 }
+
+func TestComputeIdentity_MissingOverlaySourceFile_Error(t *testing.T) {
+	ctx := newTestFS(t, map[string]string{
+		"/specs/test.spec": "Name: testpkg\nVersion: 1.0",
+		// Deliberately NOT creating the patch file.
+	})
+	releaseVer := testReleaseVer
+
+	comp := baseComponent()
+	comp.Overlays = []projectconfig.ComponentOverlay{
+		{Type: "patch-add", Source: "/patches/nonexistent.patch"},
+	}
+
+	_, err := fingerprint.ComputeIdentity(ctx.FS(), comp, releaseVer, fingerprint.IdentityOptions{
+		SourceIdentity: "test-source-identity",
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "overlay")
+}
+
+func TestComputeIdentity_MissingFileAddSource_Error(t *testing.T) {
+	ctx := newTestFS(t, map[string]string{
+		"/specs/test.spec": "Name: testpkg\nVersion: 1.0",
+	})
+	releaseVer := testReleaseVer
+
+	comp := baseComponent()
+	comp.Overlays = []projectconfig.ComponentOverlay{
+		{Type: "file-add", Source: "/files/nonexistent.txt", Filename: "extra.txt"},
+	}
+
+	_, err := fingerprint.ComputeIdentity(ctx.FS(), comp, releaseVer, fingerprint.IdentityOptions{
+		SourceIdentity: "test-source-identity",
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "overlay")
+}

--- a/internal/lockfile/lockfile_test.go
+++ b/internal/lockfile/lockfile_test.go
@@ -836,3 +836,41 @@ func TestStoreValidateConsistency(t *testing.T) {
 		assert.Contains(t, orphans, "removed")
 	})
 }
+
+func TestParse_EmptyContent(t *testing.T) {
+	// Empty content has version=0 which doesn't match currentVersion=1.
+	_, err := lockfile.Parse([]byte(""))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unsupported lock file version")
+}
+
+func TestParse_VersionZero(t *testing.T) {
+	_, err := lockfile.Parse([]byte("version = 0"))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unsupported lock file version")
+}
+
+func TestParse_GarbageContent(t *testing.T) {
+	_, err := lockfile.Parse([]byte("\x00\x01\x02binary garbage"))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "parsing lock file")
+}
+
+func TestParse_ValidMinimal(t *testing.T) {
+	lock, err := lockfile.Parse([]byte("version = 1\n"))
+	require.NoError(t, err)
+	assert.Equal(t, 1, lock.Version)
+	assert.Empty(t, lock.UpstreamCommit)
+}
+
+func TestLockPath_InvalidComponentName(t *testing.T) {
+	// Path traversal attempts should be rejected.
+	_, err := lockfile.LockPath(testLockDir, "../escape")
+	require.Error(t, err)
+
+	_, err = lockfile.LockPath(testLockDir, "../../etc/passwd")
+	require.Error(t, err)
+
+	_, err = lockfile.LockPath(testLockDir, "")
+	require.Error(t, err)
+}

--- a/internal/projectconfig/build.go
+++ b/internal/projectconfig/build.go
@@ -58,6 +58,19 @@ type ComponentBuildFailureConfig struct {
 	ExpectedReason string `toml:"expected-reason,omitempty" json:"expectedReason,omitempty" jsonschema:"title=Expected failure reason,description=Required justification for why this component is expected to fail building."`
 }
 
+// Validate checks that required fields are set when Expected is true.
+func (c *ComponentBuildFailureConfig) Validate() error {
+	if !c.Expected {
+		return nil
+	}
+
+	if c.ExpectedReason == "" {
+		return errors.New("failure.expected-reason is required when failure.expected is true")
+	}
+
+	return nil
+}
+
 // ComponentBuildHints encapsulates non-essential hints for how or when to build a component.
 // These are not required for correctness of builds, but may be used by tools to provide guidance
 // or optimizations.
@@ -69,6 +82,10 @@ type ComponentBuildHints struct {
 // Validate checks that the build configuration is valid.
 func (c *ComponentBuildConfig) Validate() error {
 	if err := c.Check.Validate(); err != nil {
+		return fmt.Errorf("invalid build configuration:\n%w", err)
+	}
+
+	if err := c.Failure.Validate(); err != nil {
 		return fmt.Errorf("invalid build configuration:\n%w", err)
 	}
 

--- a/internal/projectconfig/build_test.go
+++ b/internal/projectconfig/build_test.go
@@ -11,46 +11,20 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestCheckConfig_Validate(t *testing.T) {
-	testCases := []struct {
-		name          string
-		config        projectconfig.CheckConfig
-		errorExpected bool
-		errorContains string
-	}{
-		{
-			name:          "empty config is valid",
-			config:        projectconfig.CheckConfig{},
-			errorExpected: false,
-		},
-		{
-			name: "skip false without reason is valid",
-			config: projectconfig.CheckConfig{
-				Skip: false,
-			},
-			errorExpected: false,
-		},
-		{
-			name: "skip true with reason is valid",
-			config: projectconfig.CheckConfig{
-				Skip:       true,
-				SkipReason: "Tests require network access",
-			},
-			errorExpected: false,
-		},
-		{
-			name: "skip true without reason is invalid",
-			config: projectconfig.CheckConfig{
-				Skip: true,
-			},
-			errorExpected: true,
-			errorContains: "skip_reason",
-		},
-	}
+// validateTestCase is a generic test case for validatable types.
+type validateTestCase struct {
+	name          string
+	validate      func() error
+	errorExpected bool
+	errorContains string
+}
+
+func runValidateTests(t *testing.T, testCases []validateTestCase) {
+	t.Helper()
 
 	for _, testCase := range testCases {
 		t.Run(testCase.name, func(t *testing.T) {
-			err := testCase.config.Validate()
+			err := testCase.validate()
 
 			if testCase.errorExpected {
 				require.Error(t, err)
@@ -65,6 +39,94 @@ func TestCheckConfig_Validate(t *testing.T) {
 			require.NoError(t, err)
 		})
 	}
+}
+
+func TestCheckConfig_Validate(t *testing.T) {
+	runValidateTests(t, []validateTestCase{
+		{
+			name:     "empty config is valid",
+			validate: func() error { return (&projectconfig.CheckConfig{}).Validate() },
+		},
+		{
+			name: "skip false without reason is valid",
+			validate: func() error {
+				return (&projectconfig.CheckConfig{Skip: false}).Validate()
+			},
+		},
+		{
+			name: "skip true with reason is valid",
+			validate: func() error {
+				return (&projectconfig.CheckConfig{
+					Skip: true, SkipReason: "Tests require network access",
+				}).Validate()
+			},
+		},
+		{
+			name: "skip true without reason is invalid",
+			validate: func() error {
+				return (&projectconfig.CheckConfig{Skip: true}).Validate()
+			},
+			errorExpected: true,
+			errorContains: "skip_reason",
+		},
+	})
+}
+
+func TestComponentBuildFailureConfig_Validate(t *testing.T) {
+	runValidateTests(t, []validateTestCase{
+		{
+			name:     "empty config is valid",
+			validate: func() error { return (&projectconfig.ComponentBuildFailureConfig{}).Validate() },
+		},
+		{
+			name: "expected false without reason is valid",
+			validate: func() error {
+				return (&projectconfig.ComponentBuildFailureConfig{Expected: false}).Validate()
+			},
+		},
+		{
+			name: "expected true with reason is valid",
+			validate: func() error {
+				return (&projectconfig.ComponentBuildFailureConfig{
+					Expected: true, ExpectedReason: "Known upstream build failure tracked in issue #123",
+				}).Validate()
+			},
+		},
+		{
+			name: "expected true without reason is invalid",
+			validate: func() error {
+				return (&projectconfig.ComponentBuildFailureConfig{Expected: true}).Validate()
+			},
+			errorExpected: true,
+			errorContains: "expected-reason",
+		},
+	})
+}
+
+func TestComponentBuildConfig_Validate_FailureConfig(t *testing.T) {
+	t.Run("expected failure without reason propagates error", func(t *testing.T) {
+		config := projectconfig.ComponentBuildConfig{
+			Failure: projectconfig.ComponentBuildFailureConfig{
+				Expected: true,
+			},
+		}
+
+		err := config.Validate()
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "expected-reason")
+	})
+
+	t.Run("expected failure with reason is valid", func(t *testing.T) {
+		config := projectconfig.ComponentBuildConfig{
+			Failure: projectconfig.ComponentBuildFailureConfig{
+				Expected:       true,
+				ExpectedReason: "known issue",
+			},
+		}
+
+		err := config.Validate()
+		require.NoError(t, err)
+	})
 }
 
 func TestComponentBuildConfig_Validate(t *testing.T) {

--- a/internal/projectconfig/loader.go
+++ b/internal/projectconfig/loader.go
@@ -27,6 +27,8 @@ var (
 	ErrDuplicateImages = errors.New("duplicate image")
 	// ErrDuplicatePackageGroups is returned when duplicate conflicting package group definitions are found.
 	ErrDuplicatePackageGroups = errors.New("duplicate package group")
+	// ErrCircularInclude is returned when a config file include chain forms a cycle.
+	ErrCircularInclude = errors.New("circular include detected")
 )
 
 // Loads and resolves the project configuration files located at the given path. Referenced include files
@@ -67,7 +69,7 @@ func loadAndMergeConfigWithIncludes(
 	permissiveConfigParsing bool,
 ) error {
 	// Load the project config file and all transitive includes.
-	loadedCfgs, err := loadProjectConfigWithIncludes(fs, filePath, permissiveConfigParsing)
+	loadedCfgs, err := loadProjectConfigWithIncludes(fs, filePath, permissiveConfigParsing, nil)
 	if err != nil {
 		return err
 	}
@@ -311,7 +313,26 @@ func mergeTestSuites(resolvedCfg *ProjectConfig, loadedCfg *ConfigFile) error {
 
 func loadProjectConfigWithIncludes(
 	fs opctx.FS, filePath string, permissiveConfigParsing bool,
+	seen map[string]bool,
 ) ([]*ConfigFile, error) {
+	absFilePath, err := filepath.Abs(filePath)
+	if err != nil {
+		return nil, fmt.Errorf("failed to resolve absolute path for '%s':\n%w", filePath, err)
+	}
+
+	if seen == nil {
+		seen = make(map[string]bool)
+	}
+
+	if seen[absFilePath] {
+		return nil, fmt.Errorf(
+			"%w: '%s' is included by a file that it transitively includes",
+			ErrCircularInclude, absFilePath,
+		)
+	}
+
+	seen[absFilePath] = true
+
 	// Load the immediate config file.
 	cfg, err := loadProjectConfigFile(fs, filePath, permissiveConfigParsing)
 	if err != nil {
@@ -346,7 +367,7 @@ func loadProjectConfigWithIncludes(
 			absIncludePath := makeAbsolute(cfg.dir, includePath)
 
 			includeCfgs, err := loadProjectConfigWithIncludes(
-				fs, absIncludePath, permissiveConfigParsing,
+				fs, absIncludePath, permissiveConfigParsing, seen,
 			)
 			if err != nil {
 				return nil, err

--- a/internal/projectconfig/loader_test.go
+++ b/internal/projectconfig/loader_test.go
@@ -1123,3 +1123,80 @@ install = "invalid"
 	require.Error(t, err)
 	assert.ErrorIs(t, err, ErrInvalidInstallMode)
 }
+
+func TestLoadAndResolveProjectConfig_CircularInclude(t *testing.T) {
+	t.Run("direct self-include", func(t *testing.T) {
+		ctx := testctx.NewCtx()
+		require.NoError(t, fileutils.WriteFile(ctx.FS(), testConfigPath,
+			[]byte(`includes = ["azldev.toml"]`), fileperms.PrivateFile))
+
+		_, err := loadAndResolveProjectConfig(ctx.FS(), false, testConfigPath)
+		require.ErrorIs(t, err, ErrCircularInclude)
+	})
+
+	t.Run("A includes B, B includes A", func(t *testing.T) {
+		ctx := testctx.NewCtx()
+
+		const includePath = "/project/child.toml"
+
+		require.NoError(t, fileutils.WriteFile(ctx.FS(), testConfigPath,
+			[]byte(`includes = ["child.toml"]`), fileperms.PrivateFile))
+		require.NoError(t, fileutils.WriteFile(ctx.FS(), includePath,
+			[]byte(`includes = ["azldev.toml"]`), fileperms.PrivateFile))
+
+		_, err := loadAndResolveProjectConfig(ctx.FS(), false, testConfigPath)
+		require.ErrorIs(t, err, ErrCircularInclude)
+	})
+
+	t.Run("A includes B includes C includes A", func(t *testing.T) {
+		ctx := testctx.NewCtx()
+
+		const (
+			bPath = "/project/b.toml"
+			cPath = "/project/c.toml"
+		)
+
+		require.NoError(t, fileutils.WriteFile(ctx.FS(), testConfigPath,
+			[]byte(`includes = ["b.toml"]`), fileperms.PrivateFile))
+		require.NoError(t, fileutils.WriteFile(ctx.FS(), bPath,
+			[]byte(`includes = ["c.toml"]`), fileperms.PrivateFile))
+		require.NoError(t, fileutils.WriteFile(ctx.FS(), cPath,
+			[]byte(`includes = ["azldev.toml"]`), fileperms.PrivateFile))
+
+		_, err := loadAndResolveProjectConfig(ctx.FS(), false, testConfigPath)
+		require.ErrorIs(t, err, ErrCircularInclude)
+	})
+}
+
+func TestLoadAndResolveProjectConfig_BuildFailureValidation(t *testing.T) {
+	t.Run("failure expected without reason is rejected", func(t *testing.T) {
+		const configContents = `
+[components.test-pkg]
+[components.test-pkg.build.failure]
+expected = true
+`
+
+		ctx := testctx.NewCtx()
+		require.NoError(t, fileutils.WriteFile(ctx.FS(), testConfigPath, []byte(configContents), fileperms.PrivateFile))
+
+		_, err := loadAndResolveProjectConfig(ctx.FS(), false, testConfigPath)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "expected-reason")
+	})
+
+	t.Run("failure expected with reason is accepted", func(t *testing.T) {
+		const configContents = `
+[components.test-pkg]
+[components.test-pkg.build.failure]
+expected = true
+expected-reason = "Known upstream issue #456"
+`
+
+		ctx := testctx.NewCtx()
+		require.NoError(t, fileutils.WriteFile(ctx.FS(), testConfigPath, []byte(configContents), fileperms.PrivateFile))
+
+		config, err := loadAndResolveProjectConfig(ctx.FS(), false, testConfigPath)
+		require.NoError(t, err)
+		assert.True(t, config.Components["test-pkg"].Build.Failure.Expected)
+	})
+}

--- a/internal/rpm/extractor_test.go
+++ b/internal/rpm/extractor_test.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"net/http"
 	"os"
+	"strings"
 	"testing"
 
 	"github.com/microsoft/azure-linux-dev-tools/internal/rpm"
@@ -189,5 +190,44 @@ func TestExtractFailureSimulation(t *testing.T) {
 
 		err := extractor.Extract(testRPMStream, "")
 		assert.Error(t, err)
+	})
+}
+
+func TestExtractCorruptedData(t *testing.T) {
+	t.Run("truncated header fails gracefully", func(t *testing.T) {
+		localFS := afero.NewMemMapFs()
+
+		extractor, err := rpm.NewRPMExtractorImpl(localFS)
+		require.NoError(t, err)
+
+		// A few bytes that look like an RPM magic number but are truncated.
+		corruptData := strings.NewReader("\xed\xab\xee\xdb\x03\x00")
+
+		err = extractor.Extract(io.NopCloser(corruptData), testDestinationDir)
+		require.Error(t, err)
+	})
+
+	t.Run("random bytes fail gracefully", func(t *testing.T) {
+		localFS := afero.NewMemMapFs()
+
+		extractor, err := rpm.NewRPMExtractorImpl(localFS)
+		require.NoError(t, err)
+
+		randomData := strings.NewReader("this is definitely not an RPM file with random garbage content")
+
+		err = extractor.Extract(io.NopCloser(randomData), testDestinationDir)
+		require.Error(t, err)
+	})
+
+	t.Run("empty stream fails gracefully", func(t *testing.T) {
+		localFS := afero.NewMemMapFs()
+
+		extractor, err := rpm.NewRPMExtractorImpl(localFS)
+		require.NoError(t, err)
+
+		emptyData := strings.NewReader("")
+
+		err = extractor.Extract(io.NopCloser(emptyData), testDestinationDir)
+		require.Error(t, err)
 	})
 }

--- a/internal/rpm/spec/edit.go
+++ b/internal/rpm/spec/edit.go
@@ -502,7 +502,10 @@ func (s *Spec) SearchAndReplace(sectionName, packageName, regex, replacement str
 	)
 
 	// Compile the regex once.
-	compiledRegex := regexp.MustCompile(regex)
+	compiledRegex, err := regexp.Compile(regex)
+	if err != nil {
+		return fmt.Errorf("failed to compile regex %#q:\n%w", regex, err)
+	}
 
 	var updated bool
 

--- a/internal/rpm/spec/spec_test.go
+++ b/internal/rpm/spec/spec_test.go
@@ -4,10 +4,13 @@
 package spec_test
 
 import (
+	"bytes"
+	"strings"
 	"testing"
 
 	"github.com/microsoft/azure-linux-dev-tools/internal/rpm/spec"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestGetPackageNameFromSectionHeader(t *testing.T) {
@@ -44,4 +47,105 @@ func TestGetPackageNameFromSectionHeader(t *testing.T) {
 		spec.GetPackageNameFromSectionHeader([]string{"%filetriggerin", "-P", "100", "--", "/usr/lib"}))
 	assert.Equal(t, "devel",
 		spec.GetPackageNameFromSectionHeader([]string{"%filetriggerin", "devel", "-P", "100", "--", "/usr/lib"}))
+}
+
+func TestOpenSpec_EmptyInput(t *testing.T) {
+	sf, err := spec.OpenSpec(strings.NewReader(""))
+	require.NoError(t, err)
+
+	// Empty spec is parseable but has no tags.
+	err = sf.VisitTags(func(_ *spec.TagLine, _ *spec.Context) error {
+		t.Fatal("no tags should be visited in an empty spec")
+
+		return nil
+	})
+	require.NoError(t, err)
+}
+
+func TestOpenSpec_BinaryContent(t *testing.T) {
+	// Binary content should be parseable (lines are just raw strings).
+	binaryData := "\x00\x01\x02\xFF\xFE\x89PNG\r\n"
+	sf, err := spec.OpenSpec(strings.NewReader(binaryData))
+	require.NoError(t, err)
+
+	// Should round-trip without error.
+	var buf bytes.Buffer
+	require.NoError(t, sf.Serialize(&buf))
+}
+
+func TestOpenSpec_CRLFLineEndings(t *testing.T) {
+	input := "Name: test\r\nVersion: 1.0\r\nRelease: 1\r\n"
+	specFile, err := spec.OpenSpec(strings.NewReader(input))
+	require.NoError(t, err)
+
+	// UpdateExistingTag should still find tags despite \r in values.
+	err = specFile.UpdateExistingTag("", "Name", "updated")
+	require.NoError(t, err)
+}
+
+func TestOpenSpec_NoNameTag(t *testing.T) {
+	// A spec with no Name tag is structurally valid for OpenSpec (it just stores lines).
+	// Operations should handle it gracefully.
+	sf, err := spec.OpenSpec(strings.NewReader("Version: 1.0\nRelease: 1\n"))
+	require.NoError(t, err)
+
+	// Attempting to update a non-existent Name tag should return ErrNoSuchTag.
+	err = sf.UpdateExistingTag("", "Name", "test")
+	require.ErrorIs(t, err, spec.ErrNoSuchTag)
+}
+
+func TestOpenSpec_DuplicateSectionHeaders(t *testing.T) {
+	input := `Name: test
+Version: 1.0
+
+%description
+First description.
+
+%description
+Second description.
+`
+	specFile, err := spec.OpenSpec(strings.NewReader(input))
+	require.NoError(t, err)
+
+	// Both sections should be removable.
+	err = specFile.RemoveSection("%description", "")
+	require.NoError(t, err)
+
+	var buf bytes.Buffer
+	require.NoError(t, specFile.Serialize(&buf))
+
+	// Both %description sections should be gone.
+	assert.NotContains(t, buf.String(), "%description")
+}
+
+func TestSetTag_NonExistentPackage(t *testing.T) {
+	specFile, err := spec.OpenSpec(strings.NewReader("Name: test\nVersion: 1.0\n"))
+	require.NoError(t, err)
+
+	// Setting a tag on a non-existent package should fail with ErrSectionNotFound.
+	err = specFile.SetTag("nonexistent-pkg", "Summary", "test")
+	require.ErrorIs(t, err, spec.ErrSectionNotFound)
+}
+
+func TestAddPatchEntry_EmptySpec(t *testing.T) {
+	specFile, err := spec.OpenSpec(strings.NewReader("Name: test\n"))
+	require.NoError(t, err)
+
+	// Adding a patch entry to a minimal spec should succeed (creates Patch0 tag).
+	err = specFile.AddPatchEntry("", "fix-build.patch")
+	require.NoError(t, err)
+
+	var buf bytes.Buffer
+	require.NoError(t, specFile.Serialize(&buf))
+	assert.Contains(t, buf.String(), "Patch0: fix-build.patch")
+}
+
+func TestRemovePatchEntry_NoPatches(t *testing.T) {
+	specFile, err := spec.OpenSpec(strings.NewReader("Name: test\nVersion: 1.0\n"))
+	require.NoError(t, err)
+
+	// Removing from a spec with no patches should fail.
+	err = specFile.RemovePatchEntry("*.patch")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "no patches matching")
 }

--- a/internal/rpm/specquery_test.go
+++ b/internal/rpm/specquery_test.go
@@ -300,16 +300,18 @@ func TestQuerySpecSuccessWithWarningsAndErrors(t *testing.T) {
 
 func TestQuerySpecFailure(t *testing.T) {
 	tests := []struct {
-		name       string
-		mockStdout string
-		mockRunErr error
-		setupFS    bool
+		name          string
+		mockStdout    string
+		mockRunErr    error
+		setupFS       bool
+		errorContains string
 	}{
 		{
-			name:       "command execution error",
-			mockStdout: "",
-			mockRunErr: errors.New("command failed"),
-			setupFS:    true,
+			name:          "command execution error",
+			mockStdout:    "",
+			mockRunErr:    errors.New("command failed"),
+			setupFS:       true,
+			errorContains: "failed to run rpmspec",
 		},
 		{
 			name:       "empty output",
@@ -341,6 +343,41 @@ func TestQuerySpecFailure(t *testing.T) {
 			mockRunErr: nil,
 			setupFS:    true,
 		},
+		{
+			name:          "missing name field",
+			mockStdout:    "epoch=1\nversion=2.3.4\nrelease=5.azl3",
+			mockRunErr:    nil,
+			setupFS:       true,
+			errorContains: "missing required fields",
+		},
+		{
+			name:          "missing version field",
+			mockStdout:    "name=test-package\nepoch=1\nrelease=5.azl3",
+			mockRunErr:    nil,
+			setupFS:       true,
+			errorContains: "missing required fields",
+		},
+		{
+			name:          "missing release field",
+			mockStdout:    "name=test-package\nepoch=1\nversion=2.3.4",
+			mockRunErr:    nil,
+			setupFS:       true,
+			errorContains: "missing required fields",
+		},
+		{
+			name:          "missing epoch field",
+			mockStdout:    "name=test-package\nversion=2.3.4\nrelease=5.azl3",
+			mockRunErr:    nil,
+			setupFS:       true,
+			errorContains: "missing required fields",
+		},
+		{
+			name:          "malformed EVR - invalid epoch",
+			mockStdout:    "name=test-package\nepoch=notanumber\nversion=2.3.4\nrelease=5.azl3",
+			mockRunErr:    nil,
+			setupFS:       true,
+			errorContains: "failed to create version from EVR",
+		},
 	}
 
 	for _, test := range tests {
@@ -366,7 +403,9 @@ func TestQuerySpecFailure(t *testing.T) {
 			assert.Nil(t, result)
 			require.Error(t, err)
 
-			if test.mockRunErr != nil {
+			if test.errorContains != "" {
+				assert.Contains(t, err.Error(), test.errorContains)
+			} else if test.mockRunErr != nil {
 				assert.Contains(t, err.Error(), "failed to run rpmspec in isolated root")
 			}
 		})

--- a/scenario/component_render_test.go
+++ b/scenario/component_render_test.go
@@ -631,12 +631,14 @@ input-fingerprint = "pre-baked-for-test"
 // Setup:
 //
 //	Upstream dist-git (3 commits): C1(v1.0.0) → C2(v1.1.0) → C3(add patch)
-//	Project lock file (2 fingerprint changes): fp1, fp2
+//	Project lock file (3 fingerprint changes): fp0 (on C1), fp1 (on C3), fp2 (on C3)
 //	Dirty detection: runtime fingerprint ≠ fp2 → 1 extra synthetic commit
 //
-//	All synthetic commits reference C3 (HEAD), so interleaving places them
-//	after the upstream history: C1 → C2 → C3 → S1 → S2 → S3(dirty)
+//	S0 references C1 (pre-version-bump), so interleaving places it between
+//	C1 and C2. The remaining synthetic commits reference C3 (HEAD) and are
+//	placed after C3: C1 → S0 → C2 → C3 → S1 → S2 → S3(dirty)
 //	rpmautospec resets release on Version change (C2), giving Release = 5.
+//	Crucially, S0 sits before the reset and does NOT inflate v1.1's release.
 //
 // The bare repo is created inside the container script because
 // AddDirRecursive loses git internal structure needed for file:// clones.
@@ -731,12 +733,14 @@ dist-git-branch = "main"
 
 	// The script:
 	// 1. Creates the upstream bare repo with 3 controlled commits
-	// 2. Commits the lock file twice with different fingerprints to simulate
-	//    a realistic workflow (import → overlay change)
+	// 2. Commits the lock file three times with different fingerprints to
+	//    simulate a realistic lifecycle: import on v1.0 → overlay on v1.0 →
+	//    update to v1.1 → overlay on v1.1
 	// 3. Renders and captures output
 	//
-	// This produces 2 fingerprint changes + 1 dirty detection = 3 synthetic
-	// commits, interleaved on top of 3 upstream commits = 6 total → Release 6.
+	// This produces 3 fingerprint changes + 1 dirty detection = 4 synthetic
+	// commits. S0 references C1 (v1.0 era) and is interleaved before C2.
+	// S1, S2, S3 reference C3 and go on top. Total = 7 commits, Release = 5.
 	testScript := `
 set -ex
 
@@ -773,20 +777,34 @@ git clone --bare "$WORK" /workdir/upstream-repo/test-pkg.git
 cd /workdir
 
 # --- Create lock file with multiple fingerprint changes ---
-# This simulates a realistic project history where the component is
-# imported, then overlays are added/modified over time.
+# This simulates a realistic lifecycle:
+#   1. Import while still on v1.0 (upstream-commit = C1)
+#   2. Update to latest (upstream-commit = C3)
+#   3. Add overlay on v1.1
 mkdir -p project/locks
 cd project
 
-# Lock commit 1: initial import (fingerprint fp1)
+# Lock commit 0: initial import while upstream was at C1 (v1.0 era).
+# This creates synthetic commit S0 which interleaving must place BEFORE
+# the version bump at C2, proving it doesn't inflate v1.1's release.
+cat > locks/test-pkg.lock <<EOF
+version = 1
+import-commit = "$FIRST_COMMIT"
+upstream-commit = "$FIRST_COMMIT"
+input-fingerprint = "fp0-imported-on-v1"
+EOF
+git add locks/test-pkg.lock
+git -c commit.gpgsign=false commit -m "Import test-pkg at v1.0"
+
+# Lock commit 1: updated to latest upstream (fingerprint fp1)
 cat > locks/test-pkg.lock <<EOF
 version = 1
 import-commit = "$FIRST_COMMIT"
 upstream-commit = "$HEAD_COMMIT"
-input-fingerprint = "fp1-initial-import"
+input-fingerprint = "fp1-updated-to-latest"
 EOF
 git add locks/test-pkg.lock
-git -c commit.gpgsign=false commit -m "Import test-pkg with initial lock"
+git -c commit.gpgsign=false commit -m "Update test-pkg to v1.1"
 
 # Lock commit 2: simulated overlay addition (fingerprint fp2)
 cat > locks/test-pkg.lock <<EOF
@@ -852,17 +870,20 @@ azldev -C project -v component render test-pkg -o project/SPECS --output-format 
 	// last Version change.
 	//
 	// Expected release calculation:
-	// All synthetic commits reference the same upstream-commit (C3/HEAD),
-	// so interleaving places them all in the "top" group after C3:
-	//   C1 → C2 → C3 → S1(fp1) → S2(fp2) → S3(dirty)
+	// S0 references C1 (v1.0 era), so interleaving places it between C1 and C2.
+	// S1, S2 reference C3 (HEAD), so they go on top after C3.
+	// S3 is dirty detection (also references C3).
+	//   C1 → S0(fp0) → C2 → C3 → S1(fp1) → S2(fp2) → S3(dirty)
 	// rpmautospec resets release on Version change (C2 bumps 1.0.0 → 1.1.0):
 	//   C2 = release 1 (reset), C3 = 2, S1 = 3, S2 = 4, S3 = 5
+	// S0 sits before the reset — it does NOT count toward v1.1's release.
 	releasePattern := regexp.MustCompile(`release_number = (\d+);`)
 	releaseMatch := releasePattern.FindStringSubmatch(contentStr)
 	require.NotEmpty(t, releaseMatch,
 		"Should find release_number in rpmautospec Lua block")
 	assert.Equal(t, "5", releaseMatch[1],
-		"Release should be 5 (commits since last Version change: C2=1, C3=2, S1=3, S2=4, S3=5)")
+		"Release should be 5: S0 is before the version bump and must not inflate v1.1's release "+
+			"(commits after reset: C2=1, C3=2, S1=3, S2=4, S3=5)")
 
 	// %autochangelog should be expanded to real entries from the controlled history.
 	assert.NotContains(t, contentStr, "%autochangelog",
@@ -878,13 +899,25 @@ azldev -C project -v component render test-pkg -o project/SPECS --output-format 
 	assert.Contains(t, contentStr, "Initial import of test-pkg",
 		"Changelog should contain the first commit message")
 
-	// Verify ordering: synthetic commits should appear above upstream commits.
-	// In newest-first changelog, "Import test-pkg with initial lock" (S1)
-	// must precede "Add fix.patch for build issue" (C3).
-	s1Pos := strings.Index(contentStr, "Import test-pkg with initial lock")
+	// Verify ordering: post-bump synthetic commits should appear above upstream commits.
+	// In newest-first changelog, "Update test-pkg to v1.1" (S1) must precede
+	// "Add fix.patch for build issue" (C3).
+	s1Pos := strings.Index(contentStr, "Update test-pkg to v1.1")
 	c3Pos := strings.Index(contentStr, "Add fix.patch for build issue")
 	require.Greater(t, s1Pos, 0, "S1 commit message should be in changelog")
 	require.Greater(t, c3Pos, 0, "C3 commit message should be in changelog")
 	assert.Less(t, s1Pos, c3Pos,
-		"Synthetic commit (S1) should appear before upstream commit (C3) in changelog")
+		"Post-bump synthetic commit (S1) should appear before upstream commit (C3) in changelog")
+
+	// Verify S0 (v1.0-era synthetic) appears AFTER C2 in the changelog
+	// (i.e. deeper in the history, since changelog is newest-first).
+	// This confirms the v1.0-era commit was correctly interleaved before
+	// the version bump and doesn't leak into the v1.1 section.
+	s0Pos := strings.Index(contentStr, "Import test-pkg at v1.0")
+	c2Pos := strings.Index(contentStr, "Bump to 1.1.0")
+	require.Greater(t, s0Pos, 0, "S0 commit message should be in changelog")
+	require.Greater(t, c2Pos, 0, "C2 commit message should be in changelog")
+	assert.Greater(t, s0Pos, c2Pos,
+		"v1.0-era synthetic commit (S0) should appear after version bump (C2) in changelog, "+
+			"confirming it was interleaved before C2 and doesn't inflate v1.1's release")
 }


### PR DESCRIPTION
Summary of tests added:

| Area | Tests Added |
|------|------------|
| Config validation | ComponentBuildFailureConfig.Validate() requires expected-reason when expected=true |
| Config validation | Circular include detection: self-include, A→B→A, A→B→C→A cycles |
| Config validation | End-to-end TOML load rejects failure.expected without reason |
| Spec parsing | Empty input, binary content, CRLF line endings, missing Name tag |
| Spec parsing | Duplicate section headers, SetTag on non-existent package |
| Spec parsing | AddPatchEntry on empty spec, RemovePatchEntry with no patches |
| Spec querying | Missing individual rpmspec output fields (name, version, release, epoch) |
| Spec querying | Malformed EVR (non-numeric epoch) |
| RPM extraction | Truncated RPM header, random garbage bytes, empty stream |
| Overlay application | Invalid regex in spec-search-replace and file-search-replace |
| Overlay application | Missing source file for file-add, patch-add |
| Overlay application | Search-replace on non-existent target file |
| Fingerprint | Missing overlay source files for patch-add and file-add |
| Lock files | Parse empty content, version 0, binary garbage, valid minimal |
| Lock files | Path traversal rejected in component names |
| CLI filter | HasNoCriteria() for all filter permutations |
| Synthetic history | Multi-cycle autorelease lifecycle: upstream→overlay→bump→upstream→overlay with correct interleaved commit ordering |
| Bug fix | Spec.SearchAndReplace changed from regexp.MustCompile (panic) to regexp.Compile (error) |