### PR TITLE
feat(projectconfig): accept [tests] and [test-groups] schema in config

### DIFF
--- a/docs/user/reference/cli/azldev_image_test.md
+++ b/docs/user/reference/cli/azldev_image_test.md
@@ -6,15 +6,17 @@ Run tests against an Azure Linux image
 
 ### Synopsis
 
-Run tests against an Azure Linux image using test suites defined in the
+Run tests against an Azure Linux image using test definitions declared in the
 project configuration.
 
-Test suites are defined in the [test-suites] section of azldev.toml and referenced
-by images via the [images.NAME.tests] subtable. Each test suite specifies a type
-(pytest or lisa) and framework-specific configuration in a matching subtable.
+Images may reference tests directly via [images.NAME.tests.tests] entries, or via
+named [test-groups]. Legacy [test-suites] references are still supported.
 
-By default, all test suites associated with the named image are run. Use
---test-suite to select specific suites (may be repeated).
+By default, all tests associated with the named image are run. Use
+--test-suite to select specific test names or test-group names (may be repeated).
+For images still configured with legacy [test-suites] (via 'tests.test-suites'),
+the values passed to --test-suite are instead matched against those legacy
+test suite names.
 
 The image artifact can be specified explicitly with --image-path, or resolved
 automatically from the image name in the output directory.
@@ -26,10 +28,15 @@ extra-args to insert the image path. Glob patterns (including **) in
 test-paths are expanded automatically.
 
 For LISA tests, the test runner executes on the host and boots the image in a
-QEMU VM. azldev clones the LISA framework, generates a runbook from the suite's
-configured test cases, and runs it against the image. azldev generates an
-ephemeral SSH key pair to access the booted VM and removes it once the suite
-finishes.
+QEMU VM. azldev clones the LISA framework, generates a runbook from the test's
+configured criteria (or, for legacy [test-suites], its test cases), and runs it
+against the image. azldev generates an ephemeral SSH key pair to access the
+booted VM and removes it once the test finishes. New-style [tests.X] LISA
+definitions require a [tests.X.lisa.source] (git-url, ref) to run locally;
+without one, the test is metadata-only and must be run through the LISA
+infrastructure. Use --lisa-dir to run against an already-cloned LISA checkout
+instead of cloning; this also allows running new-style LISA tests that have no
+[tests.X.lisa.source] configured.
 
 ```
 azldev image test IMAGE_NAME [flags]
@@ -38,17 +45,17 @@ azldev image test IMAGE_NAME [flags]
 ### Examples
 
 ```
-  # Run all test suites for an image (artifact auto-resolved from output dir)
+  # Run all tests for an image (artifact auto-resolved from output dir)
   azldev image test vm-base
 
   # Run all test suites with an explicit image path
   azldev image test vm-base --image-path ./out/images/vm-base/image.raw
 
-  # Run a specific test suite
-  azldev image test vm-base --test-suite common-vm-checks
+	# Run a specific test
+	azldev image test vm-base --test-suite static-image-checks
 
-  # Run multiple specific test suites
-  azldev image test vm-base --test-suite common-vm-checks --test-suite vm-base-checks
+	# Run multiple tests or a test-group
+	azldev image test vm-base --test-suite static-image-checks --test-suite vm-base-functional
 
   # Generate JUnit XML output
   azldev image test vm-base --junit-xml results.xml
@@ -60,7 +67,8 @@ azldev image test IMAGE_NAME [flags]
   -h, --help                 help for test
   -i, --image-path string    Path to the disk image file (resolved from image name if not specified)
       --junit-xml string     Path for writing JUnit XML output
-      --test-suite strings   Name of a test suite to run (may be repeated; defaults to all suites for the image)
+      --lisa-dir string      Path to an already-cloned LISA framework checkout to run against, instead of cloning the framework's configured git source
+      --test-suite strings   Name of a test or test-group to run (may be repeated; defaults to all tests for the image). For images configured with legacy [test-suites], this instead selects legacy test suite names
 ```
 
 ### Options inherited from parent commands

--- a/docs/user/reference/config/components.md
+++ b/docs/user/reference/config/components.md
@@ -16,6 +16,7 @@ A component definition tells azldev where to find the spec file, how to customiz
 | Render config | `render` | [RenderConfig](#render-configuration) | No | Options controlling spec rendering behavior |
 | Source files | `source-files` | array of [SourceFileReference](#source-file-references) | No | Additional source files to download for this component |
 | Package overrides | `packages` | map of string → [PackageConfig](package-groups.md#package-config) | No | Exact per-package configuration overrides; highest priority in the resolution order |
+| Tests | `tests` | [ComponentTests](#component-tests) | No | Test references that apply to this component (see [Tests and Test Groups](tests.md)) |
 
 ### Bare Components
 
@@ -338,6 +339,24 @@ rpm-channel = "rpm-devel"
 rpm-channel = "none"
 ```
 
+## Component Tests
+
+The `[components.<name>.tests]` subtable lists test or test-group
+references that apply to the component. Each entry is a [TestRef](tests.md#test-reference)
+with exactly one of `name` or `group`.
+
+| Field | TOML Key | Type | Required | Description |
+|-------|----------|------|----------|-------------|
+| Tests | `tests` | array of [TestRef](tests.md#test-reference) | No | References to `[tests.<name>]` entries or `[test-groups.<name>]` entries |
+
+```toml
+[components.kernel.tests]
+tests = [
+  { group = "kernel-bvt" },
+  { name  = "kdump-smoke" },
+]
+```
+
 ## Source File References
 
 The `[[components.<name>.source-files]]` array defines additional source files to fetch or generate before building — binaries, pre-built artifacts, or archives generated on-the-fly by a script.
@@ -537,5 +556,6 @@ lines = ["cp -vf %{shimdirx64}/$(basename %{shimefix64}) %{shimefix64} ||:"]
 - [Distros](distros.md) — distro definitions and `default-component-config` inheritance
 - [Component Groups](component-groups.md) — grouping components with shared defaults
 - [Package Groups](package-groups.md) — project-level package groups and full resolution order
+- [Tests and Test Groups](tests.md) — definitions referenced by `[components.<name>.tests]`
 - [Configuration System](../../explanation/config-system.md) — inheritance and merge behavior
 - [JSON Schema](../../../../schemas/azldev.schema.json) — machine-readable schema

--- a/docs/user/reference/config/config-file.md
+++ b/docs/user/reference/config/config-file.md
@@ -15,6 +15,8 @@ All config files share the same schema — there is no distinction between a "ro
 | `component-groups` | map of objects | Named groups of components with shared defaults | [Component Groups](component-groups.md) |
 | `images` | map of objects | Image definitions (VMs, containers) | [Images](images.md) |
 | `test-suites` | map of objects | Named test suite definitions referenced by images | [Test Suites](test-suites.md) |
+| `tests` | map of objects | Named test definitions (new-shape, parse-only) | [Tests and Test Groups](tests.md) |
+| `test-groups` | map of objects | Named bundles of test references (new-shape, parse-only) | [Tests and Test Groups](tests.md) |
 | `tools` | object | Configuration for external tools used by azldev | [Tools](tools.md) |
 | `default-package-config` | object | Project-wide default applied to all binary packages | [Package Groups — Resolution Order](package-groups.md#resolution-order) |
 | `package-groups` | map of objects | Named groups of binary packages with shared config | [Package Groups](package-groups.md) |

--- a/docs/user/reference/config/images.md
+++ b/docs/user/reference/config/images.md
@@ -32,14 +32,19 @@ The `capabilities` subtable describes what the image supports. All fields are op
 | Container | `container` | bool | unset | Whether the image can be run on an OCI container host |
 | Systemd | `systemd` | bool | unset | Whether the image runs systemd as its init system |
 | Runtime Package Management | `runtime-package-management` | bool | unset | Whether the image supports installing/removing packages at runtime (e.g., via dnf/tdnf) |
+| WSL | `wsl` | bool | unset | Whether the image runs under the Windows Subsystem for Linux runtime |
+| Installer Media | `installer-media` | bool | unset | Whether the image is installer media (e.g. an ISO) that installs another OS, rather than a directly runnable end-state image |
+| FIPS Enabled | `fips-enabled` | bool | unset | Whether the image is built or configured to run in FIPS mode |
+| CVM | `cvm` | bool | unset | Whether the image supports running as a Confidential VM (CVM) |
 
 ## Image Tests
 
-The `tests` subtable links an image to one or more test suites defined in the top-level [`[test-suites]`](test-suites.md) section.
+The `tests` subtable links an image to one or more test suites defined in the top-level [`[test-suites]`](test-suites.md) section, and/or to entries from the new-shape [`[tests]` / `[test-groups]`](tests.md) sections.
 
 | Field | TOML Key | Type | Required | Description |
 |-------|----------|------|----------|-------------|
 | Test Suites | `test-suites` | array of inline tables | No | List of test suite references. Each entry must have a `name` field matching a key in `[test-suites]`. |
+| Tests | `tests` | array of [TestRef](tests.md#test-reference) | No | References to `[tests.<name>]` entries or `[test-groups.<name>]` entries (parse-only; see [Tests and Test Groups](tests.md)). |
 
 ## Image Publish
 
@@ -118,4 +123,5 @@ channels = ["registry-prod", "registry-staging"]
 
 - [Config File Structure](config-file.md) — top-level config file layout
 - [Test Suites](test-suites.md) — test suite definitions
+- [Tests and Test Groups](tests.md) — new-shape test/group definitions referenced by `[images.<name>.tests]`
 - [Tools](tools.md) — Image Customizer tool configuration

--- a/docs/user/reference/config/tests.md
+++ b/docs/user/reference/config/tests.md
@@ -1,0 +1,120 @@
+# Tests and Test Groups
+
+The `[tests]` and `[test-groups]` sections declare framework-agnostic test
+metadata that components and images can target by name. Each test entry
+binds a single test (a pytest run, a LISA case, or a TMT plan)
+to a named identifier; each group entry bundles tests (and
+named references) under one name so callers can reference a curated set
+without enumerating every member.
+
+## Test Definition
+
+Each entry under `[tests.<name>]` describes one configuration of one
+runner. Framework-specific options live in a typed subtable
+(`pytest`, `lisa`, `tmt`) whose contents are passed through
+to the runner. azldev validates only the minimal set of keys each
+framework requires (e.g. `pytest` requires `working-dir`/`test-paths`,
+`tmt` requires `plan`/`source`, `lisa` requires at least one selector);
+any other keys are passed through unvalidated so frameworks can evolve
+independently.
+
+| Field | TOML Key | Type | Required | Description |
+|-------|----------|------|----------|-------------|
+| Type | `type` | string | Yes | Test framework: `pytest`, `lisa`, or `tmt` |
+| Description | `description` | string | No | Human-readable description |
+| Kind | `kind` | string | No | Test kind hint: `functional` or `performance` |
+| Long running | `long-running` | boolean | No | Hints that this test may run for hours |
+| Metrics enabled | `metrics-enabled` | boolean | No | Hints to the test execution environment/validation service whether metrics from this test should be collected and stored |
+| Required capabilities | `required-capabilities` | string array | No | Capability tokens the image must declare for this test to be applicable |
+| Lisa | `lisa` | table | No | LISA-specific configuration (see [LISA fields](#lisa-fields)) |
+| Tmt | `tmt` | table | No | TMT-specific configuration (opaque to azldev; metadata-only, no local execution) |
+| Pytest | `pytest` | table | No | pytest-specific configuration (opaque to azldev) |
+
+### LISA Fields
+
+The `[tests.<name>.lisa]` subtable is mostly opaque to azldev, but it
+recognizes a few keys used to select LISA test cases and, optionally, to
+run the test locally via `azldev image test` (booting the image in a QEMU
+VM, same as legacy `[test-suites]` LISA suites).
+
+| Field | TOML Key | Type | Description |
+|-------|----------|------|-------------|
+| Source | `source` | table (`git-url`, `ref`) | Git source for the LISA framework. Required for local execution; `ref` must be a full 40-character hex commit SHA. Tests without a `source` are metadata-only and must be run through external LISA orchestration. |
+| Criteria | `criteria` | table or array of tables | One or more LISA criteria blocks (`name`, `area`, `category`, `priority`, `tags`) used to select test cases. |
+| Name | `name` | string | Shorthand for a single criteria with a `name` filter. |
+| Testcase name | `testcase-name` | string | Shorthand for a single criteria matching one test case by name. |
+| Testcase names | `testcase-names` | string array | Shorthand for a single criteria matching multiple test cases by name (joined as an OR). |
+| Pip pre-install | `pip-pre-install` | string array | Pip packages to install before the framework (for overriding version pins); used only for local execution. |
+| Pip extras | `pip-extras` | string array | Pip extras to install from the LISA framework package; used only for local execution. |
+| Extra args | `extra-args` | string array | Additional arguments passed to LISA. Supports `{image-path}`, `{image-name}`, `{capabilities}` placeholders; used only for local execution. |
+
+At least one of `criteria`, `name`, `testcase-name`, or `testcase-names` is
+required.
+
+## Test Group
+
+Each entry under `[test-groups.<name>]` names an ordered list of test
+references that callers can target as a single unit.
+
+| Field | TOML Key | Type | Required | Description |
+|-------|----------|------|----------|-------------|
+| Description | `description` | string | No | Human-readable description |
+| Tests | `tests` | array of [TestRef](#test-reference) | No | Ordered members of the group (name refs only) |
+
+## Test Reference
+
+`TestRef` is an inline table with exactly one of `name` or `group`:
+
+| Field | TOML Key | Type | Description |
+|-------|----------|------|-------------|
+| Name | `name` | string | References a `[tests.<name>]` entry |
+| Group | `group` | string | References a `[test-groups.<name>]` entry |
+
+## Referencing from Components and Images
+
+Components and images both expose a `tests` subtable that holds a list
+of `TestRef`s:
+
+```toml
+[components.kernel.tests]
+tests = [{ group = "kernel-bvt" }, { name = "kdump-smoke" }]
+
+[images.vm-base.tests]
+tests = [{ group = "bvt" }]
+```
+
+## Example
+
+```toml
+[tests.bvt-ssh]
+type        = "pytest"
+description = "Basic SSH boot verification"
+kind        = "functional"
+required-capabilities = ["ssh"]
+pytest = { working-dir = "tests/bvt", test-paths = ["test_ssh.py"] }
+
+[tests.kdump-smoke]
+type        = "lisa"
+description = "Smoke test for kdump"
+lisa        = { testcase-name = "kdump_smoke" }
+
+[tests.kdump-smoke-local]
+type        = "lisa"
+description = "Smoke test for kdump (runs locally via 'azldev image test')"
+lisa.source = { git-url = "https://github.com/microsoft/lisa.git", ref = "0123456789012345678901234567890123456789" }
+lisa.testcase-names = ["kdump_smoke"]
+
+[test-groups.bvt]
+description = "Build verification tests"
+tests = [
+  { name  = "bvt-ssh" },
+  { name  = "kdump-smoke" },
+]
+```
+
+## Related Resources
+
+- [Test Suites](test-suites.md) - legacy test suite definitions
+- [Components](components.md#component-tests) — per-component `tests` field
+- [Images](images.md#image-tests) — per-image `tests` field
+- [Config File Structure](config-file.md) — top-level config layout

--- a/go.mod
+++ b/go.mod
@@ -40,6 +40,7 @@ require (
 	github.com/muesli/termenv v0.16.0
 	github.com/nxadm/tail v1.4.11
 	github.com/opencontainers/selinux v1.15.1
+	github.com/pb33f/ordered-map/v2 v2.3.1
 	github.com/pelletier/go-toml/v2 v2.4.3
 	github.com/pmezard/go-difflib v1.0.0
 	github.com/samber/lo v1.53.0
@@ -131,7 +132,6 @@ require (
 	github.com/muesli/cancelreader v0.2.2 // indirect
 	github.com/opencontainers/go-digest v1.0.0 // indirect
 	github.com/opencontainers/image-spec v1.1.1 // indirect
-	github.com/pb33f/ordered-map/v2 v2.3.1 // indirect
 	github.com/pjbgf/sha1cd v0.6.0 // indirect
 	github.com/power-devops/perfstat v0.0.0-20240221224432-82ca36839d55 // indirect
 	github.com/rivo/uniseg v0.4.7 // indirect

--- a/internal/app/azldev/cmds/component/query.go
+++ b/internal/app/azldev/cmds/component/query.go
@@ -56,6 +56,10 @@ slower than 'list' but more informative.`,
 // componentDetails encapsulates detailed information about a component.
 type componentDetails struct {
 	specs.ComponentSpecDetails
+
+	// ResolvedTests lists concrete test names after expanding any component
+	// tests.tests refs and test-groups.
+	ResolvedTests []string `json:"resolvedTests,omitempty" table:"-"`
 }
 
 // Queries env for component details, in accordance with options. Returns the found components.
@@ -72,6 +76,7 @@ func QueryComponents(
 	}
 
 	allDetails := make([]*componentDetails, 0, comps.Len())
+	cfg := env.Config()
 
 	for _, comp := range comps.Components() {
 		spec := comp.GetSpec()
@@ -83,6 +88,18 @@ func QueryComponents(
 
 		details := &componentDetails{
 			ComponentSpecDetails: *specInfo,
+		}
+
+		if cfg != nil {
+			resolvedTests, err := cfg.ResolveComponentTests(comp.GetConfig())
+			if err != nil {
+				return nil, fmt.Errorf("failed to resolve tests for component %#q:\n%w", comp.GetName(), err)
+			}
+
+			details.ResolvedTests = make([]string, 0, len(resolvedTests))
+			for _, resolvedTest := range resolvedTests {
+				details.ResolvedTests = append(details.ResolvedTests, resolvedTest.Name)
+			}
 		}
 
 		allDetails = append(allDetails, details)

--- a/internal/app/azldev/cmds/component/query_test.go
+++ b/internal/app/azldev/cmds/component/query_test.go
@@ -80,3 +80,92 @@ func TestQueryComponents_OneComponent(t *testing.T) {
 	result := results[0]
 	assert.Equal(t, testComponentName, result.Name)
 }
+
+func TestQueryComponents_ResolvesComponentTests(t *testing.T) {
+	const (
+		testComponentName = "test-component"
+		testSpecPath      = "/path/to/spec"
+	)
+
+	testEnv := testutils.NewTestEnv(t)
+	testEnv.Config.Components[testComponentName] = projectconfig.ComponentConfig{
+		Name: testComponentName,
+		Spec: projectconfig.SpecSource{
+			SourceType: projectconfig.SpecSourceTypeLocal,
+			Path:       testSpecPath,
+		},
+		Tests: &projectconfig.ComponentTestsConfig{
+			Tests: []projectconfig.TestRef{{Group: "runtime"}},
+		},
+	}
+	testEnv.Config.Tests = map[string]projectconfig.TestDefinition{
+		"runtime-a": {Type: "pytest", Pytest: map[string]any{"test-paths": []string{"tests/a.py"}}},
+		"runtime-b": {Type: "pytest", Pytest: map[string]any{"test-paths": []string{"tests/b.py"}}},
+	}
+	testEnv.Config.TestGroups = map[string]projectconfig.TestGroup{
+		"runtime": {Tests: []projectconfig.TestRef{{Name: "runtime-a"}, {Name: "runtime-b"}}},
+	}
+
+	// Pretend mock is present.
+	testEnv.CmdFactory.RegisterCommandInSearchPath(mock.MockBinary)
+
+	// Mock the rpmspec command to return valid output.
+	testEnv.CmdFactory.RunAndGetOutputHandler = func(cmd *exec.Cmd) (string, error) {
+		return "name=test-component\nepoch=0\nversion=1.0.0\nrelease=1.azl4\n", nil
+	}
+
+	options := component.QueryComponentsOptions{
+		ComponentFilter: components.ComponentFilter{
+			ComponentNamePatterns: []string{testComponentName},
+		},
+	}
+
+	err := fileutils.WriteFile(testEnv.FS(), testSpecPath, []byte("test spec content"), fileperms.PublicFile)
+	require.NoError(t, err)
+
+	results, err := component.QueryComponents(testEnv.Env, &options)
+	require.NoError(t, err)
+	require.Len(t, results, 1)
+	assert.Equal(t, []string{"runtime-a", "runtime-b"}, results[0].ResolvedTests)
+}
+
+func TestQueryComponents_InvalidComponentTestRef(t *testing.T) {
+	const (
+		testComponentName = "test-component"
+		testSpecPath      = "/path/to/spec"
+	)
+
+	testEnv := testutils.NewTestEnv(t)
+	testEnv.Config.Components[testComponentName] = projectconfig.ComponentConfig{
+		Name: testComponentName,
+		Spec: projectconfig.SpecSource{
+			SourceType: projectconfig.SpecSourceTypeLocal,
+			Path:       testSpecPath,
+		},
+		Tests: &projectconfig.ComponentTestsConfig{
+			Tests: []projectconfig.TestRef{{Name: "missing-test"}},
+		},
+	}
+
+	// Pretend mock is present.
+	testEnv.CmdFactory.RegisterCommandInSearchPath(mock.MockBinary)
+
+	// Mock the rpmspec command to return valid output.
+	testEnv.CmdFactory.RunAndGetOutputHandler = func(cmd *exec.Cmd) (string, error) {
+		return "name=test-component\nepoch=0\nversion=1.0.0\nrelease=1.azl4\n", nil
+	}
+
+	options := component.QueryComponentsOptions{
+		ComponentFilter: components.ComponentFilter{
+			ComponentNamePatterns: []string{testComponentName},
+		},
+	}
+
+	err := fileutils.WriteFile(testEnv.FS(), testSpecPath, []byte("test spec content"), fileperms.PublicFile)
+	require.NoError(t, err)
+
+	_, err = component.QueryComponents(testEnv.Env, &options)
+	require.Error(t, err)
+	require.ErrorContains(t, err, "failed to resolve tests for component")
+	require.ErrorContains(t, err, "missing-test")
+}

--- a/internal/app/azldev/cmds/image/lisacriteria.go
+++ b/internal/app/azldev/cmds/image/lisacriteria.go
@@ -1,0 +1,256 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+package image
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/microsoft/azure-linux-dev-tools/internal/projectconfig"
+)
+
+// parseLisaSource extracts and validates the LISA framework git source from a new-style
+// [tests.X.lisa] subtable. A 'source' (git-url, ref) is required to run a test locally;
+// tests without one are metadata-only and must be run through external LISA orchestration.
+func parseLisaSource(lisa map[string]any, testName string) (*projectconfig.GitSourceConfig, error) {
+	rawSource, hasSource := lisa["source"]
+	if !hasSource {
+		return nil, fmt.Errorf(
+			"LISA test %#q cannot be run locally via 'azldev image test': it has no "+
+				"[tests.%s.lisa.source] (git-url, ref) and must be run through the LISA "+
+				"infrastructure; add a 'source' with a pinned commit SHA to enable local execution",
+			testName, testName,
+		)
+	}
+
+	sourceMap, ok := rawSource.(map[string]any)
+	if !ok {
+		return nil, fmt.Errorf("test %#q lisa.source must be a table with 'git-url' and 'ref'", testName)
+	}
+
+	gitURL, _ := sourceMap["git-url"].(string)
+	ref, _ := sourceMap["ref"].(string)
+
+	source := &projectconfig.GitSourceConfig{GitURL: gitURL, Ref: ref}
+
+	if err := source.Validate(fmt.Sprintf("test %#q lisa.source", testName)); err != nil {
+		return nil, fmt.Errorf("test %#q lisa.source: %w", testName, err)
+	}
+
+	return source, nil
+}
+
+// parseLisaCriteriaFromDefinition converts a new-style [tests.X.lisa] subtable's selectors
+// (criteria table/list, or top-level name/testcase-name/testcase-names) into the runbook
+// criteria blocks used to generate a LISA runbook. Config-load-time validation already
+// guarantees at least one selector is present and that criteria entries only use allowed
+// keys, so this focuses on type conversion.
+func parseLisaCriteriaFromDefinition(lisa map[string]any, testName string) ([]lisaCriteria, error) {
+	var entries []map[string]any
+
+	if rawCriteria, ok := lisa["criteria"]; ok {
+		var err error
+
+		entries, err = normalizeLisaCriteriaEntries(rawCriteria)
+		if err != nil {
+			return nil, fmt.Errorf("test %#q lisa.criteria: %w", testName, err)
+		}
+	}
+
+	if len(entries) == 0 {
+		topLevel := map[string]any{}
+
+		for _, key := range []string{"name", "testcase-name", "testcase-names"} {
+			if value, ok := lisa[key]; ok {
+				topLevel[key] = value
+			}
+		}
+
+		if len(topLevel) > 0 {
+			entries = []map[string]any{topLevel}
+		}
+	}
+
+	if len(entries) == 0 {
+		return nil, fmt.Errorf(
+			"test %#q has no LISA selector (lisa.criteria, lisa.name, lisa.testcase-name, or "+
+				"lisa.testcase-names)", testName,
+		)
+	}
+
+	criteria := make([]lisaCriteria, 0, len(entries))
+
+	for _, entry := range entries {
+		converted, err := convertLisaCriteriaEntry(entry)
+		if err != nil {
+			return nil, fmt.Errorf("test %#q lisa.criteria: %w", testName, err)
+		}
+
+		criteria = append(criteria, converted)
+	}
+
+	return criteria, nil
+}
+
+// normalizeLisaCriteriaEntries accepts either a single criteria table or a list of criteria
+// tables, returning a uniform list of maps.
+func normalizeLisaCriteriaEntries(raw any) ([]map[string]any, error) {
+	switch value := raw.(type) {
+	case map[string]any:
+		return []map[string]any{value}, nil
+	case []any:
+		entries := make([]map[string]any, 0, len(value))
+
+		for entryIndex, item := range value {
+			entryMap, ok := item.(map[string]any)
+			if !ok {
+				return nil, fmt.Errorf("entry %d must be a table", entryIndex)
+			}
+
+			entries = append(entries, entryMap)
+		}
+
+		return entries, nil
+	default:
+		return nil, errors.New("must be a table or list of tables")
+	}
+}
+
+// convertLisaCriteriaEntry converts a single criteria (or top-level selector) map into a
+// lisaCriteria runbook block. 'testcase-name'/'testcase-names' are azldev conveniences for
+// LISA's underlying 'name' filter and are joined with '|' when multiple are given; an
+// explicit 'name' takes precedence if also present.
+func convertLisaCriteriaEntry(entry map[string]any) (lisaCriteria, error) {
+	criteria := lisaCriteria{}
+
+	if name, ok := entry["name"].(string); ok {
+		criteria.Name = name
+	}
+
+	if criteria.Name == "" {
+		if name, ok := entry["testcase-name"].(string); ok {
+			criteria.Name = name
+		}
+	}
+
+	if criteria.Name == "" {
+		if rawNames, ok := entry["testcase-names"]; ok {
+			names, err := toStringSlice(rawNames)
+			if err != nil {
+				return lisaCriteria{}, fmt.Errorf("testcase-names: %w", err)
+			}
+
+			criteria.Name = strings.Join(names, "|")
+		}
+	}
+
+	if area, ok := entry["area"].(string); ok {
+		criteria.Area = area
+	}
+
+	if category, ok := entry["category"].(string); ok {
+		criteria.Category = category
+	}
+
+	if rawPriority, ok := entry["priority"]; ok {
+		priority, err := convertLisaPriority(rawPriority)
+		if err != nil {
+			return lisaCriteria{}, fmt.Errorf("priority: %w", err)
+		}
+
+		criteria.Priority = priority
+	}
+
+	if rawTags, ok := entry["tags"]; ok {
+		tags, err := toStringSlice(rawTags)
+		if err != nil {
+			return lisaCriteria{}, fmt.Errorf("tags: %w", err)
+		}
+
+		criteria.Tags = tags
+	}
+
+	return criteria, nil
+}
+
+// convertLisaPriority converts a TOML-decoded priority value (a single integer or a list of
+// integers) into either an int or []int for embedding into the generated runbook YAML.
+func convertLisaPriority(value any) (any, error) {
+	if n, ok := toInt(value); ok {
+		return n, nil
+	}
+
+	items, ok := value.([]any)
+	if !ok {
+		return nil, fmt.Errorf("must be an integer or list of integers, got %T", value)
+	}
+
+	result := make([]int, 0, len(items))
+
+	for _, item := range items {
+		n, ok := toInt(item)
+		if !ok {
+			return nil, fmt.Errorf("must be a list of integers, got element of type %T", item)
+		}
+
+		result = append(result, n)
+	}
+
+	return result, nil
+}
+
+// toInt converts a TOML-decoded numeric value (int, int64, or float64) into an int.
+func toInt(value any) (int, bool) {
+	switch typed := value.(type) {
+	case int:
+		return typed, true
+	case int64:
+		return int(typed), true
+	case float64:
+		if typed != float64(int(typed)) {
+			return 0, false
+		}
+
+		return int(typed), true
+	default:
+		return 0, false
+	}
+}
+
+// toStringSlice converts a TOML-decoded list value ([]any of strings) into a []string.
+func toStringSlice(value any) ([]string, error) {
+	items, ok := value.([]any)
+	if !ok {
+		return nil, fmt.Errorf("must be a list of strings, got %T", value)
+	}
+
+	result := make([]string, 0, len(items))
+
+	for _, item := range items {
+		s, ok := item.(string)
+		if !ok {
+			return nil, fmt.Errorf("must be a list of strings, got element of type %T", item)
+		}
+
+		result = append(result, s)
+	}
+
+	return result, nil
+}
+
+// toOptionalStringSlice converts an optional TOML-decoded list value into a []string,
+// returning nil (with no error) when the value is absent.
+func toOptionalStringSlice(value any, fieldName string) ([]string, error) {
+	if value == nil {
+		return nil, nil
+	}
+
+	list, err := toStringSlice(value)
+	if err != nil {
+		return nil, fmt.Errorf("%s: %w", fieldName, err)
+	}
+
+	return list, nil
+}

--- a/internal/app/azldev/cmds/image/lisacriteria_internal_test.go
+++ b/internal/app/azldev/cmds/image/lisacriteria_internal_test.go
@@ -1,0 +1,143 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+package image
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseLisaSource(t *testing.T) {
+	t.Run("missing source", func(t *testing.T) {
+		_, err := parseLisaSource(map[string]any{"criteria": map[string]any{"name": "x"}}, "my-test")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "cannot be run locally")
+		assert.Contains(t, err.Error(), "my-test")
+	})
+
+	t.Run("valid source", func(t *testing.T) {
+		sha := "1234567890123456789012345678901234567890"
+		lisa := map[string]any{
+			"source": map[string]any{
+				"git-url": "https://example.com/lisa.git",
+				"ref":     sha,
+			},
+		}
+
+		source, err := parseLisaSource(lisa, "my-test")
+		require.NoError(t, err)
+		assert.Equal(t, "https://example.com/lisa.git", source.GitURL)
+		assert.Equal(t, sha, source.Ref)
+	})
+
+	t.Run("rejects non-sha ref", func(t *testing.T) {
+		lisa := map[string]any{
+			"source": map[string]any{
+				"git-url": "https://example.com/lisa.git",
+				"ref":     "20260330.1",
+			},
+		}
+
+		_, err := parseLisaSource(lisa, "my-test")
+		require.Error(t, err)
+	})
+}
+
+func TestParseLisaCriteriaFromDefinition(t *testing.T) {
+	t.Run("single criteria table with testcase-names", func(t *testing.T) {
+		lisa := map[string]any{
+			"criteria": map[string]any{
+				"testcase-names": []any{"verify_cpu_count", "verify_grub"},
+			},
+		}
+
+		criteria, err := parseLisaCriteriaFromDefinition(lisa, "my-test")
+		require.NoError(t, err)
+		require.Len(t, criteria, 1)
+		assert.Equal(t, "verify_cpu_count|verify_grub", criteria[0].Name)
+	})
+
+	t.Run("priority-only criteria", func(t *testing.T) {
+		lisa := map[string]any{
+			"criteria": map[string]any{
+				"priority": []any{int64(1)},
+			},
+		}
+
+		criteria, err := parseLisaCriteriaFromDefinition(lisa, "my-test")
+		require.NoError(t, err)
+		require.Len(t, criteria, 1)
+		assert.Equal(t, []int{1}, criteria[0].Priority)
+		assert.Empty(t, criteria[0].Name)
+	})
+
+	t.Run("list of area/category criteria", func(t *testing.T) {
+		lisa := map[string]any{
+			"criteria": []any{
+				map[string]any{"area": "network", "category": "performance"},
+				map[string]any{"area": "storage", "category": "performance"},
+			},
+		}
+
+		criteria, err := parseLisaCriteriaFromDefinition(lisa, "my-test")
+		require.NoError(t, err)
+		require.Len(t, criteria, 2)
+		assert.Equal(t, "network", criteria[0].Area)
+		assert.Equal(t, "performance", criteria[0].Category)
+		assert.Equal(t, "storage", criteria[1].Area)
+	})
+
+	t.Run("top-level testcase-name fallback", func(t *testing.T) {
+		lisa := map[string]any{
+			"testcase-name": "verify_grub",
+		}
+
+		criteria, err := parseLisaCriteriaFromDefinition(lisa, "my-test")
+		require.NoError(t, err)
+		require.Len(t, criteria, 1)
+		assert.Equal(t, "verify_grub", criteria[0].Name)
+	})
+
+	t.Run("no selector", func(t *testing.T) {
+		_, err := parseLisaCriteriaFromDefinition(map[string]any{}, "my-test")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "no LISA selector")
+	})
+
+	t.Run("tags on criteria", func(t *testing.T) {
+		lisa := map[string]any{
+			"criteria": map[string]any{
+				"name": "verify_x",
+				"tags": []any{"smoke", "fast"},
+			},
+		}
+
+		criteria, err := parseLisaCriteriaFromDefinition(lisa, "my-test")
+		require.NoError(t, err)
+		require.Len(t, criteria, 1)
+		assert.Equal(t, []string{"smoke", "fast"}, criteria[0].Tags)
+	})
+}
+
+func TestToOptionalStringSlice(t *testing.T) {
+	t.Run("nil value", func(t *testing.T) {
+		result, err := toOptionalStringSlice(nil, "extra-args")
+		require.NoError(t, err)
+		assert.Nil(t, result)
+	})
+
+	t.Run("valid list", func(t *testing.T) {
+		result, err := toOptionalStringSlice([]any{"-v", "--foo"}, "extra-args")
+		require.NoError(t, err)
+		assert.Equal(t, []string{"-v", "--foo"}, result)
+	})
+
+	t.Run("invalid type", func(t *testing.T) {
+		_, err := toOptionalStringSlice("not-a-list", "extra-args")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "extra-args")
+	})
+}

--- a/internal/app/azldev/cmds/image/lisarunbook.go
+++ b/internal/app/azldev/cmds/image/lisarunbook.go
@@ -31,8 +31,16 @@ type lisaTestcase struct {
 	Criteria lisaCriteria `yaml:"criteria"`
 }
 
+// lisaCriteria models a single LISA runbook testcase criteria block. All rules within
+// one criteria are AND-ed together by LISA; multiple criteria (multiple lisaTestcase
+// entries) are OR-ed. Name carries either an explicit name pattern or one or more test
+// case names joined with '|' (azldev's 'testcase-name'/'testcase-names' selectors).
 type lisaCriteria struct {
-	Name string `yaml:"name"`
+	Name     string   `yaml:"name,omitempty"`
+	Area     string   `yaml:"area,omitempty"`
+	Category string   `yaml:"category,omitempty"`
+	Priority any      `yaml:"priority,omitempty"`
+	Tags     []string `yaml:"tags,omitempty"`
 }
 
 type lisaNotifier struct {
@@ -76,12 +84,28 @@ const (
 // key path) are inlined as concrete values. keep_environment is "no" so LISA tears down the
 // VM environment after the run.
 func generateRunbookYAML(suiteName string, testCases []string, imagePath, adminKeyPath string) ([]byte, error) {
+	criteria := []lisaCriteria{{Name: strings.Join(testCases, "|")}}
+
+	return generateRunbookYAMLFromCriteria(suiteName, criteria, imagePath, adminKeyPath)
+}
+
+// generateRunbookYAMLFromCriteria builds a LISA runbook selecting test cases via one or
+// more criteria blocks (name, area, category, priority, tags) on a QEMU VM booted from
+// imagePath, authenticating with adminKeyPath. Each criteria produces its own testcase
+// entry; LISA ORs test cases matched across entries. keep_environment is "no" so LISA
+// tears down the VM environment after the run.
+func generateRunbookYAMLFromCriteria(
+	suiteName string, criteria []lisaCriteria, imagePath, adminKeyPath string,
+) ([]byte, error) {
+	testcases := make([]lisaTestcase, 0, len(criteria))
+	for _, c := range criteria {
+		testcases = append(testcases, lisaTestcase{Criteria: c})
+	}
+
 	runbook := lisaRunbook{
-		Name:    suiteName,
-		Include: []lisaInclude{{Path: runbookTierIncludePath}},
-		Testcase: []lisaTestcase{
-			{Criteria: lisaCriteria{Name: strings.Join(testCases, "|")}},
-		},
+		Name:     suiteName,
+		Include:  []lisaInclude{{Path: runbookTierIncludePath}},
+		Testcase: testcases,
 		Notifier: []lisaNotifier{{Type: "html"}},
 		Platform: []lisaPlatform{
 			{

--- a/internal/app/azldev/cmds/image/lisarunbook_internal_test.go
+++ b/internal/app/azldev/cmds/image/lisarunbook_internal_test.go
@@ -52,3 +52,38 @@ func TestGenerateRunbookYAML_SingleTestCase(t *testing.T) {
 	require.Len(t, runbook.Testcase, 1)
 	assert.Equal(t, "verify_grub", runbook.Testcase[0].Criteria.Name)
 }
+
+func TestGenerateRunbookYAMLFromCriteria_MultipleEntries(t *testing.T) {
+	criteria := []lisaCriteria{
+		{Area: "network", Category: "performance"},
+		{Area: "storage", Category: "performance"},
+	}
+
+	data, err := generateRunbookYAMLFromCriteria("lisa-perf", criteria, "/abs/image.qcow2", "/key")
+	require.NoError(t, err)
+
+	var runbook lisaRunbook
+	require.NoError(t, yaml.Unmarshal(data, &runbook))
+
+	require.Len(t, runbook.Testcase, 2)
+	assert.Equal(t, "network", runbook.Testcase[0].Criteria.Area)
+	assert.Equal(t, "performance", runbook.Testcase[0].Criteria.Category)
+	assert.Empty(t, runbook.Testcase[0].Criteria.Name)
+	assert.Equal(t, "storage", runbook.Testcase[1].Criteria.Area)
+}
+
+func TestGenerateRunbookYAMLFromCriteria_PriorityAndTags(t *testing.T) {
+	criteria := []lisaCriteria{
+		{Priority: []int{1}, Tags: []string{"smoke", "fast"}},
+	}
+
+	data, err := generateRunbookYAMLFromCriteria("functional-core", criteria, "img", "key")
+	require.NoError(t, err)
+
+	var runbook lisaRunbook
+	require.NoError(t, yaml.Unmarshal(data, &runbook))
+
+	require.Len(t, runbook.Testcase, 1)
+	assert.Equal(t, []any{1}, runbook.Testcase[0].Criteria.Priority)
+	assert.Equal(t, []string{"smoke", "fast"}, runbook.Testcase[0].Criteria.Tags)
+}

--- a/internal/app/azldev/cmds/image/lisarunner.go
+++ b/internal/app/azldev/cmds/image/lisarunner.go
@@ -57,13 +57,98 @@ func RunLisaSuite(
 		slog.String("image-path", options.ImagePath),
 	)
 
-	// Ensure python3 and git are available.
-	if err := prereqs.RequireExecutable(env, pythonProgram, nil); err != nil {
-		return fmt.Errorf("python3 is required to run LISA tests:\n%w", err)
+	criteria := []lisaCriteria{{Name: strings.Join(lisaConfig.TestCases, "|")}}
+
+	return runLisaLocally(
+		env, suiteConfig.Name, &lisaConfig.Framework, criteria,
+		lisaConfig.PipPreInstall, lisaConfig.PipExtras, lisaConfig.ExtraArgs,
+		imageConfig, options,
+	)
+}
+
+// RunLisaTestDefinition runs a new-style [tests.X] LISA test definition locally, generating
+// a runbook from the test's configured criteria and invoking LISA. It requires either
+// options.LisaDir (an already-cloned LISA checkout) or the test's [tests.X.lisa] subtable
+// to include a 'source' (git-url, ref) identifying the LISA framework to clone; tests with
+// neither are metadata-only and cannot be run locally (they must be run through external
+// orchestration).
+func RunLisaTestDefinition(
+	env *azldev.Env, resolvedTest projectconfig.ResolvedTest,
+	imageConfig *projectconfig.ImageConfig, options *ImageTestOptions,
+) error {
+	lisa := resolvedTest.Definition.Lisa
+	if lisa == nil {
+		return fmt.Errorf(
+			"test %#q of type %#q has no [tests.%s.lisa] subtable", resolvedTest.Name,
+			projectconfig.TestTypeLisa, resolvedTest.Name,
+		)
 	}
 
-	if err := prereqs.RequireExecutable(env, "git", nil); err != nil {
-		return fmt.Errorf("git is required to clone LISA repos:\n%w", err)
+	// A user-provided LISA checkout (--lisa-dir) makes the 'source' (git-url, ref) optional:
+	// azldev runs against the given checkout instead of cloning one.
+	var framework *projectconfig.GitSourceConfig
+
+	if options.LisaDir == "" {
+		var err error
+
+		framework, err = parseLisaSource(lisa, resolvedTest.Name)
+		if err != nil {
+			return err
+		}
+	}
+
+	criteria, err := parseLisaCriteriaFromDefinition(lisa, resolvedTest.Name)
+	if err != nil {
+		return err
+	}
+
+	pipPreInstall, err := toOptionalStringSlice(lisa["pip-pre-install"], "pip-pre-install")
+	if err != nil {
+		return fmt.Errorf("test %#q lisa.%w", resolvedTest.Name, err)
+	}
+
+	pipExtras, err := toOptionalStringSlice(lisa["pip-extras"], "pip-extras")
+	if err != nil {
+		return fmt.Errorf("test %#q lisa.%w", resolvedTest.Name, err)
+	}
+
+	extraArgs, err := toOptionalStringSlice(lisa["extra-args"], "extra-args")
+	if err != nil {
+		return fmt.Errorf("test %#q lisa.%w", resolvedTest.Name, err)
+	}
+
+	logFields := []any{
+		slog.String("name", resolvedTest.Name),
+		slog.Int("criteria", len(criteria)),
+		slog.String("image-path", options.ImagePath),
+	}
+
+	if framework != nil {
+		logFields = append(logFields, slog.String("framework-ref", framework.Ref))
+	}
+
+	slog.Info("Running LISA test", logFields...)
+
+	return runLisaLocally(
+		env, resolvedTest.Name, framework, criteria,
+		pipPreInstall, pipExtras, extraArgs, imageConfig, options,
+	)
+}
+
+// runLisaLocally sets up the LISA framework and venv, generates a runbook from the given
+// criteria, and invokes LISA against the given image. It is shared by RunLisaSuite (legacy
+// [test-suites] suites) and RunLisaTestDefinition (new-style [tests] definitions). If
+// options.LisaDir is set, that checkout is used directly instead of cloning framework; in
+// that case framework may be nil.
+func runLisaLocally(
+	env *azldev.Env, name string, framework *projectconfig.GitSourceConfig, criteria []lisaCriteria,
+	pipPreInstall, pipExtras, extraArgs []string,
+	imageConfig *projectconfig.ImageConfig, options *ImageTestOptions,
+) error {
+	// Ensure python3 is available; git is only needed when azldev clones the framework
+	// itself (i.e., --lisa-dir was not given).
+	if err := prereqs.RequireExecutable(env, pythonProgram, nil); err != nil {
+		return fmt.Errorf("python3 is required to run LISA tests:\n%w", err)
 	}
 
 	workDir := env.WorkDir()
@@ -72,15 +157,14 @@ func RunLisaSuite(
 		// 'lisa/' tree (keys, framework clones, generated runbooks) under the
 		// user's CWD, which is surprising and can pollute repos. Fail fast instead.
 		return fmt.Errorf(
-			"cannot run LISA test suite %#q: project work directory is not configured",
-			suiteConfig.Name,
+			"cannot run LISA test %#q: project work directory is not configured", name,
 		)
 	}
 
 	lisaBaseDir := filepath.Join(workDir, lisaDirName)
 
 	// Generate an ephemeral admin SSH key pair for VM access; it is removed once the
-	// suite finishes.
+	// test finishes.
 	adminKeyPath, keyCleanup, err := generateAdminKeyPair(env, lisaBaseDir)
 	if err != nil {
 		return err
@@ -88,16 +172,15 @@ func RunLisaSuite(
 
 	defer keyCleanup()
 
-	// Clone/update the LISA framework.
-	frameworkDir, err := ensureGitRepo(
-		env, lisaBaseDir, lisaFrameworkDirName, &lisaConfig.Framework,
-	)
+	// Resolve the LISA framework directory: either a user-provided checkout, or a
+	// clone/update of the configured git source.
+	frameworkDir, err := resolveLisaFrameworkDir(env, name, lisaBaseDir, framework, options)
 	if err != nil {
-		return fmt.Errorf("failed to set up LISA framework:\n%w", err)
+		return err
 	}
 
 	// Set up or reuse the LISA venv and install the framework.
-	venvDir, err := ensureLisaVenv(env, suiteConfig.Name, frameworkDir, lisaConfig.PipPreInstall, lisaConfig.PipExtras)
+	venvDir, err := ensureLisaVenv(env, name, frameworkDir, pipPreInstall, pipExtras)
 	if err != nil {
 		return err
 	}
@@ -108,16 +191,14 @@ func RunLisaSuite(
 		return err
 	}
 
-	// Generate a runbook from the configured test cases and write it into the framework
+	// Generate a runbook from the configured criteria and write it into the framework
 	// tree so its relative includes resolve.
-	runbookPath, err := writeGeneratedRunbook(
-		env, frameworkDir, suiteConfig.Name, lisaConfig.TestCases, options.ImagePath, adminKeyPath,
-	)
+	runbookPath, err := writeGeneratedRunbook(env, frameworkDir, name, criteria, options.ImagePath, adminKeyPath)
 	if err != nil {
 		return err
 	}
 
-	// Remove the generated runbook from the framework checkout once the suite finishes so
+	// Remove the generated runbook from the framework checkout once the test finishes so
 	// stale azldev-generated-* files don't accumulate or influence future runs.
 	defer func() {
 		if removeErr := env.FS().RemoveAll(runbookPath); removeErr != nil {
@@ -127,9 +208,56 @@ func RunLisaSuite(
 	}()
 
 	// Build LISA arguments with placeholder expansion.
-	lisaArgs := buildLisaArgs(runbookPath, lisaConfig.ExtraArgs, imageConfig, options)
+	lisaArgs := buildLisaArgs(runbookPath, extraArgs, imageConfig, options)
 
 	return runLisaCommand(env, venvDir, frameworkDir, lisaArgs)
+}
+
+// resolveLisaFrameworkDir returns the LISA framework directory to run against: either
+// options.LisaDir, an already-cloned checkout provided by the user (validated to exist),
+// or a clone/update of the given git source. Using a user-provided checkout avoids
+// introducing any git-source metadata requirement for the test. framework may be nil only
+// when options.LisaDir is set.
+func resolveLisaFrameworkDir(
+	env *azldev.Env, name, lisaBaseDir string, framework *projectconfig.GitSourceConfig, options *ImageTestOptions,
+) (string, error) {
+	if options.LisaDir != "" {
+		absDir, err := filepath.Abs(options.LisaDir)
+		if err != nil {
+			return "", fmt.Errorf("failed to resolve --lisa-dir %#q:\n%w", options.LisaDir, err)
+		}
+
+		isDir, err := fileutils.DirExists(env.FS(), absDir)
+		if err != nil {
+			return "", fmt.Errorf("cannot access --lisa-dir %#q:\n%w", absDir, err)
+		}
+
+		if !isDir {
+			return "", fmt.Errorf("--lisa-dir %#q does not exist or is not a directory", absDir)
+		}
+
+		slog.Info("Using user-provided LISA framework checkout", slog.String("path", absDir))
+
+		return absDir, nil
+	}
+
+	if framework == nil {
+		return "", fmt.Errorf(
+			"cannot run LISA test %#q: no LISA framework source configured; specify --lisa-dir "+
+				"to run against an existing checkout", name,
+		)
+	}
+
+	if err := prereqs.RequireExecutable(env, "git", nil); err != nil {
+		return "", fmt.Errorf("git is required to clone LISA repos:\n%w", err)
+	}
+
+	frameworkDir, err := ensureGitRepo(env, lisaBaseDir, lisaFrameworkDirName, framework)
+	if err != nil {
+		return "", fmt.Errorf("failed to set up LISA framework:\n%w", err)
+	}
+
+	return frameworkDir, nil
 }
 
 // runLisaCommand invokes the LISA executable from the framework's venv with the given args,
@@ -158,16 +286,16 @@ func runLisaCommand(env *azldev.Env, venvDir, frameworkDir string, lisaArgs []st
 	return nil
 }
 
-// writeGeneratedRunbook generates a LISA runbook from the given test cases and writes it at
+// writeGeneratedRunbook generates a LISA runbook from the given criteria and writes it at
 // the framework repo root, so that its repo-root-relative tier include
 // ('lisa/microsoft/runbook/tiers/tier.yml') resolves against the real tier definitions.
 // It returns the absolute path to the written runbook.
 func writeGeneratedRunbook(
-	env *azldev.Env, frameworkDir, suiteName string, testCases []string,
+	env *azldev.Env, frameworkDir, name string, criteria []lisaCriteria,
 	imagePath, adminKeyPath string,
 ) (string, error) {
-	if len(testCases) == 0 {
-		return "", fmt.Errorf("test suite %#q has no lisa test-cases to run", suiteName)
+	if len(criteria) == 0 {
+		return "", fmt.Errorf("test %#q has no LISA criteria to run", name)
 	}
 
 	absImagePath, err := filepath.Abs(imagePath)
@@ -175,13 +303,13 @@ func writeGeneratedRunbook(
 		absImagePath = imagePath
 	}
 
-	runbookYAML, err := generateRunbookYAML(suiteName, testCases, absImagePath, adminKeyPath)
+	runbookYAML, err := generateRunbookYAMLFromCriteria(name, criteria, absImagePath, adminKeyPath)
 	if err != nil {
 		return "", err
 	}
 
 	// Write the runbook at the framework repo root so its repo-root-relative include resolves.
-	runbookPath := filepath.Join(frameworkDir, lisaGeneratedRunbookPrefix+suiteName+".yml")
+	runbookPath := filepath.Join(frameworkDir, lisaGeneratedRunbookPrefix+name+".yml")
 
 	if err := fileutils.WriteFile(env.FS(), runbookPath, runbookYAML, fileperms.PrivateFile); err != nil {
 		return "", fmt.Errorf("failed to write generated runbook %#q:\n%w", runbookPath, err)

--- a/internal/app/azldev/cmds/image/list.go
+++ b/internal/app/azldev/cmds/image/list.go
@@ -38,7 +38,7 @@ type ImageListResult struct {
 
 	// Tests holds the test configuration for this image, matching the original config
 	// structure.
-	Tests projectconfig.ImageTestsConfig `json:"tests" table:"-"`
+	Tests *projectconfig.ImageTestsConfig `json:"tests,omitempty" table:"-"`
 
 	// TestsSummary is a comma-separated summary of test suite names for table display.
 	TestsSummary string `json:"-" table:"Tests"`

--- a/internal/app/azldev/cmds/image/list_test.go
+++ b/internal/app/azldev/cmds/image/list_test.go
@@ -89,7 +89,7 @@ func TestListImages_WithCapabilitiesAndTests(t *testing.T) {
 				MachineBootable: lo.ToPtr(true),
 				Systemd:         lo.ToPtr(true),
 			},
-			Tests: projectconfig.ImageTestsConfig{
+			Tests: &projectconfig.ImageTestsConfig{
 				TestSuites: []projectconfig.TestSuiteRef{
 					{Name: "smoke"},
 					{Name: "integration"},
@@ -105,7 +105,7 @@ func TestListImages_WithCapabilitiesAndTests(t *testing.T) {
 			Capabilities: projectconfig.ImageCapabilities{
 				Container: lo.ToPtr(true),
 			},
-			Tests: projectconfig.ImageTestsConfig{
+			Tests: &projectconfig.ImageTestsConfig{
 				TestSuites: []projectconfig.TestSuiteRef{
 					{Name: "smoke"},
 				},
@@ -131,9 +131,10 @@ func TestListImages_WithCapabilitiesAndTests(t *testing.T) {
 	assert.Equal(t, lo.ToPtr(true), results[0].Capabilities.Container)
 	assert.Nil(t, results[0].Capabilities.MachineBootable)
 	assert.Equal(t, "container", results[0].CapabilitiesSummary)
+	require.NotNil(t, results[0].Tests)
 	assert.Equal(t, projectconfig.ImageTestsConfig{
 		TestSuites: []projectconfig.TestSuiteRef{{Name: "smoke"}},
-	}, results[0].Tests)
+	}, *results[0].Tests)
 	assert.Equal(t, "smoke", results[0].TestsSummary)
 	assert.Equal(t, projectconfig.ImagePublishConfig{
 		Channels: []string{"registry-prod"},
@@ -144,7 +145,7 @@ func TestListImages_WithCapabilitiesAndTests(t *testing.T) {
 	assert.Nil(t, results[1].Capabilities.MachineBootable)
 	assert.Nil(t, results[1].Capabilities.Container)
 	assert.Empty(t, results[1].CapabilitiesSummary)
-	assert.Empty(t, results[1].Tests.TestSuites)
+	assert.Nil(t, results[1].Tests)
 	assert.Empty(t, results[1].TestsSummary)
 	assert.Empty(t, results[1].Publish.Channels)
 	assert.Empty(t, results[1].PublishSummary)
@@ -154,9 +155,10 @@ func TestListImages_WithCapabilitiesAndTests(t *testing.T) {
 	assert.Equal(t, lo.ToPtr(true), results[2].Capabilities.Systemd)
 	assert.Nil(t, results[2].Capabilities.Container)
 	assert.Equal(t, "machine-bootable, systemd", results[2].CapabilitiesSummary)
+	require.NotNil(t, results[2].Tests)
 	assert.Equal(t, projectconfig.ImageTestsConfig{
 		TestSuites: []projectconfig.TestSuiteRef{{Name: "smoke"}, {Name: "integration"}},
-	}, results[2].Tests)
+	}, *results[2].Tests)
 	assert.Equal(t, "smoke, integration", results[2].TestsSummary)
 	assert.Equal(t, projectconfig.ImagePublishConfig{
 		Channels: []string{"registry-prod", "registry-staging"},

--- a/internal/app/azldev/cmds/image/test.go
+++ b/internal/app/azldev/cmds/image/test.go
@@ -8,7 +8,6 @@ import (
 	"fmt"
 	"log/slog"
 	"path/filepath"
-	"slices"
 	"sort"
 	"strings"
 
@@ -16,6 +15,7 @@ import (
 	"github.com/microsoft/azure-linux-dev-tools/internal/global/opctx"
 	"github.com/microsoft/azure-linux-dev-tools/internal/projectconfig"
 	"github.com/microsoft/azure-linux-dev-tools/internal/utils/fileutils"
+	"github.com/pelletier/go-toml/v2"
 	"github.com/samber/lo"
 	"github.com/spf13/cobra"
 )
@@ -26,13 +26,18 @@ type ImageTestOptions struct {
 	// test suites and optionally resolve the image artifact path.
 	ImageName string
 
-	// TestSuites optionally selects specific test suites to run. When empty, all test
-	// suites associated with the image are run.
+	// TestSuites optionally selects specific test names or test-group names to run.
+	// When empty, all tests associated with the image are run.
 	TestSuites []string
 
 	// ImagePath is an optional explicit path to the image file. When empty, the image
 	// artifact is resolved from the image name in the output directory.
 	ImagePath string
+
+	// LisaDir optionally points to an already-cloned LISA framework checkout. When set,
+	// LISA tests run against this checkout directly instead of azldev cloning the
+	// framework's configured git source.
+	LisaDir string
 
 	// JUnitXMLPath is an optional path for writing JUnit XML output.
 	JUnitXMLPath string
@@ -49,15 +54,17 @@ func NewImageTestCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "test IMAGE_NAME",
 		Short: "Run tests against an Azure Linux image",
-		Long: `Run tests against an Azure Linux image using test suites defined in the
+		Long: `Run tests against an Azure Linux image using test definitions declared in the
 project configuration.
 
-Test suites are defined in the [test-suites] section of azldev.toml and referenced
-by images via the [images.NAME.tests] subtable. Each test suite specifies a type
-(pytest or lisa) and framework-specific configuration in a matching subtable.
+Images may reference tests directly via [images.NAME.tests.tests] entries, or via
+named [test-groups]. Legacy [test-suites] references are still supported.
 
-By default, all test suites associated with the named image are run. Use
---test-suite to select specific suites (may be repeated).
+By default, all tests associated with the named image are run. Use
+--test-suite to select specific test names or test-group names (may be repeated).
+For images still configured with legacy [test-suites] (via 'tests.test-suites'),
+the values passed to --test-suite are instead matched against those legacy
+test suite names.
 
 The image artifact can be specified explicitly with --image-path, or resolved
 automatically from the image name in the output directory.
@@ -69,21 +76,26 @@ extra-args to insert the image path. Glob patterns (including **) in
 test-paths are expanded automatically.
 
 For LISA tests, the test runner executes on the host and boots the image in a
-QEMU VM. azldev clones the LISA framework, generates a runbook from the suite's
-configured test cases, and runs it against the image. azldev generates an
-ephemeral SSH key pair to access the booted VM and removes it once the suite
-finishes.`,
-		Example: `  # Run all test suites for an image (artifact auto-resolved from output dir)
+QEMU VM. azldev clones the LISA framework, generates a runbook from the test's
+configured criteria (or, for legacy [test-suites], its test cases), and runs it
+against the image. azldev generates an ephemeral SSH key pair to access the
+booted VM and removes it once the test finishes. New-style [tests.X] LISA
+definitions require a [tests.X.lisa.source] (git-url, ref) to run locally;
+without one, the test is metadata-only and must be run through the LISA
+infrastructure. Use --lisa-dir to run against an already-cloned LISA checkout
+instead of cloning; this also allows running new-style LISA tests that have no
+[tests.X.lisa.source] configured.`,
+		Example: `  # Run all tests for an image (artifact auto-resolved from output dir)
   azldev image test vm-base
 
   # Run all test suites with an explicit image path
   azldev image test vm-base --image-path ./out/images/vm-base/image.raw
 
-  # Run a specific test suite
-  azldev image test vm-base --test-suite common-vm-checks
+	# Run a specific test
+	azldev image test vm-base --test-suite static-image-checks
 
-  # Run multiple specific test suites
-  azldev image test vm-base --test-suite common-vm-checks --test-suite vm-base-checks
+	# Run multiple tests or a test-group
+	azldev image test vm-base --test-suite static-image-checks --test-suite vm-base-functional
 
   # Generate JUnit XML output
   azldev image test vm-base --junit-xml results.xml`,
@@ -97,11 +109,17 @@ finishes.`,
 	}
 
 	cmd.Flags().StringSliceVar(&options.TestSuites, "test-suite", nil,
-		"Name of a test suite to run (may be repeated; defaults to all suites for the image)")
+		"Name of a test or test-group to run (may be repeated; defaults to all tests for the image). "+
+			"For images configured with legacy [test-suites], this instead selects legacy test suite names")
 
 	cmd.Flags().StringVarP(&options.ImagePath, "image-path", "i", "",
 		"Path to the disk image file (resolved from image name if not specified)")
 	_ = cmd.MarkFlagFilename("image-path")
+
+	cmd.Flags().StringVar(&options.LisaDir, "lisa-dir", "",
+		"Path to an already-cloned LISA framework checkout to run against, instead of "+
+			"cloning the framework's configured git source")
+	_ = cmd.MarkFlagDirname("lisa-dir")
 
 	cmd.Flags().StringVar(&options.JUnitXMLPath, "junit-xml", "",
 		"Path for writing JUnit XML output")
@@ -110,74 +128,101 @@ finishes.`,
 	return cmd
 }
 
-// runImageTest resolves which test suites to run and dispatches each one.
+// runImageTest resolves which tests to run and dispatches each one.
 func runImageTest(env *azldev.Env, options *ImageTestOptions) error {
 	cfg := env.Config()
 	if cfg == nil {
 		return errors.New("no project configuration loaded")
 	}
 
-	// Resolve the image config from the positional argument.
-	imageConfig, err := ResolveImageByName(env, options.ImageName)
+	imageConfig, err := prepareImageTest(env, options)
 	if err != nil {
 		return err
 	}
 
-	// Resolve image path: explicit --image-path takes precedence, otherwise resolve
-	// from the image name in the output directory.
-	imagePath := options.ImagePath
-	if imagePath == "" {
-		var resolveErr error
-
-		imagePath, _, resolveErr = findImageArtifact(env, options.ImageName, "", AllImageFormats())
-		if resolveErr != nil {
-			return resolveErr
-		}
-
-		slog.Info("Resolved image artifact",
-			slog.String("image", options.ImageName),
-			slog.String("path", imagePath),
-		)
+	resolvedTests, legacySuiteNames, err := resolveImageTestsToRun(cfg, imageConfig, options.TestSuites)
+	if err != nil {
+		return err
 	}
 
-	// Validate that the image file exists.
+	if len(resolvedTests) == 0 && len(legacySuiteNames) == 0 {
+		slog.Warn("No tests to run for image", slog.String("image", options.ImageName))
+
+		return nil
+	}
+
+	return runImageTests(env, cfg, imageConfig, options, resolvedTests, legacySuiteNames)
+}
+
+func prepareImageTest(env *azldev.Env, options *ImageTestOptions) (*projectconfig.ImageConfig, error) {
+	imageConfig, err := ResolveImageByName(env, options.ImageName)
+	if err != nil {
+		return nil, err
+	}
+
+	imagePath, err := resolveImageTestPath(env, options)
+	if err != nil {
+		return nil, err
+	}
+
 	if err := validateFileExists(env.FS(), imagePath); err != nil {
-		return fmt.Errorf("image path:\n%w", err)
+		return nil, fmt.Errorf("image path:\n%w", err)
 	}
 
 	options.ImagePath = imagePath
 
-	// Absolutize JUnitXMLPath against the user's CWD so pytest writes to the location the
-	// user expected — pytest itself resolves relative paths against its own working
-	// directory (the test suite's working-dir), which is rarely what the user intended.
 	if options.JUnitXMLPath != "" && !filepath.IsAbs(options.JUnitXMLPath) {
 		absJUnitPath, err := filepath.Abs(options.JUnitXMLPath)
 		if err != nil {
-			return fmt.Errorf("failed to resolve --junit-xml path %#q:\n%w", options.JUnitXMLPath, err)
+			return nil, fmt.Errorf("failed to resolve --junit-xml path %#q:\n%w", options.JUnitXMLPath, err)
 		}
 
 		options.JUnitXMLPath = absJUnitPath
 	}
 
-	// Determine which test suites to run.
-	suiteNames := resolveTestSuiteNames(imageConfig, options.TestSuites)
+	return imageConfig, nil
+}
 
-	// Warn when explicitly requested suites are not referenced by the image config.
-	if len(options.TestSuites) > 0 {
-		warnUnassociatedSuites(options.ImageName, imageConfig, options.TestSuites)
+func resolveImageTestPath(env *azldev.Env, options *ImageTestOptions) (string, error) {
+	if options.ImagePath != "" {
+		return options.ImagePath, nil
 	}
 
-	if len(suiteNames) == 0 {
-		slog.Warn("No test suites to run for image", slog.String("image", options.ImageName))
-
-		return nil
+	imagePath, _, err := findImageArtifact(env, options.ImageName, "", AllImageFormats())
+	if err != nil {
+		return "", err
 	}
 
-	// Resolve and run each test suite, continuing past failures so all suites get a chance
-	// to run. Config/resolution errors abort immediately since they indicate a broken setup.
+	slog.Info("Resolved image artifact",
+		slog.String("image", options.ImageName),
+		slog.String("path", imagePath),
+	)
+
+	return imagePath, nil
+}
+
+func runImageTests(
+	env *azldev.Env,
+	cfg *projectconfig.ProjectConfig,
+	imageConfig *projectconfig.ImageConfig,
+	options *ImageTestOptions,
+	resolvedTests []projectconfig.ResolvedTest,
+	legacySuiteNames []string,
+) error {
 	var testFailures []string
 
-	for _, suiteName := range suiteNames {
+	for _, resolvedTest := range resolvedTests {
+		if err := runResolvedTest(env, resolvedTest, imageConfig, options); err != nil {
+			slog.Error("Test failed",
+				slog.String("test", resolvedTest.Name),
+				slog.Any("error", err),
+			)
+
+			testFailures = append(testFailures, resolvedTest.Name)
+		}
+	}
+
+	for _, suiteName := range legacySuiteNames {
 		suiteConfig, err := resolveTestSuiteByName(cfg, suiteName)
 		if err != nil {
 			return err
@@ -194,41 +239,135 @@ func runImageTest(env *azldev.Env, options *ImageTestOptions) error {
 	}
 
 	if len(testFailures) > 0 {
-		return fmt.Errorf("%d of %d test suite(s) failed: %s",
-			len(testFailures), len(suiteNames), strings.Join(testFailures, ", "))
+		total := len(resolvedTests) + len(legacySuiteNames)
+
+		return fmt.Errorf("%d of %d test(s) failed: %s",
+			len(testFailures), total, strings.Join(testFailures, ", "))
 	}
 
 	return nil
 }
 
-// resolveTestSuiteNames determines which test suites to run. If explicit names are
-// provided, they are used as-is. Otherwise, all test suites associated with the image
-// are returned.
-func resolveTestSuiteNames(
-	imageConfig *projectconfig.ImageConfig, explicitSuites []string,
-) []string {
-	if len(explicitSuites) > 0 {
-		return explicitSuites
+func resolveImageTestsToRun(
+	cfg *projectconfig.ProjectConfig,
+	imageConfig *projectconfig.ImageConfig,
+	explicitSelectors []string,
+) ([]projectconfig.ResolvedTest, []string, error) {
+	if imageConfig.Tests != nil && len(imageConfig.Tests.Tests) > 0 {
+		return resolveCanonicalImageTests(cfg, imageConfig, explicitSelectors)
 	}
 
-	return imageConfig.TestNames()
+	if len(explicitSelectors) > 0 {
+		return nil, explicitSelectors, nil
+	}
+
+	return nil, imageConfig.TestNames(), nil
 }
 
-// warnUnassociatedSuites logs a warning for each explicitly requested test suite
-// that is not referenced by the image's test configuration.
-func warnUnassociatedSuites(
-	imageName string, imageConfig *projectconfig.ImageConfig, explicitSuites []string,
-) {
-	imageTestNames := imageConfig.TestNames()
+func resolveCanonicalImageTests(
+	cfg *projectconfig.ProjectConfig,
+	imageConfig *projectconfig.ImageConfig,
+	explicitSelectors []string,
+) ([]projectconfig.ResolvedTest, []string, error) {
+	warnIfLegacyTestSuitesIgnored(imageConfig)
 
-	for _, name := range explicitSuites {
-		if !slices.Contains(imageTestNames, name) {
-			slog.Warn("Test suite is not associated with image",
-				slog.String("suite", name),
-				slog.String("image", imageName),
-			)
+	if len(explicitSelectors) > 0 {
+		resolvedTests, err := cfg.ResolveTestSelectors(explicitSelectors)
+		if err != nil {
+			return nil, nil, fmt.Errorf("resolve test selectors: %w", err)
 		}
+
+		return resolvedTests, nil, nil
 	}
+
+	resolvedTests, err := cfg.ResolveImageTests(imageConfig)
+	if err != nil {
+		return nil, nil, fmt.Errorf("resolve image tests: %w", err)
+	}
+
+	return resolvedTests, nil, nil
+}
+
+func warnIfLegacyTestSuitesIgnored(imageConfig *projectconfig.ImageConfig) {
+	if len(imageConfig.Tests.TestSuites) == 0 {
+		return
+	}
+
+	slog.Warn(
+		"image defines both 'tests.tests' and legacy 'tests.test-suites'; "+
+			"the legacy 'tests.test-suites' entries are ignored and only 'tests.tests' "+
+			"will run. Remove 'tests.test-suites' to silence this warning",
+		slog.String("image", imageConfig.Name),
+		slog.Int("ignored-test-suites", len(imageConfig.Tests.TestSuites)),
+	)
+}
+
+func runResolvedTest(
+	env *azldev.Env,
+	resolvedTest projectconfig.ResolvedTest,
+	imageConfig *projectconfig.ImageConfig,
+	options *ImageTestOptions,
+) error {
+	switch resolvedTest.Definition.Type {
+	case string(projectconfig.TestTypePytest):
+		suiteConfig, err := testDefinitionToSuiteConfig(resolvedTest)
+		if err != nil {
+			return err
+		}
+
+		return RunPytestSuite(env, suiteConfig, imageConfig, options)
+
+	case string(projectconfig.TestTypeLisa):
+		return RunLisaTestDefinition(env, resolvedTest, imageConfig, options)
+
+	case "tmt":
+		return fmt.Errorf(
+			"TMT tests cannot be run locally via 'azldev image test'; "+
+				"test %#q is metadata-only for external orchestration",
+			resolvedTest.Name,
+		)
+
+	default:
+		return fmt.Errorf("unsupported test type %#q for test %#q", resolvedTest.Definition.Type, resolvedTest.Name)
+	}
+}
+
+func testDefinitionToSuiteConfig(resolvedTest projectconfig.ResolvedTest) (*projectconfig.TestSuiteConfig, error) {
+	pytestConfig, err := decodePytestConfig(resolvedTest.Definition.Pytest)
+	if err != nil {
+		return nil, fmt.Errorf("decode pytest config for test %#q:\n%w", resolvedTest.Name, err)
+	}
+
+	suiteConfig := &projectconfig.TestSuiteConfig{
+		Name:        resolvedTest.Name,
+		Description: resolvedTest.Definition.Description,
+		Type:        projectconfig.TestTypePytest,
+		Pytest:      pytestConfig,
+	}
+
+	if err := suiteConfig.Validate(); err != nil {
+		return nil, fmt.Errorf("invalid pytest test %#q:\n%w", resolvedTest.Name, err)
+	}
+
+	return suiteConfig, nil
+}
+
+func decodePytestConfig(raw map[string]any) (*projectconfig.PytestConfig, error) {
+	if raw == nil {
+		return nil, errors.New("missing [pytest] subtable")
+	}
+
+	bytes, err := toml.Marshal(raw)
+	if err != nil {
+		return nil, fmt.Errorf("marshal pytest config:\n%w", err)
+	}
+
+	pytestConfig := &projectconfig.PytestConfig{}
+	if err := toml.Unmarshal(bytes, pytestConfig); err != nil {
+		return nil, fmt.Errorf("unmarshal pytest config:\n%w", err)
+	}
+
+	return pytestConfig, nil
 }
 
 // resolveTestSuiteByName looks up a test suite by name in the project configuration.

--- a/internal/app/azldev/cmds/image/test_internal_test.go
+++ b/internal/app/azldev/cmds/image/test_internal_test.go
@@ -1,0 +1,165 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+package image
+
+import (
+	"bytes"
+	"log/slog"
+	"testing"
+
+	"github.com/microsoft/azure-linux-dev-tools/internal/app/azldev/core/testutils"
+	"github.com/microsoft/azure-linux-dev-tools/internal/projectconfig"
+	"github.com/microsoft/azure-linux-dev-tools/internal/utils/fileutils"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestResolveImageTestsToRun_UsesNewTestsRefs(t *testing.T) {
+	testEnv := testutils.NewTestEnv(t)
+	testEnv.Config.Tests = map[string]projectconfig.TestDefinition{
+		"static-image-checks": {Type: "pytest", Pytest: map[string]any{"working-dir": "/project/tests"}},
+		"functional_core":     {Type: "lisa", Lisa: map[string]any{"criteria": map[string]any{"priority": []any{1}}}},
+	}
+	testEnv.Config.TestGroups = map[string]projectconfig.TestGroup{
+		"vm-base-functional": {Tests: []projectconfig.TestRef{{Name: "functional_core"}}},
+	}
+
+	imageCfg := &projectconfig.ImageConfig{
+		Tests: &projectconfig.ImageTestsConfig{
+			Tests: []projectconfig.TestRef{
+				{Name: "static-image-checks"},
+				{Group: "vm-base-functional"},
+			},
+		},
+	}
+
+	resolved, legacy, err := resolveImageTestsToRun(testEnv.Config, imageCfg, nil)
+	require.NoError(t, err)
+	assert.Empty(t, legacy)
+	require.Len(t, resolved, 2)
+	assert.Equal(t, "static-image-checks", resolved[0].Name)
+	assert.Equal(t, "functional_core", resolved[1].Name)
+}
+
+func TestResolveImageTestsToRun_FallsBackToLegacyTestSuites(t *testing.T) {
+	testEnv := testutils.NewTestEnv(t)
+	imageCfg := &projectconfig.ImageConfig{
+		Tests: &projectconfig.ImageTestsConfig{
+			TestSuites: []projectconfig.TestSuiteRef{{Name: "smoke"}, {Name: "integration"}},
+		},
+	}
+
+	resolved, legacy, err := resolveImageTestsToRun(testEnv.Config, imageCfg, nil)
+	require.NoError(t, err)
+	assert.Empty(t, resolved)
+	assert.Equal(t, []string{"smoke", "integration"}, legacy)
+}
+
+func TestResolveImageTestsToRun_WarnsWhenBothTestsAndLegacyTestSuitesPresent(t *testing.T) {
+	var buf bytes.Buffer
+
+	prev := slog.Default()
+	slog.SetDefault(slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelWarn})))
+
+	t.Cleanup(func() { slog.SetDefault(prev) })
+
+	testEnv := testutils.NewTestEnv(t)
+	testEnv.Config.Tests = map[string]projectconfig.TestDefinition{
+		"static-image-checks": {Type: "pytest", Pytest: map[string]any{"working-dir": "/project/tests"}},
+	}
+
+	imageCfg := &projectconfig.ImageConfig{
+		Name: "vm-base",
+		Tests: &projectconfig.ImageTestsConfig{
+			Tests:      []projectconfig.TestRef{{Name: "static-image-checks"}},
+			TestSuites: []projectconfig.TestSuiteRef{{Name: "smoke"}},
+		},
+	}
+
+	resolved, legacy, err := resolveImageTestsToRun(testEnv.Config, imageCfg, nil)
+	require.NoError(t, err)
+	assert.Empty(t, legacy)
+	require.Len(t, resolved, 1)
+	assert.Equal(t, "static-image-checks", resolved[0].Name)
+
+	logs := buf.String()
+	assert.Contains(t, logs, "tests.test-suites")
+	assert.Contains(t, logs, "ignored")
+	assert.Contains(t, logs, "vm-base")
+}
+
+func TestResolveImageTestsToRun_NoWarnWhenOnlyNewTestsPresent(t *testing.T) {
+	var buf bytes.Buffer
+
+	prev := slog.Default()
+	slog.SetDefault(slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelWarn})))
+
+	t.Cleanup(func() { slog.SetDefault(prev) })
+
+	testEnv := testutils.NewTestEnv(t)
+	testEnv.Config.Tests = map[string]projectconfig.TestDefinition{
+		"static-image-checks": {Type: "pytest", Pytest: map[string]any{"working-dir": "/project/tests"}},
+	}
+
+	imageCfg := &projectconfig.ImageConfig{
+		Name: "vm-base",
+		Tests: &projectconfig.ImageTestsConfig{
+			Tests: []projectconfig.TestRef{{Name: "static-image-checks"}},
+		},
+	}
+
+	_, _, err := resolveImageTestsToRun(testEnv.Config, imageCfg, nil)
+	require.NoError(t, err)
+	assert.NotContains(t, buf.String(), "ignored")
+}
+
+func TestResolveLisaFrameworkDir_UsesLisaDirWhenSet(t *testing.T) {
+	testEnv := testutils.NewTestEnv(t)
+	require.NoError(t, fileutils.MkdirAll(testEnv.Env.FS(), "/checkouts/lisa"))
+
+	options := &ImageTestOptions{LisaDir: "/checkouts/lisa"}
+
+	dir, err := resolveLisaFrameworkDir(testEnv.Env, "my-test", "/work/lisa", nil, options)
+	require.NoError(t, err)
+	assert.Equal(t, "/checkouts/lisa", dir)
+}
+
+func TestResolveLisaFrameworkDir_LisaDirMissingReturnsError(t *testing.T) {
+	testEnv := testutils.NewTestEnv(t)
+
+	options := &ImageTestOptions{LisaDir: "/does/not/exist"}
+
+	_, err := resolveLisaFrameworkDir(testEnv.Env, "my-test", "/work/lisa", nil, options)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "does not exist")
+}
+
+func TestResolveLisaFrameworkDir_NoLisaDirAndNoFrameworkReturnsError(t *testing.T) {
+	testEnv := testutils.NewTestEnv(t)
+
+	options := &ImageTestOptions{}
+
+	_, err := resolveLisaFrameworkDir(testEnv.Env, "my-test", "/work/lisa", nil, options)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "--lisa-dir")
+}
+
+func TestTestDefinitionToSuiteConfig_Pytest(t *testing.T) {
+	resolvedTest := projectconfig.ResolvedTest{
+		Name: "static-image-checks",
+		Definition: projectconfig.TestDefinition{
+			Type:        "pytest",
+			Description: "offline validation",
+			Pytest:      map[string]any{"working-dir": "/project/tests", "install": "pyproject"},
+		},
+	}
+
+	suite, err := testDefinitionToSuiteConfig(resolvedTest)
+	require.NoError(t, err)
+	require.NotNil(t, suite)
+	assert.Equal(t, "static-image-checks", suite.Name)
+	require.NotNil(t, suite.Pytest)
+	assert.Equal(t, "/project/tests", suite.Pytest.WorkingDir)
+	assert.Equal(t, projectconfig.PytestInstallPyproject, suite.Pytest.Install)
+}

--- a/internal/projectconfig/component.go
+++ b/internal/projectconfig/component.go
@@ -422,6 +422,14 @@ type ComponentConfig struct {
 	// all packages produced by this component. Overridden by package-group and per-package settings
 	// for binary and debuginfo channels.
 	Publish ComponentPublishConfig `toml:"publish,omitempty" json:"publish,omitempty" table:"-" jsonschema:"title=Publish settings,description=Component-level publish channel settings" fingerprint:"-"`
+
+	// Tests holds the new-shape per-component tests block:
+	//
+	//   tests.tests = [{ name = "..." }, { group = "..." }]
+	//
+	// References must resolve to entries in the project-level [tests] or
+	// [test-groups] maps; resolution is the responsibility of the test layer.
+	Tests *ComponentTestsConfig `toml:"tests,omitempty" json:"tests,omitempty" table:"-" jsonschema:"title=Tests,description=Per-component test or test-group references" fingerprint:"-"`
 }
 
 // AllowedSourceFilesHashTypes defines the set of hash types that are supported
@@ -525,6 +533,7 @@ func (c *ComponentConfig) WithAbsolutePaths(referenceDir string) *ComponentConfi
 		// here so inherited patterns can be interpreted relative to the concrete component
 		// config file.
 		OverlayFiles: slices.Clone(c.OverlayFiles),
+		Tests:        deep.MustCopy(c.Tests),
 	}
 
 	// Fix up paths.

--- a/internal/projectconfig/configfile.go
+++ b/internal/projectconfig/configfile.go
@@ -174,6 +174,13 @@ func validateTestSuites(testSuites map[string]TestSuiteConfig) error {
 
 func validateTestDefinitions(tests map[string]TestDefinition) error {
 	for testName, testDef := range tests {
+		// Test names are used as path components (e.g., for the per-test venv directory),
+		// so reject anything that could escape the intended directory or otherwise be unsafe
+		// across platforms.
+		if err := fileutils.ValidateFilename(testName); err != nil {
+			return fmt.Errorf("invalid test name %#q:\n%w", testName, err)
+		}
+
 		if err := testDef.Validate(testName); err != nil {
 			return fmt.Errorf("invalid test %#q:\n%w", testName, err)
 		}

--- a/internal/projectconfig/configfile.go
+++ b/internal/projectconfig/configfile.go
@@ -66,6 +66,12 @@ type ConfigFile struct {
 	// Definitions of test suites.
 	TestSuites map[string]TestSuiteConfig `toml:"test-suites,omitempty" validate:"dive" jsonschema:"title=Test Suites,description=Definitions of test suites for this project"`
 
+	// Definitions of individual tests (new schema, [tests.X]).
+	Tests map[string]TestDefinition `toml:"tests,omitempty" validate:"dive" jsonschema:"title=Tests,description=Definitions of individual tests"`
+
+	// Definitions of test groups (new schema, [test-groups.X]).
+	TestGroups map[string]TestGroup `toml:"test-groups,omitempty" validate:"dive" jsonschema:"title=Test Groups,description=Definitions of named bundles of tests"`
+
 	// Internal fields used to track the origin of the config file; `dir` is the directory
 	// that the config file's relative paths are based from.
 	sourcePath string `toml:"-"`
@@ -136,8 +142,19 @@ func (f ConfigFile) Validate() error {
 		}
 	}
 
-	// Validate test suite configurations.
-	for suiteName, suite := range f.TestSuites {
+	if err := validateTestSuites(f.TestSuites); err != nil {
+		return err
+	}
+
+	if err := validateTestDefinitions(f.Tests); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func validateTestSuites(testSuites map[string]TestSuiteConfig) error {
+	for suiteName, suite := range testSuites {
 		// Suite names are used as path components (e.g., for the per-suite venv directory),
 		// so reject anything that could escape the intended directory or otherwise be unsafe
 		// across platforms.
@@ -155,6 +172,16 @@ func (f ConfigFile) Validate() error {
 	return nil
 }
 
+func validateTestDefinitions(tests map[string]TestDefinition) error {
+	for testName, testDef := range tests {
+		if err := testDef.Validate(testName); err != nil {
+			return fmt.Errorf("invalid test %#q:\n%w", testName, err)
+		}
+	}
+
+	return nil
+}
+
 // validateComponentGroupMetadata validates the optional documentation metadata declared
 // on each component group.
 func validateComponentGroupMetadata(groups map[string]ComponentGroupConfig) error {
@@ -165,6 +192,185 @@ func validateComponentGroupMetadata(groups map[string]ComponentGroupConfig) erro
 
 		if err := group.Metadata.Validate(); err != nil {
 			return fmt.Errorf("invalid metadata on component group %#q:\n%w", groupName, err)
+		}
+	}
+
+	return nil
+}
+
+func validateNewTestReferences(
+	tests map[string]TestDefinition,
+	groups map[string]TestGroup,
+	components map[string]ComponentConfig,
+	images map[string]ImageConfig,
+) error {
+	for groupName, group := range groups {
+		scope := fmt.Sprintf("test-group %#q tests", groupName)
+		if err := validateTestGroupMembers(scope, group.Tests, tests); err != nil {
+			return err
+		}
+	}
+
+	for componentName, component := range components {
+		if component.Tests == nil {
+			continue
+		}
+
+		scope := fmt.Sprintf("component %#q tests.tests", componentName)
+		if err := validateTestRefList(scope, component.Tests.Tests, tests, groups); err != nil {
+			return err
+		}
+	}
+
+	for imageName, image := range images {
+		if image.Tests == nil {
+			continue
+		}
+
+		scope := fmt.Sprintf("image %#q tests.tests", imageName)
+		if err := validateTestRefList(scope, image.Tests.Tests, tests, groups); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func validateTestGroupMembers(
+	scope string,
+	refs []TestRef,
+	tests map[string]TestDefinition,
+) error {
+	seenRefs := make(map[string]int, len(refs))
+
+	for idx, ref := range refs {
+		hasName := ref.Name != ""
+		hasGroup := ref.Group != ""
+
+		if hasName == hasGroup {
+			return fmt.Errorf(
+				"%w: %s[%d] must set exactly one of 'name' or 'group'",
+				ErrInvalidTestRef,
+				scope,
+				idx,
+			)
+		}
+
+		if hasGroup {
+			return fmt.Errorf(
+				"%w: %s[%d].group is not allowed in [test-groups]; use .name to reference a [tests] entry",
+				ErrNestedTestGroupReference,
+				scope,
+				idx,
+			)
+		}
+
+		if _, ok := tests[ref.Name]; !ok {
+			return fmt.Errorf(
+				"%w: %s[%d].name references undefined test %#q",
+				ErrUndefinedTest,
+				scope,
+				idx,
+				ref.Name,
+			)
+		}
+
+		refKey := "name:" + ref.Name
+		if firstIdx, exists := seenRefs[refKey]; exists {
+			return fmt.Errorf(
+				"%w: %s[%d] duplicates %s[%d] (%#q)",
+				ErrDuplicateTestRef,
+				scope,
+				idx,
+				scope,
+				firstIdx,
+				ref.Name,
+			)
+		}
+
+		seenRefs[refKey] = idx
+	}
+
+	return nil
+}
+
+func validateTestRefList(
+	scope string,
+	refs []TestRef,
+	tests map[string]TestDefinition,
+	groups map[string]TestGroup,
+) error {
+	// seenTests maps a resolved (post-group-expansion) test name to a description of
+	// the ref that first contributed it, so that a name ref and a group ref (or two
+	// group refs) which both resolve to the same underlying test are caught, not just
+	// two textually-identical refs.
+	seenTests := make(map[string]string, len(refs))
+
+	checkDuplicate := func(testName, desc string) error {
+		if firstDesc, exists := seenTests[testName]; exists {
+			return fmt.Errorf(
+				"%w: %s duplicates %s (both resolve to test %#q)",
+				ErrDuplicateTestRef,
+				desc,
+				firstDesc,
+				testName,
+			)
+		}
+
+		seenTests[testName] = desc
+
+		return nil
+	}
+
+	for idx, ref := range refs {
+		hasName := ref.Name != ""
+		hasGroup := ref.Group != ""
+
+		if hasName == hasGroup {
+			return fmt.Errorf(
+				"%w: %s[%d] must set exactly one of 'name' or 'group'",
+				ErrInvalidTestRef,
+				scope,
+				idx,
+			)
+		}
+
+		if hasName {
+			if _, ok := tests[ref.Name]; !ok {
+				return fmt.Errorf(
+					"%w: %s[%d].name references undefined test %#q",
+					ErrUndefinedTest,
+					scope,
+					idx,
+					ref.Name,
+				)
+			}
+
+			desc := fmt.Sprintf("%s[%d] (name=%#q)", scope, idx, ref.Name)
+			if err := checkDuplicate(ref.Name, desc); err != nil {
+				return err
+			}
+
+			continue
+		}
+
+		group, ok := groups[ref.Group]
+		if !ok {
+			return fmt.Errorf(
+				"%w: %s[%d].group references undefined test-group %#q",
+				ErrUndefinedTestGroup,
+				scope,
+				idx,
+				ref.Group,
+			)
+		}
+
+		desc := fmt.Sprintf("%s[%d] (group=%#q)", scope, idx, ref.Group)
+
+		for _, groupRef := range group.Tests {
+			if err := checkDuplicate(groupRef.Name, desc); err != nil {
+				return err
+			}
 		}
 	}
 

--- a/internal/projectconfig/configfile_test.go
+++ b/internal/projectconfig/configfile_test.go
@@ -4,6 +4,8 @@
 package projectconfig_test
 
 import (
+	"bytes"
+	"log/slog"
 	"testing"
 
 	"github.com/microsoft/azure-linux-dev-tools/internal/projectconfig"
@@ -15,6 +17,482 @@ import (
 func TestProjectConfigFileValidation_EmptyFile(t *testing.T) {
 	file := projectconfig.ConfigFile{}
 	assert.NoError(t, file.Validate())
+}
+
+func TestProjectConfigFileValidation_TestDefinitionMismatchedSubtable(t *testing.T) {
+	file := projectconfig.ConfigFile{
+		Tests: map[string]projectconfig.TestDefinition{
+			"smoke": {
+				Type:   "pytest",
+				Pytest: map[string]any{"working-dir": "tests", "test-paths": []any{"test_smoke.py"}},
+				Lisa:   map[string]any{"suite": "vm"},
+			},
+		},
+	}
+
+	err := file.Validate()
+	require.Error(t, err)
+	require.ErrorIs(t, err, projectconfig.ErrMismatchedTestSubtable)
+	assert.Contains(t, err.Error(), "invalid test")
+	assert.Contains(t, err.Error(), "smoke")
+	assert.Contains(t, err.Error(), "lisa")
+}
+
+func TestProjectConfigFileValidation_TestDefinitionMatchingSubtable(t *testing.T) {
+	file := projectconfig.ConfigFile{
+		Tests: map[string]projectconfig.TestDefinition{
+			"smoke": {
+				Type:   "pytest",
+				Pytest: map[string]any{"working-dir": "tests", "test-paths": []any{"test_smoke.py"}},
+			},
+		},
+	}
+
+	assert.NoError(t, file.Validate())
+}
+
+func TestProjectConfigFileValidation_TestDefinitionRequiredSubtablePresentButEmpty(t *testing.T) {
+	file := projectconfig.ConfigFile{
+		Tests: map[string]projectconfig.TestDefinition{
+			"smoke": {
+				Type:   "pytest",
+				Pytest: map[string]any{},
+			},
+		},
+	}
+
+	err := file.Validate()
+	require.Error(t, err)
+	require.ErrorIs(t, err, projectconfig.ErrInvalidPytestConfig)
+	assert.Contains(t, err.Error(), "working-dir")
+}
+
+func TestProjectConfigFileValidation_TestDefinitionDisallowedSubtablePresentButEmpty(t *testing.T) {
+	file := projectconfig.ConfigFile{
+		Tests: map[string]projectconfig.TestDefinition{
+			"smoke": {
+				Type:   "pytest",
+				Pytest: map[string]any{"working-dir": "tests", "test-paths": []any{"test_smoke.py"}},
+				Lisa:   map[string]any{},
+			},
+		},
+	}
+
+	err := file.Validate()
+	require.Error(t, err)
+	require.ErrorIs(t, err, projectconfig.ErrMismatchedTestSubtable)
+	assert.Contains(t, err.Error(), "smoke")
+	assert.Contains(t, err.Error(), "lisa")
+}
+
+func TestProjectConfigFileValidation_TestDefinitionInvalidKind(t *testing.T) {
+	file := projectconfig.ConfigFile{
+		Tests: map[string]projectconfig.TestDefinition{
+			"smoke": {
+				Type:   "pytest",
+				Kind:   projectconfig.TestKind("unknown-kind"),
+				Pytest: map[string]any{"working-dir": "tests", "test-paths": []any{"test_smoke.py"}},
+			},
+		},
+	}
+
+	err := file.Validate()
+	require.Error(t, err)
+	require.ErrorIs(t, err, projectconfig.ErrUnknownTestKind)
+	assert.Contains(t, err.Error(), "unknown-kind")
+}
+
+func TestProjectConfigFileValidation_LisaSelectionMissing(t *testing.T) {
+	file := projectconfig.ConfigFile{
+		Tests: map[string]projectconfig.TestDefinition{
+			"smoke": {
+				Type: "lisa",
+				Lisa: map[string]any{
+					"source": map[string]any{"git-url": "https://example.com/lisa.git", "ref": "main"},
+				},
+			},
+		},
+	}
+
+	err := file.Validate()
+	require.Error(t, err)
+	require.ErrorIs(t, err, projectconfig.ErrInvalidLisaSelection)
+	assert.Contains(t, err.Error(), "must set at least one LISA selector")
+}
+
+func TestProjectConfigFileValidation_LisaSelectionCriteriaValid(t *testing.T) {
+	file := projectconfig.ConfigFile{
+		Tests: map[string]projectconfig.TestDefinition{
+			"smoke": {
+				Type: "lisa",
+				Lisa: map[string]any{
+					"criteria": map[string]any{"priority": []any{1, 2}, "tags": []any{"vm", "smoke"}},
+				},
+			},
+			"perf": {
+				Type: "lisa",
+				Lisa: map[string]any{
+					"criteria": []any{
+						map[string]any{"area": "network", "category": "performance"},
+						map[string]any{"testcase-names": []any{"case_a", "case_b"}},
+					},
+				},
+			},
+		},
+	}
+
+	assert.NoError(t, file.Validate())
+}
+
+func TestProjectConfigFileValidation_LisaSelectionUnsupportedCriteriaKey(t *testing.T) {
+	file := projectconfig.ConfigFile{
+		Tests: map[string]projectconfig.TestDefinition{
+			"smoke": {
+				Type: "lisa",
+				Lisa: map[string]any{
+					"criteria": map[string]any{"suite": "smoke"},
+				},
+			},
+		},
+	}
+
+	err := file.Validate()
+	require.Error(t, err)
+	require.ErrorIs(t, err, projectconfig.ErrInvalidLisaSelection)
+	assert.Contains(t, err.Error(), "unsupported selector")
+}
+
+func TestProjectConfigValidation_UndefinedTestReferenceInGroup(t *testing.T) {
+	cfg := projectconfig.NewProjectConfig()
+	cfg.TestGroups = map[string]projectconfig.TestGroup{
+		"bvt": {
+			Tests: []projectconfig.TestRef{{Name: "does-not-exist"}},
+		},
+	}
+
+	err := cfg.Validate()
+	require.Error(t, err)
+	require.ErrorIs(t, err, projectconfig.ErrUndefinedTest)
+	assert.Contains(t, err.Error(), "does-not-exist")
+}
+
+func TestProjectConfigValidation_UndefinedTestGroupReferenceInComponent(t *testing.T) {
+	cfg := projectconfig.NewProjectConfig()
+	cfg.Components = map[string]projectconfig.ComponentConfig{
+		"openssl": {
+			Tests: &projectconfig.ComponentTestsConfig{
+				Tests: []projectconfig.TestRef{{Group: "missing-group"}},
+			},
+		},
+	}
+
+	err := cfg.Validate()
+	require.Error(t, err)
+	require.ErrorIs(t, err, projectconfig.ErrUndefinedTestGroup)
+	assert.Contains(t, err.Error(), "missing-group")
+}
+
+func TestProjectConfigValidation_InvalidTestReferenceShapeInImage(t *testing.T) {
+	cfg := projectconfig.NewProjectConfig()
+	cfg.Images = map[string]projectconfig.ImageConfig{
+		"base": {
+			Tests: &projectconfig.ImageTestsConfig{
+				Tests: []projectconfig.TestRef{{Name: "smoke", Group: "bvt"}},
+			},
+		},
+	}
+	cfg.Tests = map[string]projectconfig.TestDefinition{
+		"smoke": {
+			Type:   "pytest",
+			Pytest: map[string]any{"working-dir": "tests", "test-paths": []any{"test_smoke.py"}},
+		},
+	}
+	cfg.TestGroups = map[string]projectconfig.TestGroup{
+		"bvt": {Tests: []projectconfig.TestRef{{Name: "smoke"}}},
+	}
+
+	err := cfg.Validate()
+	require.Error(t, err)
+	require.ErrorIs(t, err, projectconfig.ErrInvalidTestRef)
+	assert.Contains(t, err.Error(), "exactly one")
+}
+
+func TestProjectConfigValidation_DuplicateTestReferenceInGroup(t *testing.T) {
+	cfg := projectconfig.NewProjectConfig()
+	cfg.Tests = map[string]projectconfig.TestDefinition{
+		"smoke": {
+			Type:   "pytest",
+			Pytest: map[string]any{"working-dir": "tests", "test-paths": []any{"test_smoke.py"}},
+		},
+	}
+	cfg.TestGroups = map[string]projectconfig.TestGroup{
+		"bvt": {
+			Tests: []projectconfig.TestRef{
+				{Name: "smoke"},
+				{Name: "smoke"},
+			},
+		},
+	}
+
+	err := cfg.Validate()
+	require.Error(t, err)
+	require.ErrorIs(t, err, projectconfig.ErrDuplicateTestRef)
+	assert.Contains(t, err.Error(), "duplicates")
+	assert.Contains(t, err.Error(), "smoke")
+}
+
+func TestProjectConfigValidation_DuplicateTestGroupReferenceInImage(t *testing.T) {
+	cfg := projectconfig.NewProjectConfig()
+	cfg.Tests = map[string]projectconfig.TestDefinition{
+		"smoke": {
+			Type:   "pytest",
+			Pytest: map[string]any{"working-dir": "tests", "test-paths": []any{"test_smoke.py"}},
+		},
+	}
+	cfg.TestGroups = map[string]projectconfig.TestGroup{
+		"bvt": {
+			Tests: []projectconfig.TestRef{{Name: "smoke"}},
+		},
+	}
+	cfg.Images = map[string]projectconfig.ImageConfig{
+		"base": {
+			Tests: &projectconfig.ImageTestsConfig{
+				Tests: []projectconfig.TestRef{
+					{Group: "bvt"},
+					{Group: "bvt"},
+				},
+			},
+		},
+	}
+
+	err := cfg.Validate()
+	require.Error(t, err)
+	require.ErrorIs(t, err, projectconfig.ErrDuplicateTestRef)
+	assert.Contains(t, err.Error(), "duplicates")
+	assert.Contains(t, err.Error(), "bvt")
+}
+
+func TestProjectConfigValidation_DuplicateTestViaNameAndGroupInImage(t *testing.T) {
+	cfg := projectconfig.NewProjectConfig()
+	cfg.Tests = map[string]projectconfig.TestDefinition{
+		"ssh-smoke": {
+			Type:   "pytest",
+			Pytest: map[string]any{"working-dir": "tests", "test-paths": []any{"test_smoke.py"}},
+		},
+	}
+	cfg.TestGroups = map[string]projectconfig.TestGroup{
+		"bvt": {
+			Tests: []projectconfig.TestRef{{Name: "ssh-smoke"}},
+		},
+	}
+	cfg.Images = map[string]projectconfig.ImageConfig{
+		"vm-base": {
+			Tests: &projectconfig.ImageTestsConfig{
+				Tests: []projectconfig.TestRef{
+					{Name: "ssh-smoke"},
+					{Group: "bvt"},
+				},
+			},
+		},
+	}
+
+	err := cfg.Validate()
+	require.Error(t, err)
+	require.ErrorIs(t, err, projectconfig.ErrDuplicateTestRef)
+	assert.Contains(t, err.Error(), "duplicates")
+	assert.Contains(t, err.Error(), "ssh-smoke")
+	assert.Contains(t, err.Error(), "name=")
+	assert.Contains(t, err.Error(), "group=")
+	assert.Contains(t, err.Error(), "bvt")
+}
+
+func TestProjectConfigValidation_ContradictingImageCapabilities(t *testing.T) {
+	trueVal := true
+
+	cfg := projectconfig.NewProjectConfig()
+	cfg.Images = map[string]projectconfig.ImageConfig{
+		"vm-iso-installer": {
+			Capabilities: projectconfig.ImageCapabilities{
+				MachineBootable: &trueVal,
+				InstallerMedia:  &trueVal,
+			},
+		},
+	}
+
+	err := cfg.Validate()
+	require.Error(t, err)
+	require.ErrorIs(t, err, projectconfig.ErrContradictingImageCapabilities)
+	assert.Contains(t, err.Error(), "vm-iso-installer")
+	assert.Contains(t, err.Error(), "machine-bootable")
+	assert.Contains(t, err.Error(), "installer-media")
+}
+
+func TestProjectConfigValidation_NonContradictingImageCapabilities(t *testing.T) {
+	trueVal := true
+
+	cfg := projectconfig.NewProjectConfig()
+	cfg.Images = map[string]projectconfig.ImageConfig{
+		"vm-base": {
+			Capabilities: projectconfig.ImageCapabilities{
+				MachineBootable: &trueVal,
+			},
+		},
+		"container-base": {
+			Capabilities: projectconfig.ImageCapabilities{
+				Container: &trueVal,
+			},
+		},
+		"wsl": {
+			Capabilities: projectconfig.ImageCapabilities{
+				WSL: &trueVal,
+			},
+		},
+		"vm-iso-installer": {
+			Capabilities: projectconfig.ImageCapabilities{
+				InstallerMedia: &trueVal,
+			},
+		},
+	}
+
+	err := cfg.Validate()
+	require.NoError(t, err)
+}
+
+func TestProjectConfigValidation_LegacyTestSuitesEmitsDeprecationWarning(t *testing.T) {
+	var buf bytes.Buffer
+
+	prev := slog.Default()
+	slog.SetDefault(slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelWarn})))
+
+	t.Cleanup(func() { slog.SetDefault(prev) })
+
+	cfg := projectconfig.NewProjectConfig()
+	cfg.TestSuites = map[string]projectconfig.TestSuiteConfig{
+		"static-image-checks": {},
+	}
+	cfg.Images = map[string]projectconfig.ImageConfig{
+		"legacy-img": {
+			Tests: &projectconfig.ImageTestsConfig{
+				TestSuites: []projectconfig.TestSuiteRef{{Name: "static-image-checks"}},
+			},
+		},
+	}
+
+	err := cfg.Validate()
+	require.NoError(t, err)
+
+	logs := buf.String()
+	assert.Contains(t, logs, "deprecated")
+	assert.Contains(t, logs, "tests.test-suites")
+	assert.Contains(t, logs, "legacy-img")
+}
+
+func TestProjectConfigValidation_NewShapeTestsNoDeprecationWarning(t *testing.T) {
+	var buf bytes.Buffer
+
+	prev := slog.Default()
+	slog.SetDefault(slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelWarn})))
+
+	t.Cleanup(func() { slog.SetDefault(prev) })
+
+	cfg := projectconfig.NewProjectConfig()
+	cfg.Tests = map[string]projectconfig.TestDefinition{
+		"static-image-checks": {
+			Type:   "pytest",
+			Pytest: map[string]any{"working-dir": "tests", "test-paths": []any{"test_smoke.py"}},
+		},
+	}
+	cfg.Images = map[string]projectconfig.ImageConfig{
+		"new-img": {
+			Tests: &projectconfig.ImageTestsConfig{
+				Tests: []projectconfig.TestRef{{Name: "static-image-checks"}},
+			},
+		},
+	}
+
+	err := cfg.Validate()
+	require.NoError(t, err)
+
+	assert.NotContains(t, buf.String(), "deprecated")
+}
+
+func TestProjectConfigValidation_NestedTestGroupReferenceNotAllowed(t *testing.T) {
+	cfg := projectconfig.NewProjectConfig()
+	cfg.Tests = map[string]projectconfig.TestDefinition{
+		"smoke": {
+			Type:   "pytest",
+			Pytest: map[string]any{"working-dir": "tests", "test-paths": []any{"test_smoke.py"}},
+		},
+	}
+	cfg.TestGroups = map[string]projectconfig.TestGroup{
+		"a": {Tests: []projectconfig.TestRef{{Group: "b"}}},
+		"b": {Tests: []projectconfig.TestRef{{Name: "smoke"}}},
+	}
+
+	err := cfg.Validate()
+	require.Error(t, err)
+	require.ErrorIs(t, err, projectconfig.ErrNestedTestGroupReference)
+	assert.Contains(t, err.Error(), "is not allowed in [test-groups]")
+}
+
+func TestProjectConfigResolveImageTests_ExpandsGroups(t *testing.T) {
+	cfg := projectconfig.NewProjectConfig()
+	cfg.Tests = map[string]projectconfig.TestDefinition{
+		"static-image-checks": {
+			Type:   "pytest",
+			Pytest: map[string]any{"working-dir": "tests", "test-paths": []any{"test_smoke.py"}},
+		},
+		"functional_core": {Type: "lisa", Lisa: map[string]any{"criteria": map[string]any{"priority": []any{1}}}},
+		"lisa_perf": {
+			Type: "lisa",
+			Lisa: map[string]any{"criteria": map[string]any{"area": "network", "category": "performance"}},
+		},
+	}
+	cfg.TestGroups = map[string]projectconfig.TestGroup{
+		"vm-base-functional":  {Tests: []projectconfig.TestRef{{Name: "functional_core"}}},
+		"vm-base-performance": {Tests: []projectconfig.TestRef{{Name: "lisa_perf"}}},
+	}
+
+	imageCfg := &projectconfig.ImageConfig{
+		Tests: &projectconfig.ImageTestsConfig{
+			Tests: []projectconfig.TestRef{
+				{Name: "static-image-checks"},
+				{Group: "vm-base-functional"},
+				{Group: "vm-base-performance"},
+			},
+		},
+	}
+
+	resolved, err := cfg.ResolveImageTests(imageCfg)
+	require.NoError(t, err)
+	require.Len(t, resolved, 3)
+	assert.Equal(t, []string{"static-image-checks", "functional_core", "lisa_perf"}, []string{
+		resolved[0].Name,
+		resolved[1].Name,
+		resolved[2].Name,
+	})
+}
+
+func TestProjectConfigResolveComponentTests_ExpandsGroups(t *testing.T) {
+	cfg := projectconfig.NewProjectConfig()
+	cfg.Tests = map[string]projectconfig.TestDefinition{
+		"bash-fedora-shell": {Type: "tmt", Tmt: map[string]any{"plan": "/plans/shell"}},
+	}
+	cfg.TestGroups = map[string]projectconfig.TestGroup{
+		"shell-tests": {Tests: []projectconfig.TestRef{{Name: "bash-fedora-shell"}}},
+	}
+
+	componentCfg := &projectconfig.ComponentConfig{
+		Tests: &projectconfig.ComponentTestsConfig{
+			Tests: []projectconfig.TestRef{{Group: "shell-tests"}},
+		},
+	}
+
+	resolved, err := cfg.ResolveComponentTests(componentCfg)
+	require.NoError(t, err)
+	require.Len(t, resolved, 1)
+	assert.Equal(t, "bash-fedora-shell", resolved[0].Name)
+	assert.Equal(t, "tmt", resolved[0].Definition.Type)
 }
 
 func TestProjectConfigFileValidation_DefaultProjectInfo(t *testing.T) {

--- a/internal/projectconfig/fingerprint_test.go
+++ b/internal/projectconfig/fingerprint_test.go
@@ -67,6 +67,9 @@ func TestAllFingerprintedFieldsHaveDecision(t *testing.T) {
 		// ComponentConfig.Publish — post-build routing (where to publish), not a build input.
 		"ComponentConfig.Publish": true,
 
+		// ComponentConfig.Tests — test selection metadata (new schema), not a build input.
+		"ComponentConfig.Tests": true,
+
 		// ComponentOverlay.Description — human-readable documentation for the overlay.
 		"ComponentOverlay.Description": true,
 		// ComponentOverlay.Source — absolute path that varies by checkout location.

--- a/internal/projectconfig/image.go
+++ b/internal/projectconfig/image.go
@@ -30,7 +30,7 @@ type ImageConfig struct {
 
 	// Tests holds the test configuration for this image, including which test suites
 	// apply to it.
-	Tests ImageTestsConfig `toml:"tests,omitempty" json:"tests,omitempty" jsonschema:"title=Tests,description=Test configuration for this image"`
+	Tests *ImageTestsConfig `toml:"tests,omitempty" json:"tests,omitempty" jsonschema:"title=Tests,description=Test configuration for this image"`
 
 	// Publish holds the publish settings for this image.
 	Publish ImagePublishConfig `toml:"publish,omitempty" json:"publish,omitempty" jsonschema:"title=Publish settings,description=Publishing settings for this image"`
@@ -61,6 +61,20 @@ type ImageCapabilities struct {
 	// RuntimePackageManagement indicates whether the image supports installing or
 	// removing packages at runtime (e.g., via dnf/tdnf).
 	RuntimePackageManagement *bool `toml:"runtime-package-management,omitempty" json:"runtimePackageManagement,omitempty" jsonschema:"title=Runtime package management,description=Whether the image supports installing or removing packages at runtime"`
+
+	// WSL indicates whether the image runs under the Windows Subsystem for Linux
+	// runtime, rather than being booted as a VM/bare-metal machine.
+	WSL *bool `toml:"wsl,omitempty" json:"wsl,omitempty" jsonschema:"title=WSL,description=Whether the image runs under the Windows Subsystem for Linux runtime"`
+
+	// InstallerMedia indicates whether the image is installer media (e.g. an ISO) that
+	// installs another OS, rather than a directly runnable/bootable end-state image.
+	InstallerMedia *bool `toml:"installer-media,omitempty" json:"installerMedia,omitempty" jsonschema:"title=Installer media,description=Whether the image is installer media that installs another OS rather than a directly runnable end-state image"`
+
+	// FipsEnabled indicates whether the image is built/configured to run in FIPS mode.
+	FipsEnabled *bool `toml:"fips-enabled,omitempty" json:"fipsEnabled,omitempty" jsonschema:"title=FIPS enabled,description=Whether the image is built or configured to run in FIPS mode"`
+
+	// CVM indicates whether the image supports running as a Confidential VM (CVM).
+	CVM *bool `toml:"cvm,omitempty" json:"cvm,omitempty" jsonschema:"title=Confidential VM,description=Whether the image supports running as a Confidential VM (CVM)"`
 }
 
 // IsMachineBootable returns true if the image is explicitly marked as machine-bootable.
@@ -85,6 +99,26 @@ func (c *ImageCapabilities) IsRuntimePackageManagement() bool {
 	return c.RuntimePackageManagement != nil && *c.RuntimePackageManagement
 }
 
+// IsWSL returns true if the image explicitly runs under the WSL runtime.
+func (c *ImageCapabilities) IsWSL() bool {
+	return c.WSL != nil && *c.WSL
+}
+
+// IsInstallerMedia returns true if the image is explicitly marked as installer media.
+func (c *ImageCapabilities) IsInstallerMedia() bool {
+	return c.InstallerMedia != nil && *c.InstallerMedia
+}
+
+// IsFipsEnabled returns true if the image is explicitly marked as FIPS-enabled.
+func (c *ImageCapabilities) IsFipsEnabled() bool {
+	return c.FipsEnabled != nil && *c.FipsEnabled
+}
+
+// IsCVM returns true if the image explicitly supports running as a Confidential VM.
+func (c *ImageCapabilities) IsCVM() bool {
+	return c.CVM != nil && *c.CVM
+}
+
 // EnabledNames returns the TOML field names of capabilities that are explicitly set to
 // true, in a stable order matching the struct field declaration order.
 func (c *ImageCapabilities) EnabledNames() []string {
@@ -106,6 +140,22 @@ func (c *ImageCapabilities) EnabledNames() []string {
 		names = append(names, "runtime-package-management")
 	}
 
+	if c.IsWSL() {
+		names = append(names, "wsl")
+	}
+
+	if c.IsInstallerMedia() {
+		names = append(names, "installer-media")
+	}
+
+	if c.IsFipsEnabled() {
+		names = append(names, "fips-enabled")
+	}
+
+	if c.IsCVM() {
+		names = append(names, "cvm")
+	}
+
 	return names
 }
 
@@ -115,6 +165,11 @@ type ImageTestsConfig struct {
 	// reference identifies a test suite defined in the top-level [test-suites] section
 	// and may carry per-test metadata in the future (e.g., required vs optional).
 	TestSuites []TestSuiteRef `toml:"test-suites,omitempty" json:"testSuites,omitempty" jsonschema:"title=Test Suites,description=List of test suite references that apply to this image"`
+
+	// Tests is the new-shape list of test or test-group references that apply to this
+	// image. References must resolve to entries in the project-level [tests] or
+	// [test-groups] maps; resolution is the responsibility of the test layer.
+	Tests []TestRef `toml:"tests,omitempty" json:"tests,omitempty" jsonschema:"title=Tests,description=List of test or test-group references that apply to this image"`
 }
 
 // TestSuiteRef is a reference to a named test suite. Using a structured type (rather than
@@ -126,6 +181,10 @@ type TestSuiteRef struct {
 
 // TestNames returns the test suite names referenced by this image.
 func (i *ImageConfig) TestNames() []string {
+	if i.Tests == nil {
+		return nil
+	}
+
 	names := make([]string, len(i.Tests.TestSuites))
 	for idx, ref := range i.Tests.TestSuites {
 		names[idx] = ref.Name

--- a/internal/projectconfig/loader.go
+++ b/internal/projectconfig/loader.go
@@ -45,6 +45,8 @@ func loadAndResolveProjectConfig(
 		GroupsByComponent: make(map[string][]string),
 		PackageGroups:     make(map[string]PackageGroupConfig),
 		TestSuites:        make(map[string]TestSuiteConfig),
+		Tests:             make(map[string]TestDefinition),
+		TestGroups:        make(map[string]TestGroup),
 	}
 
 	for _, configFilePath := range configFilePaths {
@@ -143,6 +145,14 @@ func mergeConfigFile(resolvedCfg *ProjectConfig, loadedCfg *ConfigFile) error {
 	}
 
 	if err := mergeTestSuites(resolvedCfg, loadedCfg); err != nil {
+		return err
+	}
+
+	if err := mergeTests(resolvedCfg, loadedCfg); err != nil {
+		return err
+	}
+
+	if err := mergeTestGroups(resolvedCfg, loadedCfg); err != nil {
 		return err
 	}
 
@@ -314,6 +324,34 @@ func mergeTestSuites(resolvedCfg *ProjectConfig, loadedCfg *ConfigFile) error {
 		suite.SourceConfigFile = loadedCfg
 
 		resolvedCfg.TestSuites[suiteName] = *(suite.WithAbsolutePaths(loadedCfg.dir))
+	}
+
+	return nil
+}
+
+// mergeTests merges individual test definitions from a loaded config file into the
+// resolved config. Duplicate test names are not allowed.
+func mergeTests(resolvedCfg *ProjectConfig, loadedCfg *ConfigFile) error {
+	for testName, testDef := range loadedCfg.Tests {
+		if _, ok := resolvedCfg.Tests[testName]; ok {
+			return fmt.Errorf("%w: test %#q", ErrDuplicateTests, testName)
+		}
+
+		resolvedCfg.Tests[testName] = testDef.WithAbsolutePaths(loadedCfg.dir)
+	}
+
+	return nil
+}
+
+// mergeTestGroups merges named test groups from a loaded config file into the
+// resolved config. Duplicate group names are not allowed.
+func mergeTestGroups(resolvedCfg *ProjectConfig, loadedCfg *ConfigFile) error {
+	for groupName, group := range loadedCfg.TestGroups {
+		if _, ok := resolvedCfg.TestGroups[groupName]; ok {
+			return fmt.Errorf("%w: test group %#q", ErrDuplicateTestGroups, groupName)
+		}
+
+		resolvedCfg.TestGroups[groupName] = group
 	}
 
 	return nil

--- a/internal/projectconfig/loader_test.go
+++ b/internal/projectconfig/loader_test.go
@@ -1071,6 +1071,26 @@ working-dir = "tests"
 	assert.Contains(t, err.Error(), "invalid test suite name")
 }
 
+func TestLoadAndResolveProjectConfig_TestInvalidName(t *testing.T) {
+	// Names containing path separators or traversal segments must be rejected at
+	// config load time since they are used as path components (e.g., venv directories).
+	const configContents = `
+[tests."../escape"]
+type = "pytest"
+
+[tests."../escape".pytest]
+working-dir = "tests"
+test-paths = ["test_smoke.py"]
+`
+
+	ctx := testctx.NewCtx()
+	require.NoError(t, fileutils.WriteFile(ctx.FS(), testConfigPath, []byte(configContents), fileperms.PrivateFile))
+
+	_, err := loadAndResolveProjectConfig(ctx.FS(), false, testConfigPath)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid test name")
+}
+
 func TestLoadAndResolveProjectConfig_ImageWithValidTestRef(t *testing.T) {
 	const configContents = `
 [test-suites.smoke]

--- a/internal/projectconfig/loader_test.go
+++ b/internal/projectconfig/loader_test.go
@@ -122,6 +122,45 @@ key = "value"
 	assert.Equal(t, "/project/artifacts/logs", config.Project.LogDir)
 }
 
+func TestLoadAndResolveProjectConfig_TestReferencesResolvedAcrossIncludedFiles(t *testing.T) {
+	testFiles := []struct {
+		path     string
+		contents string
+	}{
+		{testConfigPath, `
+includes = ["components.toml", "tests.toml"]
+`},
+		{"/project/components.toml", `
+[components.bash]
+tests.tests = [{ name = "bash-fedora-shell" }]
+`},
+		{"/project/tests.toml", `
+[tests.bash-fedora-shell]
+type = "tmt"
+kind = "functional"
+
+[tests.bash-fedora-shell.tmt]
+plan = "/plans/shell"
+
+[tests.bash-fedora-shell.tmt.source]
+git-url = "https://example.com/tmt-tests.git"
+ref = "0123456789abcdef0123456789abcdef01234567"
+`},
+	}
+
+	ctx := testctx.NewCtx()
+	for _, testFile := range testFiles {
+		require.NoError(t, fileutils.MkdirAll(ctx.FS(), filepath.Dir(testFile.path)))
+		require.NoError(t, fileutils.WriteFile(ctx.FS(), testFile.path, []byte(testFile.contents), fileperms.PrivateFile))
+	}
+
+	config, err := loadAndResolveProjectConfig(ctx.FS(), false, testConfigPath)
+	require.NoError(t, err)
+	require.Contains(t, config.Components, "bash")
+	require.Contains(t, config.Tests, "bash-fedora-shell")
+	assert.Equal(t, TestKindFunctional, config.Tests["bash-fedora-shell"].Kind)
+}
+
 func TestLoadAndResolveProjectConfig_PermissiveParsing_IgnoresValidationError(t *testing.T) {
 	// This config is structurally valid TOML but fails semantic validation: the
 	// component group references a component that is not defined.
@@ -1055,6 +1094,7 @@ test-suites = [{ name = "smoke" }]
 	require.NoError(t, err)
 
 	if assert.Contains(t, config.Images, "myimage") {
+		require.NotNil(t, config.Images["myimage"].Tests)
 		assert.Equal(t, []TestSuiteRef{{Name: "smoke"}}, config.Images["myimage"].Tests.TestSuites)
 	}
 }
@@ -1075,6 +1115,54 @@ test-suites = [{ name = "nonexistent" }]
 	require.Error(t, err)
 	require.ErrorIs(t, err, ErrUndefinedTestSuite)
 	assert.Contains(t, err.Error(), "nonexistent")
+}
+
+func TestLoadAndResolveProjectConfig_ImageCapabilities_FipsEnabledAndCVM(t *testing.T) {
+	const configContents = `
+[images.myimage]
+description = "Test image"
+
+[images.myimage.capabilities]
+machine-bootable = true
+fips-enabled = true
+cvm = true
+`
+
+	ctx := testctx.NewCtx()
+	require.NoError(t, fileutils.WriteFile(ctx.FS(), testConfigPath, []byte(configContents), fileperms.PrivateFile))
+
+	config, err := loadAndResolveProjectConfig(ctx.FS(), false, testConfigPath)
+	require.NoError(t, err)
+
+	if assert.Contains(t, config.Images, "myimage") {
+		caps := config.Images["myimage"].Capabilities
+		assert.True(t, caps.IsFipsEnabled())
+		assert.True(t, caps.IsCVM())
+		assert.Contains(t, caps.EnabledNames(), "fips-enabled")
+		assert.Contains(t, caps.EnabledNames(), "cvm")
+	}
+}
+
+func TestLoadAndResolveProjectConfig_TestDefinitionMetricsEnabled(t *testing.T) {
+	const configContents = `
+[tests.smoke-test]
+type = "lisa"
+description = "Smoke test"
+metrics-enabled = true
+
+[tests.smoke-test.lisa]
+name = "smoke_test"
+`
+
+	ctx := testctx.NewCtx()
+	require.NoError(t, fileutils.WriteFile(ctx.FS(), testConfigPath, []byte(configContents), fileperms.PrivateFile))
+
+	config, err := loadAndResolveProjectConfig(ctx.FS(), false, testConfigPath)
+	require.NoError(t, err)
+
+	if assert.Contains(t, config.Tests, "smoke-test") {
+		assert.True(t, config.Tests["smoke-test"].MetricsEnabled)
+	}
 }
 
 // TestLoadAndResolveProjectConfig_DeprecatedChannelField_DefaultPackageConfig verifies that the

--- a/internal/projectconfig/project.go
+++ b/internal/projectconfig/project.go
@@ -6,7 +6,9 @@ package projectconfig
 import (
 	"errors"
 	"fmt"
+	"log/slog"
 	"sort"
+	"strings"
 
 	"dario.cat/mergo"
 	"github.com/brunoga/deep"
@@ -47,6 +49,12 @@ type ProjectConfig struct {
 	// Definitions of test suites.
 	TestSuites map[string]TestSuiteConfig `toml:"test-suites,omitempty" json:"testSuites,omitempty" jsonschema:"title=Test Suites,description=Mapping of test suite names to configurations"`
 
+	// Definitions of individual tests.
+	Tests map[string]TestDefinition `toml:"tests,omitempty" json:"tests,omitempty" jsonschema:"title=Tests,description=Mapping of test names to configurations"`
+
+	// Definitions of named test groups.
+	TestGroups map[string]TestGroup `toml:"test-groups,omitempty" json:"testGroups,omitempty" jsonschema:"title=Test Groups,description=Mapping of test group names to configurations"`
+
 	// Root config file path; not serialized.
 	RootConfigFilePath string `toml:"-" json:"-"`
 	// Map from component names to groups they belong to; not serialized.
@@ -65,6 +73,8 @@ func NewProjectConfig() ProjectConfig {
 		GroupsByComponent: make(map[string][]string),
 		PackageGroups:     make(map[string]PackageGroupConfig),
 		TestSuites:        make(map[string]TestSuiteConfig),
+		Tests:             make(map[string]TestDefinition),
+		TestGroups:        make(map[string]TestGroup),
 	}
 }
 
@@ -84,6 +94,14 @@ func (cfg *ProjectConfig) Validate() error {
 	}
 
 	if err := validateImageTestReferences(cfg.Images, cfg.TestSuites); err != nil {
+		return err
+	}
+
+	if err := validateImageCapabilities(cfg.Images); err != nil {
+		return err
+	}
+
+	if err := validateNewTestReferences(cfg.Tests, cfg.TestGroups, cfg.Components, cfg.Images); err != nil {
 		return err
 	}
 
@@ -270,9 +288,18 @@ func validatePackageGroupMembership(groups map[string]PackageGroupConfig) error 
 
 // validateImageTestReferences checks that every test suite name in an image's
 // [ImageConfig.Tests.TestSuites] list corresponds to a defined entry in the top-level
-// TestSuites map.
+// TestSuites map. The legacy [tests.test-suites] image key is deprecated in favor of the
+// new [tests.tests] shape; a warning is emitted for each image still using it.
 func validateImageTestReferences(images map[string]ImageConfig, testSuites map[string]TestSuiteConfig) error {
 	for imageName, image := range images {
+		if image.Tests != nil && len(image.Tests.TestSuites) > 0 {
+			slog.Warn(
+				"image uses deprecated 'tests.test-suites' key; migrate to 'tests.tests' "+
+					"(referencing [tests.X] / [test-groups.X]) as legacy test-suites will be removed",
+				slog.String("image", imageName),
+			)
+		}
+
 		for _, suiteName := range image.TestNames() {
 			if _, ok := testSuites[suiteName]; !ok {
 				return fmt.Errorf(
@@ -280,6 +307,43 @@ func validateImageTestReferences(images map[string]ImageConfig, testSuites map[s
 					ErrUndefinedTestSuite, imageName, suiteName,
 				)
 			}
+		}
+	}
+
+	return nil
+}
+
+// validateImageCapabilities enforces mutual exclusivity among delivery-kind
+// capability flags. At most one of machine-bootable, container, wsl, and
+// installer-media may be true for a single image.
+func validateImageCapabilities(images map[string]ImageConfig) error {
+	for imageName, image := range images {
+		var trueKinds []string
+
+		if image.Capabilities.IsMachineBootable() {
+			trueKinds = append(trueKinds, "machine-bootable")
+		}
+
+		if image.Capabilities.IsContainer() {
+			trueKinds = append(trueKinds, "container")
+		}
+
+		if image.Capabilities.IsWSL() {
+			trueKinds = append(trueKinds, "wsl")
+		}
+
+		if image.Capabilities.IsInstallerMedia() {
+			trueKinds = append(trueKinds, "installer-media")
+		}
+
+		if len(trueKinds) > 1 {
+			return fmt.Errorf(
+				"%w: image %#q sets mutually exclusive capabilities to true (%s); "+
+					"at most one of machine-bootable, container, wsl, installer-media may be true",
+				ErrContradictingImageCapabilities,
+				imageName,
+				strings.Join(trueKinds, ", "),
+			)
 		}
 	}
 

--- a/internal/projectconfig/tests.go
+++ b/internal/projectconfig/tests.go
@@ -1,0 +1,717 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+package projectconfig
+
+import (
+	"errors"
+	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/invopop/jsonschema"
+	orderedmap "github.com/pb33f/ordered-map/v2"
+)
+
+// ResolvedTest is a concrete test definition resolved from a direct [tests.X]
+// reference or from expansion of a [test-groups.X] reference.
+type ResolvedTest struct {
+	Name       string
+	Definition TestDefinition
+}
+
+// TestKind indicates what kind of behavior a test exercises.
+type TestKind string
+
+const (
+	TestKindFunctional  TestKind = "functional"
+	TestKindPerformance TestKind = "performance"
+)
+
+func (k TestKind) IsValid() bool {
+	switch k {
+	case "":
+		return true
+	case TestKindFunctional,
+		TestKindPerformance:
+		return true
+	default:
+		return false
+	}
+}
+
+func orderedMapWithConst(key string, value any) *orderedmap.OrderedMap[string, *jsonschema.Schema] {
+	m := orderedmap.New[string, *jsonschema.Schema]()
+	m.Set(key, &jsonschema.Schema{Const: value})
+
+	return m
+}
+
+// TestDefinition is the new-shape [tests.X] declaration: one configuration of one
+// runner/harness with framework-specific options. Framework subtables are kept as
+// loosely-typed maps so the resolver can evolve their schemas without requiring
+// matching struct changes here.
+type TestDefinition struct {
+	// Type identifies the framework/runner. Required, and constrained to the
+	// closed enum in the schema tag at the schema layer. [TestDefinition.Validate]
+	// rejects unknown values at load time; the schema enum and Validate should be
+	// kept in sync.
+	Type string `toml:"type" json:"type" jsonschema:"required,title=Type,description=Test framework type,enum=pytest,enum=lisa,enum=tmt"`
+
+	// Human-readable description.
+	Description string `toml:"description,omitempty" json:"description,omitempty" jsonschema:"title=Description,description=Description of this test"`
+
+	// Kind hints at what the test exercises.
+	Kind TestKind `toml:"kind,omitempty" json:"kind,omitempty" jsonschema:"title=Kind,description=Kind hint for the test,enum=functional,enum=performance"`
+
+	// LongRunning hints to schedulers/policy that this test may take a long time.
+	LongRunning bool `toml:"long-running,omitempty" json:"longRunning,omitempty" jsonschema:"title=Long running,description=Hints that this test may run for hours"`
+
+	// MetricsEnabled hints to the test execution environment (TEE) / validation
+	// service whether metrics from this test run should be collected and stored
+	// (e.g. in Kusto). This is metadata only; azldev does not act on it directly.
+	MetricsEnabled bool `toml:"metrics-enabled,omitempty" json:"metricsEnabled,omitempty" jsonschema:"title=Metrics enabled,description=Hints to the test execution environment/validation service whether metrics from this test should be collected and stored"`
+
+	// RequiredCapabilities lists capability tokens an image must declare to be a
+	// valid target for this test. Tokens are matched against [ImageCapabilities].
+	RequiredCapabilities []string `toml:"required-capabilities,omitempty" json:"requiredCapabilities,omitempty" jsonschema:"title=Required capabilities,description=Capability tokens the image must declare"`
+
+	// Framework-specific subtables. Kept untyped so framework schema can evolve
+	// independently of the dev-tools type definitions.
+	Lisa   map[string]any `toml:"lisa,omitempty"   json:"lisa,omitempty"   jsonschema:"title=LISA config,description=LISA-specific configuration"`
+	Tmt    map[string]any `toml:"tmt,omitempty"    json:"tmt,omitempty"    jsonschema:"title=TMT config,description=TMT-specific configuration"`
+	Pytest map[string]any `toml:"pytest,omitempty" json:"pytest,omitempty" jsonschema:"title=Pytest config,description=pytest-specific configuration"`
+}
+
+// WithAbsolutePaths returns a copy of the test definition with any relative
+// paths in framework-specific subtables converted to absolute paths.
+func (t TestDefinition) WithAbsolutePaths(referenceDir string) TestDefinition {
+	result := t
+	result.Lisa = cloneStringAnyMap(t.Lisa)
+	result.Tmt = cloneStringAnyMap(t.Tmt)
+	result.Pytest = cloneStringAnyMap(t.Pytest)
+
+	if workingDir, ok := result.Pytest["working-dir"].(string); ok {
+		result.Pytest["working-dir"] = makeAbsolute(referenceDir, workingDir)
+	}
+
+	return result
+}
+
+// TestGroup is a [test-groups.X] declaration: a named bundle of test references that
+// images or components can target via a single name.
+type TestGroup struct {
+	// Human-readable description.
+	Description string `toml:"description,omitempty" json:"description,omitempty" jsonschema:"title=Description,description=Description of this test group"`
+
+	// Tests is the ordered list of test references that make up the group's
+	// membership. Group refs are validated as invalid at load time.
+	Tests []TestRef `toml:"tests,omitempty" json:"tests,omitempty" jsonschema:"title=Tests,description=Ordered test references for this group (name only)"`
+}
+
+// TestRef is a reference to either a test (by name) or another group (by name).
+// Exactly one of Name or Group should be set; semantic validation is the resolver's
+// responsibility.
+type TestRef struct {
+	// Name references a [tests.X] entry.
+	Name string `toml:"name,omitempty" json:"name,omitempty" jsonschema:"title=Name,description=Name of a test (mutually exclusive with group)"`
+
+	// Group references a [test-groups.X] entry.
+	Group string `toml:"group,omitempty" json:"group,omitempty" jsonschema:"title=Group,description=Name of a test group (mutually exclusive with name)"`
+}
+
+// ComponentTestsConfig holds the new-shape per-component tests block:
+//
+//	tests.tests = [{ name = "..." }, { group = "..." }]
+type ComponentTestsConfig struct {
+	// Tests is the list of test or test-group references that apply to the component.
+	Tests []TestRef `toml:"tests,omitempty" json:"tests,omitempty" jsonschema:"title=Tests,description=Per-component test or test-group references"`
+}
+
+// ResolveTestRefs expands a list of [TestRef] entries into concrete tests.
+func (cfg *ProjectConfig) ResolveTestRefs(refs []TestRef) ([]ResolvedTest, error) {
+	resolved := make([]ResolvedTest, 0, len(refs))
+
+	for _, ref := range refs {
+		hasName := ref.Name != ""
+		hasGroup := ref.Group != ""
+
+		switch {
+		case hasName && hasGroup:
+			return nil, fmt.Errorf(
+				"%w: must set exactly one of 'name' or 'group', got both %#q and %#q",
+				ErrInvalidTestRef, ref.Name, ref.Group,
+			)
+
+		case hasName:
+			testDef, ok := cfg.Tests[ref.Name]
+			if !ok {
+				return nil, fmt.Errorf("%w: %#q", ErrUndefinedTest, ref.Name)
+			}
+
+			resolved = append(resolved, ResolvedTest{Name: ref.Name, Definition: testDef})
+
+		case hasGroup:
+			group, ok := cfg.TestGroups[ref.Group]
+			if !ok {
+				return nil, fmt.Errorf("%w: %#q", ErrUndefinedTestGroup, ref.Group)
+			}
+
+			for _, groupRef := range group.Tests {
+				if groupRef.Group != "" {
+					return nil, fmt.Errorf("%w: %#q", ErrNestedTestGroupReference, ref.Group)
+				}
+
+				testDef, ok := cfg.Tests[groupRef.Name]
+				if !ok {
+					return nil, fmt.Errorf("%w: %#q", ErrUndefinedTest, groupRef.Name)
+				}
+
+				resolved = append(resolved, ResolvedTest{Name: groupRef.Name, Definition: testDef})
+			}
+
+		default:
+			return nil, fmt.Errorf("%w: must set exactly one of 'name' or 'group'", ErrInvalidTestRef)
+		}
+	}
+
+	return resolved, nil
+}
+
+// ResolveTestSelectors resolves user-provided selectors, where each selector may
+// reference either a concrete test or a test group.
+func (cfg *ProjectConfig) ResolveTestSelectors(selectors []string) ([]ResolvedTest, error) {
+	refs := make([]TestRef, 0, len(selectors))
+
+	for _, selector := range selectors {
+		_, isTest := cfg.Tests[selector]
+		_, isGroup := cfg.TestGroups[selector]
+
+		switch {
+		case isTest && isGroup:
+			return nil, fmt.Errorf("ambiguous test selector %#q matches both [tests] and [test-groups]", selector)
+		case isTest:
+			refs = append(refs, TestRef{Name: selector})
+		case isGroup:
+			refs = append(refs, TestRef{Group: selector})
+		default:
+			return nil, fmt.Errorf("unknown test selector %#q", selector)
+		}
+	}
+
+	return cfg.ResolveTestRefs(refs)
+}
+
+// ResolveImageTests expands the new-style test refs associated with an image.
+func (cfg *ProjectConfig) ResolveImageTests(image *ImageConfig) ([]ResolvedTest, error) {
+	if image == nil || image.Tests == nil {
+		return nil, nil
+	}
+
+	return cfg.ResolveTestRefs(image.Tests.Tests)
+}
+
+// ResolveComponentTests expands the new-style test refs associated with a component.
+func (cfg *ProjectConfig) ResolveComponentTests(component *ComponentConfig) ([]ResolvedTest, error) {
+	if component == nil || component.Tests == nil {
+		return nil, nil
+	}
+
+	return cfg.ResolveTestRefs(component.Tests.Tests)
+}
+
+func cloneStringAnyMap(input map[string]any) map[string]any {
+	if input == nil {
+		return nil
+	}
+
+	result := make(map[string]any, len(input))
+	for key, value := range input {
+		result[key] = value
+	}
+
+	return result
+}
+
+// Validate checks that exactly one framework subtable is set and it matches Type.
+func (t TestDefinition) Validate(testName string) error {
+	if t.Type == "" {
+		return fmt.Errorf("%w: test %#q is missing required field 'type'", ErrMissingTestField, testName)
+	}
+
+	if !t.Kind.IsValid() {
+		return fmt.Errorf("%w: test %#q has invalid kind %#q", ErrUnknownTestKind, testName, t.Kind)
+	}
+
+	type testTypeRule struct {
+		required   string
+		disallowed []string
+	}
+
+	typeRules := map[string]testTypeRule{
+		"pytest": {required: "pytest", disallowed: []string{"lisa", "tmt"}},
+		"lisa":   {required: "lisa", disallowed: []string{"pytest", "tmt"}},
+		"tmt":    {required: "tmt", disallowed: []string{"pytest", "lisa"}},
+	}
+
+	rule, ok := typeRules[t.Type]
+	if !ok {
+		return fmt.Errorf("%w: %#q (test: %#q)", ErrUnknownTestType, t.Type, testName)
+	}
+
+	subtablePresence := map[string]bool{
+		"pytest": t.Pytest != nil,
+		"lisa":   t.Lisa != nil,
+		"tmt":    t.Tmt != nil,
+	}
+
+	if !subtablePresence[rule.required] {
+		return fmt.Errorf(
+			"%w: test %#q of type %#q requires a [%s] subtable",
+			ErrMissingTestField,
+			testName,
+			t.Type,
+			rule.required,
+		)
+	}
+
+	for _, subtable := range rule.disallowed {
+		if subtablePresence[subtable] {
+			return fmt.Errorf(
+				"%w: test %#q of type %#q cannot include subtable '%s'",
+				ErrMismatchedTestSubtable,
+				testName,
+				t.Type,
+				subtable,
+			)
+		}
+	}
+
+	if t.Type == "lisa" {
+		if err := validateLisaSelection(t.Lisa, testName); err != nil {
+			return err
+		}
+	}
+
+	if t.Type == "tmt" {
+		if err := validateTmtConfig(t.Tmt, testName); err != nil {
+			return err
+		}
+	}
+
+	if t.Type == "pytest" {
+		if err := validatePytestConfig(t.Pytest, testName); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// validatePytestConfig checks that a [tests.X.pytest] subtable sets both
+// 'working-dir' and 'test-paths', which are mandatory for pytest tests.
+func validatePytestConfig(pytest map[string]any, testName string) error {
+	if !isNonEmptyString(pytest["working-dir"]) {
+		return fmt.Errorf(
+			"%w: test %#q pytest.working-dir is required and must be a non-empty string",
+			ErrInvalidPytestConfig, testName,
+		)
+	}
+
+	if err := validateStringList(pytest["test-paths"], "pytest.test-paths", testName, ErrInvalidPytestConfig); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// validateTmtConfig checks that a [tests.X.tmt] subtable sets both 'plan' and
+// 'source' (git-url, ref), which are mandatory for tmt tests.
+func validateTmtConfig(tmt map[string]any, testName string) error {
+	if !isNonEmptyString(tmt["plan"]) {
+		return fmt.Errorf(
+			"%w: test %#q tmt.plan is required and must be a non-empty string",
+			ErrInvalidTmtConfig, testName,
+		)
+	}
+
+	rawSource, hasSource := tmt["source"]
+	if !hasSource {
+		return fmt.Errorf(
+			"%w: test %#q tmt.source (git-url, ref) is required",
+			ErrInvalidTmtConfig, testName,
+		)
+	}
+
+	sourceMap, ok := rawSource.(map[string]any)
+	if !ok {
+		return fmt.Errorf(
+			"%w: test %#q tmt.source must be a table with 'git-url' and 'ref'",
+			ErrInvalidTmtConfig, testName,
+		)
+	}
+
+	gitURL, _ := sourceMap["git-url"].(string)
+	ref, _ := sourceMap["ref"].(string)
+	source := GitSourceConfig{GitURL: gitURL, Ref: ref}
+
+	if err := source.Validate(fmt.Sprintf("test %#q tmt.source", testName)); err != nil {
+		return fmt.Errorf("%w: %w", ErrInvalidTmtConfig, err)
+	}
+
+	return nil
+}
+
+// JSONSchemaExtend narrows [TestGroup.Tests] to name-only refs so editor-time
+// validation matches runtime behavior (group refs in [test-groups] are rejected).
+func (TestGroup) JSONSchemaExtend(schema *jsonschema.Schema) {
+	if schema == nil || schema.Properties == nil {
+		return
+	}
+
+	testsProp, ok := schema.Properties.Get("tests")
+	if !ok || testsProp == nil {
+		return
+	}
+
+	minLen := uint64(1)
+	itemProps := orderedmap.New[string, *jsonschema.Schema]()
+	itemProps.Set("name", &jsonschema.Schema{
+		Type:        "string",
+		MinLength:   &minLen,
+		Pattern:     "^\\S",
+		Description: "Name of a test",
+	})
+
+	testsProp.Items = &jsonschema.Schema{
+		Type:       "object",
+		Properties: itemProps,
+		Required:   []string{"name"},
+		Not: &jsonschema.Schema{
+			Required: []string{"group"},
+		},
+	}
+}
+
+func validateLisaSelection(lisa map[string]any, testName string) error {
+	hasSelector := false
+
+	if rawCriteria, ok := lisa["criteria"]; ok {
+		hasSelector = true
+
+		if err := validateLisaCriteria(rawCriteria, testName); err != nil {
+			return err
+		}
+	}
+
+	if rawName, ok := lisa["testcase-name"]; ok {
+		hasSelector = true
+
+		if !isNonEmptyString(rawName) {
+			return fmt.Errorf(
+				"%w: test %#q lisa.testcase-name must be a non-empty string",
+				ErrInvalidLisaSelection,
+				testName,
+			)
+		}
+	}
+
+	if rawName, ok := lisa["name"]; ok {
+		hasSelector = true
+
+		if !isNonEmptyString(rawName) {
+			return fmt.Errorf(
+				"%w: test %#q lisa.name must be a non-empty string",
+				ErrInvalidLisaSelection,
+				testName,
+			)
+		}
+	}
+
+	if rawNames, ok := lisa["testcase-names"]; ok {
+		hasSelector = true
+
+		if err := validateStringList(rawNames, "lisa.testcase-names", testName, ErrInvalidLisaSelection); err != nil {
+			return err
+		}
+	}
+
+	if !hasSelector {
+		return fmt.Errorf(
+			"%w: test %#q of type %#q must set at least one LISA selector: criteria, testcase-name, testcase-names, or name",
+			ErrInvalidLisaSelection,
+			testName,
+			"lisa",
+		)
+	}
+
+	return nil
+}
+
+func validateLisaCriteria(rawCriteria any, testName string) error {
+	criteriaList, err := normalizeCriteriaList(rawCriteria)
+	if err != nil {
+		return fmt.Errorf("%w: test %#q lisa.criteria %w", ErrInvalidLisaSelection, testName, err)
+	}
+
+	for idx, criteria := range criteriaList {
+		if err := validateSingleLisaCriteria(criteria, testName, idx); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func normalizeCriteriaList(rawCriteria any) ([]map[string]any, error) {
+	switch criteriaValue := rawCriteria.(type) {
+	case map[string]any:
+		if len(criteriaValue) == 0 {
+			return nil, errors.New("must not be empty")
+		}
+
+		return []map[string]any{criteriaValue}, nil
+	case []any:
+		if len(criteriaValue) == 0 {
+			return nil, errors.New("must not be an empty list")
+		}
+
+		result := make([]map[string]any, 0, len(criteriaValue))
+
+		for entryIndex, item := range criteriaValue {
+			criteriaMap, ok := item.(map[string]any)
+			if !ok {
+				return nil, fmt.Errorf("entry %d must be a table/object", entryIndex)
+			}
+
+			if len(criteriaMap) == 0 {
+				return nil, fmt.Errorf("entry %d must not be empty", entryIndex)
+			}
+
+			result = append(result, criteriaMap)
+		}
+
+		return result, nil
+	default:
+		return nil, errors.New("must be a table or list of tables")
+	}
+}
+
+func validateSingleLisaCriteria(criteria map[string]any, testName string, idx int) error {
+	allowedKeys := map[string]bool{
+		"name":           true,
+		"area":           true,
+		"category":       true,
+		"priority":       true,
+		"tags":           true,
+		"testcase-name":  true,
+		"testcase-names": true,
+	}
+
+	hasSelector := false
+
+	for key, value := range criteria {
+		if !allowedKeys[key] {
+			return fmt.Errorf(
+				"%w: test %#q lisa.criteria[%d] contains unsupported selector %#q",
+				ErrInvalidLisaSelection,
+				testName,
+				idx,
+				key,
+			)
+		}
+
+		switch key {
+		case "name", "area", "category", "testcase-name":
+			if !isNonEmptyString(value) {
+				return fmt.Errorf(
+					"%w: test %#q lisa.criteria[%d].%s must be a non-empty string",
+					ErrInvalidLisaSelection,
+					testName,
+					idx,
+					key,
+				)
+			}
+
+			hasSelector = true
+		case "priority":
+			if err := validateLisaPriority(value, testName, idx); err != nil {
+				return err
+			}
+
+			hasSelector = true
+		case "tags", "testcase-names":
+			fieldName := "lisa.criteria[" + strconv.Itoa(idx) + "]." + key
+
+			if err := validateStringList(value, fieldName, testName, ErrInvalidLisaSelection); err != nil {
+				return err
+			}
+
+			hasSelector = true
+		}
+	}
+
+	if !hasSelector {
+		return fmt.Errorf(
+			"%w: test %#q lisa.criteria[%d] must include at least one selector",
+			ErrInvalidLisaSelection,
+			testName,
+			idx,
+		)
+	}
+
+	return nil
+}
+
+func validateLisaPriority(value any, testName string, idx int) error {
+	if isLisaPriorityValue(value) {
+		return nil
+	}
+
+	return fmt.Errorf(
+		"%w: test %#q lisa.criteria[%d].priority must be an integer 0..4 or a non-empty list of integers 0..4",
+		ErrInvalidLisaSelection,
+		testName,
+		idx,
+	)
+}
+
+func isLisaPriorityValue(value any) bool {
+	if parsed, ok := parseLisaPriority(value); ok {
+		return parsed >= 0 && parsed <= 4
+	}
+
+	priorityList, ok := value.([]any)
+	if !ok || len(priorityList) == 0 {
+		return false
+	}
+
+	for _, item := range priorityList {
+		parsed, ok := parseLisaPriority(item)
+		if !ok || parsed < 0 || parsed > 4 {
+			return false
+		}
+	}
+
+	return true
+}
+
+func parseLisaPriority(value any) (int, bool) {
+	switch typed := value.(type) {
+	case int:
+		return typed, true
+	case int64:
+		return int(typed), true
+	case float64:
+		if typed != float64(int(typed)) {
+			return 0, false
+		}
+
+		return int(typed), true
+	default:
+		return 0, false
+	}
+}
+
+// validateStringList checks that value is a non-empty list of non-empty strings,
+// wrapping any failure with the caller-supplied sentinel error so the error chain
+// reflects the actual validation context (e.g. lisa vs. pytest) rather than always
+// being attributed to LISA validation.
+func validateStringList(value any, fieldName string, testName string, sentinel error) error {
+	items, ok := value.([]any)
+	if !ok || len(items) == 0 {
+		return fmt.Errorf(
+			"%w: test %#q %s must be a non-empty list of non-empty strings",
+			sentinel,
+			testName,
+			fieldName,
+		)
+	}
+
+	for _, item := range items {
+		if !isNonEmptyString(item) {
+			return fmt.Errorf(
+				"%w: test %#q %s must be a non-empty list of non-empty strings",
+				sentinel,
+				testName,
+				fieldName,
+			)
+		}
+	}
+
+	return nil
+}
+
+func isNonEmptyString(value any) bool {
+	s, ok := value.(string)
+	if !ok {
+		return false
+	}
+
+	return strings.TrimSpace(s) != ""
+}
+
+// JSONSchemaExtend tightens [TestDefinition] so the framework-specific subtable
+// must match the declared type.
+func (TestDefinition) JSONSchemaExtend(schema *jsonschema.Schema) {
+	if schema == nil {
+		return
+	}
+
+	onlyPytest := &jsonschema.Schema{
+		Required: []string{"pytest"},
+		Not: &jsonschema.Schema{AnyOf: []*jsonschema.Schema{
+			{Required: []string{"lisa"}},
+			{Required: []string{"tmt"}},
+		}},
+	}
+
+	onlyLisa := &jsonschema.Schema{
+		Required: []string{"lisa"},
+		Not: &jsonschema.Schema{AnyOf: []*jsonschema.Schema{
+			{Required: []string{"pytest"}},
+			{Required: []string{"tmt"}},
+		}},
+	}
+
+	onlyTmt := &jsonschema.Schema{
+		Required: []string{"tmt"},
+		Not: &jsonschema.Schema{AnyOf: []*jsonschema.Schema{
+			{Required: []string{"pytest"}},
+			{Required: []string{"lisa"}},
+		}},
+	}
+
+	schema.AllOf = append(schema.AllOf,
+		&jsonschema.Schema{If: &jsonschema.Schema{Properties: orderedMapWithConst("type", "pytest")}, Then: onlyPytest},
+		&jsonschema.Schema{If: &jsonschema.Schema{Properties: orderedMapWithConst("type", "lisa")}, Then: onlyLisa},
+		&jsonschema.Schema{If: &jsonschema.Schema{Properties: orderedMapWithConst("type", "tmt")}, Then: onlyTmt},
+	)
+}
+
+// JSONSchemaExtend tightens the generated schema for [TestRef] so editors can
+// flag refs that set neither or both of name/group, or empty/whitespace-only values.
+// The runtime resolver ([ErrInvalidTestRef]) is the source of truth; this keeps the schema in sync.
+func (TestRef) JSONSchemaExtend(schema *jsonschema.Schema) {
+	// Exactly one of name|group: encoded as oneOf with `required` on each and
+	// `not` excluding the other, which forbids both `{}` and `{name, group}`.
+	schema.OneOf = []*jsonschema.Schema{
+		{Required: []string{"name"}, Not: &jsonschema.Schema{Required: []string{"group"}}},
+		{Required: []string{"group"}, Not: &jsonschema.Schema{Required: []string{"name"}}},
+	}
+
+	// Prevent empty or leading-whitespace identifiers in both name and group fields.
+	minLen := uint64(1)
+
+	if schema.Properties != nil {
+		if nameProp, ok := schema.Properties.Get("name"); ok && nameProp != nil {
+			nameProp.MinLength = &minLen
+			nameProp.Pattern = "^\\S"
+		}
+
+		if groupProp, ok := schema.Properties.Get("group"); ok && groupProp != nil {
+			groupProp.MinLength = &minLen
+			groupProp.Pattern = "^\\S"
+		}
+	}
+}

--- a/internal/projectconfig/testsuite.go
+++ b/internal/projectconfig/testsuite.go
@@ -24,15 +24,40 @@ const (
 var (
 	// ErrDuplicateTestSuites is returned when duplicate conflicting test suite definitions are found.
 	ErrDuplicateTestSuites = errors.New("duplicate test suite")
+	// ErrDuplicateTests is returned when duplicate conflicting [tests] entries are found.
+	ErrDuplicateTests = errors.New("duplicate test")
+	// ErrDuplicateTestGroups is returned when duplicate conflicting [test-groups] entries are found.
+	ErrDuplicateTestGroups = errors.New("duplicate test group")
 	// ErrUnknownTestType is returned for unrecognized test types.
 	ErrUnknownTestType = errors.New("unknown test type")
 	// ErrMissingTestField is returned when a required test config field is missing.
 	ErrMissingTestField = errors.New("missing required test field")
 	// ErrUndefinedTestSuite is returned when an image references a test suite name that is not defined.
 	ErrUndefinedTestSuite = errors.New("undefined test suite reference")
+	// ErrUndefinedTest is returned when a test reference points to a missing [tests] entry.
+	ErrUndefinedTest = errors.New("undefined test reference")
+	// ErrUndefinedTestGroup is returned when a test reference points to a missing [test-groups] entry.
+	ErrUndefinedTestGroup = errors.New("undefined test group reference")
+	// ErrInvalidTestRef is returned when a TestRef has neither or both of name/group set.
+	ErrInvalidTestRef = errors.New("invalid test reference")
+	// ErrDuplicateTestRef is returned when a list contains the same test ref more than once.
+	ErrDuplicateTestRef = errors.New("duplicate test reference")
+	// ErrContradictingImageCapabilities is returned when mutually exclusive image
+	// capability fields are simultaneously set to true.
+	ErrContradictingImageCapabilities = errors.New("contradicting image capabilities")
+	// ErrNestedTestGroupReference is returned when a [test-groups] member uses a group ref.
+	ErrNestedTestGroupReference = errors.New("nested test group reference")
 	// ErrMismatchedTestSubtable is returned when a test config has a subtable that does not
 	// match its declared type.
 	ErrMismatchedTestSubtable = errors.New("mismatched test subtable")
+	// ErrUnknownTestKind is returned for unrecognized test kinds.
+	ErrUnknownTestKind = errors.New("unknown test kind")
+	// ErrInvalidLisaSelection is returned when a lisa test has invalid or missing selectors.
+	ErrInvalidLisaSelection = errors.New("invalid lisa selection")
+	// ErrInvalidTmtConfig is returned when a tmt test has invalid or missing configuration.
+	ErrInvalidTmtConfig = errors.New("invalid tmt configuration")
+	// ErrInvalidPytestConfig is returned when a pytest test has invalid or missing configuration.
+	ErrInvalidPytestConfig = errors.New("invalid pytest configuration")
 	// ErrInvalidInstallMode is returned when a [PytestConfig.Install] value is not recognized.
 	ErrInvalidInstallMode = errors.New("invalid install mode")
 	// ErrInvalidGitRef is returned when a git ref is not a valid hex commit SHA.

--- a/internal/projectconfig/testsuite_test.go
+++ b/internal/projectconfig/testsuite_test.go
@@ -33,9 +33,14 @@ func TestImageCapabilities_EnabledNames(t *testing.T) {
 			Container:                lo.ToPtr(true),
 			Systemd:                  lo.ToPtr(true),
 			RuntimePackageManagement: lo.ToPtr(true),
+			WSL:                      lo.ToPtr(true),
+			InstallerMedia:           lo.ToPtr(true),
+			FipsEnabled:              lo.ToPtr(true),
+			CVM:                      lo.ToPtr(true),
 		}
 		assert.Equal(t, []string{
-			"machine-bootable", "container", "systemd", "runtime-package-management",
+			"machine-bootable", "container", "systemd", "runtime-package-management", "wsl", "installer-media",
+			"fips-enabled", "cvm",
 		}, caps.EnabledNames())
 	})
 
@@ -64,7 +69,7 @@ func TestImageCapabilities_EnabledNames(t *testing.T) {
 func TestImageConfig_TestNames(t *testing.T) {
 	t.Run("with tests", func(t *testing.T) {
 		img := projectconfig.ImageConfig{
-			Tests: projectconfig.ImageTestsConfig{
+			Tests: &projectconfig.ImageTestsConfig{
 				TestSuites: []projectconfig.TestSuiteRef{
 					{Name: "smoke"},
 					{Name: "integration"},
@@ -357,7 +362,7 @@ func TestValidateTestSuiteReferences(t *testing.T) {
 			Images: map[string]projectconfig.ImageConfig{
 				"myimage": {
 					Name:  "myimage",
-					Tests: projectconfig.ImageTestsConfig{TestSuites: []projectconfig.TestSuiteRef{{Name: "smoke"}}},
+					Tests: &projectconfig.ImageTestsConfig{TestSuites: []projectconfig.TestSuiteRef{{Name: "smoke"}}},
 				},
 			},
 			TestSuites: map[string]projectconfig.TestSuiteConfig{
@@ -383,7 +388,7 @@ func TestValidateTestSuiteReferences(t *testing.T) {
 			Images: map[string]projectconfig.ImageConfig{
 				"myimage": {
 					Name:  "myimage",
-					Tests: projectconfig.ImageTestsConfig{TestSuites: []projectconfig.TestSuiteRef{{Name: "nonexistent"}}},
+					Tests: &projectconfig.ImageTestsConfig{TestSuites: []projectconfig.TestSuiteRef{{Name: "nonexistent"}}},
 				},
 			},
 			TestSuites:        make(map[string]projectconfig.TestSuiteConfig),

--- a/scenario/__snapshots__/TestSnapshotsContainer_config_generate-schema_stdout_1.snap
+++ b/scenario/__snapshots__/TestSnapshotsContainer_config_generate-schema_stdout_1.snap
@@ -162,6 +162,11 @@
           "$ref": "#/$defs/ComponentPublishConfig",
           "title": "Publish settings",
           "description": "Component-level publish channel settings"
+        },
+        "tests": {
+          "$ref": "#/$defs/ComponentTestsConfig",
+          "title": "Tests",
+          "description": "Per-component test or test-group references"
         }
       },
       "additionalProperties": false,
@@ -346,6 +351,20 @@
       "additionalProperties": false,
       "type": "object"
     },
+    "ComponentTestsConfig": {
+      "properties": {
+        "tests": {
+          "items": {
+            "$ref": "#/$defs/TestRef"
+          },
+          "type": "array",
+          "title": "Tests",
+          "description": "Per-component test or test-group references"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object"
+    },
     "ConfigFile": {
       "properties": {
         "$schema": {
@@ -431,6 +450,22 @@
           "type": "object",
           "title": "Test Suites",
           "description": "Definitions of test suites for this project"
+        },
+        "tests": {
+          "additionalProperties": {
+            "$ref": "#/$defs/TestDefinition"
+          },
+          "type": "object",
+          "title": "Tests",
+          "description": "Definitions of individual tests"
+        },
+        "test-groups": {
+          "additionalProperties": {
+            "$ref": "#/$defs/TestGroup"
+          },
+          "type": "object",
+          "title": "Test Groups",
+          "description": "Definitions of named bundles of tests"
         }
       },
       "additionalProperties": false,
@@ -638,6 +673,26 @@
           "type": "boolean",
           "title": "Runtime package management",
           "description": "Whether the image supports installing or removing packages at runtime"
+        },
+        "wsl": {
+          "type": "boolean",
+          "title": "WSL",
+          "description": "Whether the image runs under the Windows Subsystem for Linux runtime"
+        },
+        "installer-media": {
+          "type": "boolean",
+          "title": "Installer media",
+          "description": "Whether the image is installer media that installs another OS rather than a directly runnable end-state image"
+        },
+        "fips-enabled": {
+          "type": "boolean",
+          "title": "FIPS enabled",
+          "description": "Whether the image is built or configured to run in FIPS mode"
+        },
+        "cvm": {
+          "type": "boolean",
+          "title": "Confidential VM",
+          "description": "Whether the image supports running as a Confidential VM (CVM)"
         }
       },
       "additionalProperties": false,
@@ -729,6 +784,14 @@
           "type": "array",
           "title": "Test Suites",
           "description": "List of test suite references that apply to this image"
+        },
+        "tests": {
+          "items": {
+            "$ref": "#/$defs/TestRef"
+          },
+          "type": "array",
+          "title": "Tests",
+          "description": "List of test or test-group references that apply to this image"
         }
       },
       "additionalProperties": false,
@@ -1384,6 +1447,235 @@
         "name",
         "subpath"
       ]
+    },
+    "TestDefinition": {
+      "allOf": [
+        {
+          "if": {
+            "properties": {
+              "type": {
+                "const": "pytest"
+              }
+            }
+          },
+          "then": {
+            "not": {
+              "anyOf": [
+                {
+                  "required": [
+                    "lisa"
+                  ]
+                },
+                {
+                  "required": [
+                    "tmt"
+                  ]
+                }
+              ]
+            },
+            "required": [
+              "pytest"
+            ]
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "type": {
+                "const": "lisa"
+              }
+            }
+          },
+          "then": {
+            "not": {
+              "anyOf": [
+                {
+                  "required": [
+                    "pytest"
+                  ]
+                },
+                {
+                  "required": [
+                    "tmt"
+                  ]
+                }
+              ]
+            },
+            "required": [
+              "lisa"
+            ]
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "type": {
+                "const": "tmt"
+              }
+            }
+          },
+          "then": {
+            "not": {
+              "anyOf": [
+                {
+                  "required": [
+                    "pytest"
+                  ]
+                },
+                {
+                  "required": [
+                    "lisa"
+                  ]
+                }
+              ]
+            },
+            "required": [
+              "tmt"
+            ]
+          }
+        }
+      ],
+      "properties": {
+        "type": {
+          "type": "string",
+          "enum": [
+            "pytest",
+            "lisa",
+            "tmt"
+          ],
+          "title": "Type",
+          "description": "Test framework type"
+        },
+        "description": {
+          "type": "string",
+          "title": "Description",
+          "description": "Description of this test"
+        },
+        "kind": {
+          "type": "string",
+          "enum": [
+            "functional",
+            "performance"
+          ],
+          "title": "Kind",
+          "description": "Kind hint for the test"
+        },
+        "long-running": {
+          "type": "boolean",
+          "title": "Long running",
+          "description": "Hints that this test may run for hours"
+        },
+        "metrics-enabled": {
+          "type": "boolean",
+          "title": "Metrics enabled",
+          "description": "Hints to the test execution environment/validation service whether metrics from this test should be collected and stored"
+        },
+        "required-capabilities": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array",
+          "title": "Required capabilities",
+          "description": "Capability tokens the image must declare"
+        },
+        "lisa": {
+          "type": "object",
+          "title": "LISA config",
+          "description": "LISA-specific configuration"
+        },
+        "tmt": {
+          "type": "object",
+          "title": "TMT config",
+          "description": "TMT-specific configuration"
+        },
+        "pytest": {
+          "type": "object",
+          "title": "Pytest config",
+          "description": "pytest-specific configuration"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "type"
+      ]
+    },
+    "TestGroup": {
+      "properties": {
+        "description": {
+          "type": "string",
+          "title": "Description",
+          "description": "Description of this test group"
+        },
+        "tests": {
+          "items": {
+            "not": {
+              "required": [
+                "group"
+              ]
+            },
+            "properties": {
+              "name": {
+                "type": "string",
+                "minLength": 1,
+                "pattern": "^\\S",
+                "description": "Name of a test"
+              }
+            },
+            "type": "object",
+            "required": [
+              "name"
+            ]
+          },
+          "type": "array",
+          "title": "Tests",
+          "description": "Ordered test references for this group (name only)"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object"
+    },
+    "TestRef": {
+      "oneOf": [
+        {
+          "not": {
+            "required": [
+              "group"
+            ]
+          },
+          "required": [
+            "name"
+          ]
+        },
+        {
+          "not": {
+            "required": [
+              "name"
+            ]
+          },
+          "required": [
+            "group"
+          ]
+        }
+      ],
+      "properties": {
+        "name": {
+          "type": "string",
+          "minLength": 1,
+          "pattern": "^\\S",
+          "title": "Name",
+          "description": "Name of a test (mutually exclusive with group)"
+        },
+        "group": {
+          "type": "string",
+          "minLength": 1,
+          "pattern": "^\\S",
+          "title": "Group",
+          "description": "Name of a test group (mutually exclusive with name)"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object"
     },
     "TestSuiteConfig": {
       "properties": {

--- a/scenario/__snapshots__/TestSnapshots_config_generate-schema_stdout_1.snap
+++ b/scenario/__snapshots__/TestSnapshots_config_generate-schema_stdout_1.snap
@@ -162,6 +162,11 @@
           "$ref": "#/$defs/ComponentPublishConfig",
           "title": "Publish settings",
           "description": "Component-level publish channel settings"
+        },
+        "tests": {
+          "$ref": "#/$defs/ComponentTestsConfig",
+          "title": "Tests",
+          "description": "Per-component test or test-group references"
         }
       },
       "additionalProperties": false,
@@ -346,6 +351,20 @@
       "additionalProperties": false,
       "type": "object"
     },
+    "ComponentTestsConfig": {
+      "properties": {
+        "tests": {
+          "items": {
+            "$ref": "#/$defs/TestRef"
+          },
+          "type": "array",
+          "title": "Tests",
+          "description": "Per-component test or test-group references"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object"
+    },
     "ConfigFile": {
       "properties": {
         "$schema": {
@@ -431,6 +450,22 @@
           "type": "object",
           "title": "Test Suites",
           "description": "Definitions of test suites for this project"
+        },
+        "tests": {
+          "additionalProperties": {
+            "$ref": "#/$defs/TestDefinition"
+          },
+          "type": "object",
+          "title": "Tests",
+          "description": "Definitions of individual tests"
+        },
+        "test-groups": {
+          "additionalProperties": {
+            "$ref": "#/$defs/TestGroup"
+          },
+          "type": "object",
+          "title": "Test Groups",
+          "description": "Definitions of named bundles of tests"
         }
       },
       "additionalProperties": false,
@@ -638,6 +673,26 @@
           "type": "boolean",
           "title": "Runtime package management",
           "description": "Whether the image supports installing or removing packages at runtime"
+        },
+        "wsl": {
+          "type": "boolean",
+          "title": "WSL",
+          "description": "Whether the image runs under the Windows Subsystem for Linux runtime"
+        },
+        "installer-media": {
+          "type": "boolean",
+          "title": "Installer media",
+          "description": "Whether the image is installer media that installs another OS rather than a directly runnable end-state image"
+        },
+        "fips-enabled": {
+          "type": "boolean",
+          "title": "FIPS enabled",
+          "description": "Whether the image is built or configured to run in FIPS mode"
+        },
+        "cvm": {
+          "type": "boolean",
+          "title": "Confidential VM",
+          "description": "Whether the image supports running as a Confidential VM (CVM)"
         }
       },
       "additionalProperties": false,
@@ -729,6 +784,14 @@
           "type": "array",
           "title": "Test Suites",
           "description": "List of test suite references that apply to this image"
+        },
+        "tests": {
+          "items": {
+            "$ref": "#/$defs/TestRef"
+          },
+          "type": "array",
+          "title": "Tests",
+          "description": "List of test or test-group references that apply to this image"
         }
       },
       "additionalProperties": false,
@@ -1384,6 +1447,235 @@
         "name",
         "subpath"
       ]
+    },
+    "TestDefinition": {
+      "allOf": [
+        {
+          "if": {
+            "properties": {
+              "type": {
+                "const": "pytest"
+              }
+            }
+          },
+          "then": {
+            "not": {
+              "anyOf": [
+                {
+                  "required": [
+                    "lisa"
+                  ]
+                },
+                {
+                  "required": [
+                    "tmt"
+                  ]
+                }
+              ]
+            },
+            "required": [
+              "pytest"
+            ]
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "type": {
+                "const": "lisa"
+              }
+            }
+          },
+          "then": {
+            "not": {
+              "anyOf": [
+                {
+                  "required": [
+                    "pytest"
+                  ]
+                },
+                {
+                  "required": [
+                    "tmt"
+                  ]
+                }
+              ]
+            },
+            "required": [
+              "lisa"
+            ]
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "type": {
+                "const": "tmt"
+              }
+            }
+          },
+          "then": {
+            "not": {
+              "anyOf": [
+                {
+                  "required": [
+                    "pytest"
+                  ]
+                },
+                {
+                  "required": [
+                    "lisa"
+                  ]
+                }
+              ]
+            },
+            "required": [
+              "tmt"
+            ]
+          }
+        }
+      ],
+      "properties": {
+        "type": {
+          "type": "string",
+          "enum": [
+            "pytest",
+            "lisa",
+            "tmt"
+          ],
+          "title": "Type",
+          "description": "Test framework type"
+        },
+        "description": {
+          "type": "string",
+          "title": "Description",
+          "description": "Description of this test"
+        },
+        "kind": {
+          "type": "string",
+          "enum": [
+            "functional",
+            "performance"
+          ],
+          "title": "Kind",
+          "description": "Kind hint for the test"
+        },
+        "long-running": {
+          "type": "boolean",
+          "title": "Long running",
+          "description": "Hints that this test may run for hours"
+        },
+        "metrics-enabled": {
+          "type": "boolean",
+          "title": "Metrics enabled",
+          "description": "Hints to the test execution environment/validation service whether metrics from this test should be collected and stored"
+        },
+        "required-capabilities": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array",
+          "title": "Required capabilities",
+          "description": "Capability tokens the image must declare"
+        },
+        "lisa": {
+          "type": "object",
+          "title": "LISA config",
+          "description": "LISA-specific configuration"
+        },
+        "tmt": {
+          "type": "object",
+          "title": "TMT config",
+          "description": "TMT-specific configuration"
+        },
+        "pytest": {
+          "type": "object",
+          "title": "Pytest config",
+          "description": "pytest-specific configuration"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "type"
+      ]
+    },
+    "TestGroup": {
+      "properties": {
+        "description": {
+          "type": "string",
+          "title": "Description",
+          "description": "Description of this test group"
+        },
+        "tests": {
+          "items": {
+            "not": {
+              "required": [
+                "group"
+              ]
+            },
+            "properties": {
+              "name": {
+                "type": "string",
+                "minLength": 1,
+                "pattern": "^\\S",
+                "description": "Name of a test"
+              }
+            },
+            "type": "object",
+            "required": [
+              "name"
+            ]
+          },
+          "type": "array",
+          "title": "Tests",
+          "description": "Ordered test references for this group (name only)"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object"
+    },
+    "TestRef": {
+      "oneOf": [
+        {
+          "not": {
+            "required": [
+              "group"
+            ]
+          },
+          "required": [
+            "name"
+          ]
+        },
+        {
+          "not": {
+            "required": [
+              "name"
+            ]
+          },
+          "required": [
+            "group"
+          ]
+        }
+      ],
+      "properties": {
+        "name": {
+          "type": "string",
+          "minLength": 1,
+          "pattern": "^\\S",
+          "title": "Name",
+          "description": "Name of a test (mutually exclusive with group)"
+        },
+        "group": {
+          "type": "string",
+          "minLength": 1,
+          "pattern": "^\\S",
+          "title": "Group",
+          "description": "Name of a test group (mutually exclusive with name)"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object"
     },
     "TestSuiteConfig": {
       "properties": {

--- a/scenario/internal/cmdtest/cmdtest.go
+++ b/scenario/internal/cmdtest/cmdtest.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"io"
 	"io/fs"
+	"os"
 	"os/exec"
 	"path/filepath"
 	"testing"
@@ -129,13 +130,27 @@ func (params *commonTestParams) AddFileContents(dst string, contents io.Reader) 
 func (params *commonTestParams) AddDirRecursive(t *testing.T, dst, src string) *commonTestParams {
 	t.Helper()
 
-	// Recursively walk just the files in the source directory.
+	// Recursively walk just the files in the source directory. File contents are read immediately here
+	// (rather than deferring to the container copy step, which happens much later after the container
+	// image is built) to avoid a race with transient files. For example, a git repository under src may
+	// have its background maintenance create and remove '.git/objects/maintenance.lock' at any time; if
+	// we only recorded the host path here, that file could vanish before it was actually copied into the
+	// container, causing an intermittent "no such file or directory" error.
 	err := filepath.WalkDir(src, func(path string, entry fs.DirEntry, err error) error {
 		require.NoError(t, err)
 
 		if entry.IsDir() {
 			return nil // Skip directories.
 		}
+
+		contents, readErr := os.ReadFile(path)
+		if errors.Is(readErr, fs.ErrNotExist) {
+			// The file vanished between being listed and being read (e.g. a transient lock file);
+			// there's nothing meaningful to copy.
+			return nil
+		}
+
+		require.NoError(t, readErr)
 
 		// Get the relative path to the source file.
 		relPath, err := filepath.Rel(src, path)
@@ -144,7 +159,7 @@ func (params *commonTestParams) AddDirRecursive(t *testing.T, dst, src string) *
 		// Construct the destination path.
 		destPath := filepath.Join(dst, relPath)
 
-		params.AddSingleFile(destPath, path)
+		params.AddFileContents(destPath, bytes.NewReader(contents))
 
 		return nil
 	})

--- a/scenario/internal/cmdtest/cmdtest_test.go
+++ b/scenario/internal/cmdtest/cmdtest_test.go
@@ -8,6 +8,7 @@ package cmdtest
 
 import (
 	"fmt"
+	"io"
 	"os"
 	"path/filepath"
 	"strings"
@@ -46,6 +47,32 @@ func dummyDir(t *testing.T) string {
 	t.Logf("XXXXXX Created dummy directory at %s", subdir)
 
 	return tempDir
+}
+
+func Test_AddDirRecursive_CapturesContentsImmediately(t *testing.T) {
+	t.Parallel()
+
+	dir := dummyDir(t)
+
+	params := &commonTestParams{
+		FilesToCopy:  map[string]string{},
+		FilesToWrite: map[string]io.Reader{},
+	}
+
+	params.AddDirRecursive(t, "testdir", dir)
+
+	// Contents should be captured as in-memory readers, not as deferred host-path copies.
+	assert.Empty(t, params.FilesToCopy)
+
+	nestedDest := filepath.Join("testdir", "subdir", "nested.txt")
+	require.Contains(t, params.FilesToWrite, nestedDest)
+
+	contents, err := io.ReadAll(params.FilesToWrite[nestedDest])
+	require.NoError(t, err)
+	assert.Equal(t, "test content", string(contents))
+
+	// Removing the source directory after the fact must not affect the already-captured contents.
+	require.NoError(t, os.RemoveAll(dir))
 }
 
 func Test_localTestParamsRun(t *testing.T) {

--- a/schemas/azldev.schema.json
+++ b/schemas/azldev.schema.json
@@ -162,6 +162,11 @@
           "$ref": "#/$defs/ComponentPublishConfig",
           "title": "Publish settings",
           "description": "Component-level publish channel settings"
+        },
+        "tests": {
+          "$ref": "#/$defs/ComponentTestsConfig",
+          "title": "Tests",
+          "description": "Per-component test or test-group references"
         }
       },
       "additionalProperties": false,
@@ -346,6 +351,20 @@
       "additionalProperties": false,
       "type": "object"
     },
+    "ComponentTestsConfig": {
+      "properties": {
+        "tests": {
+          "items": {
+            "$ref": "#/$defs/TestRef"
+          },
+          "type": "array",
+          "title": "Tests",
+          "description": "Per-component test or test-group references"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object"
+    },
     "ConfigFile": {
       "properties": {
         "$schema": {
@@ -431,6 +450,22 @@
           "type": "object",
           "title": "Test Suites",
           "description": "Definitions of test suites for this project"
+        },
+        "tests": {
+          "additionalProperties": {
+            "$ref": "#/$defs/TestDefinition"
+          },
+          "type": "object",
+          "title": "Tests",
+          "description": "Definitions of individual tests"
+        },
+        "test-groups": {
+          "additionalProperties": {
+            "$ref": "#/$defs/TestGroup"
+          },
+          "type": "object",
+          "title": "Test Groups",
+          "description": "Definitions of named bundles of tests"
         }
       },
       "additionalProperties": false,
@@ -638,6 +673,26 @@
           "type": "boolean",
           "title": "Runtime package management",
           "description": "Whether the image supports installing or removing packages at runtime"
+        },
+        "wsl": {
+          "type": "boolean",
+          "title": "WSL",
+          "description": "Whether the image runs under the Windows Subsystem for Linux runtime"
+        },
+        "installer-media": {
+          "type": "boolean",
+          "title": "Installer media",
+          "description": "Whether the image is installer media that installs another OS rather than a directly runnable end-state image"
+        },
+        "fips-enabled": {
+          "type": "boolean",
+          "title": "FIPS enabled",
+          "description": "Whether the image is built or configured to run in FIPS mode"
+        },
+        "cvm": {
+          "type": "boolean",
+          "title": "Confidential VM",
+          "description": "Whether the image supports running as a Confidential VM (CVM)"
         }
       },
       "additionalProperties": false,
@@ -729,6 +784,14 @@
           "type": "array",
           "title": "Test Suites",
           "description": "List of test suite references that apply to this image"
+        },
+        "tests": {
+          "items": {
+            "$ref": "#/$defs/TestRef"
+          },
+          "type": "array",
+          "title": "Tests",
+          "description": "List of test or test-group references that apply to this image"
         }
       },
       "additionalProperties": false,
@@ -1384,6 +1447,235 @@
         "name",
         "subpath"
       ]
+    },
+    "TestDefinition": {
+      "allOf": [
+        {
+          "if": {
+            "properties": {
+              "type": {
+                "const": "pytest"
+              }
+            }
+          },
+          "then": {
+            "not": {
+              "anyOf": [
+                {
+                  "required": [
+                    "lisa"
+                  ]
+                },
+                {
+                  "required": [
+                    "tmt"
+                  ]
+                }
+              ]
+            },
+            "required": [
+              "pytest"
+            ]
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "type": {
+                "const": "lisa"
+              }
+            }
+          },
+          "then": {
+            "not": {
+              "anyOf": [
+                {
+                  "required": [
+                    "pytest"
+                  ]
+                },
+                {
+                  "required": [
+                    "tmt"
+                  ]
+                }
+              ]
+            },
+            "required": [
+              "lisa"
+            ]
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "type": {
+                "const": "tmt"
+              }
+            }
+          },
+          "then": {
+            "not": {
+              "anyOf": [
+                {
+                  "required": [
+                    "pytest"
+                  ]
+                },
+                {
+                  "required": [
+                    "lisa"
+                  ]
+                }
+              ]
+            },
+            "required": [
+              "tmt"
+            ]
+          }
+        }
+      ],
+      "properties": {
+        "type": {
+          "type": "string",
+          "enum": [
+            "pytest",
+            "lisa",
+            "tmt"
+          ],
+          "title": "Type",
+          "description": "Test framework type"
+        },
+        "description": {
+          "type": "string",
+          "title": "Description",
+          "description": "Description of this test"
+        },
+        "kind": {
+          "type": "string",
+          "enum": [
+            "functional",
+            "performance"
+          ],
+          "title": "Kind",
+          "description": "Kind hint for the test"
+        },
+        "long-running": {
+          "type": "boolean",
+          "title": "Long running",
+          "description": "Hints that this test may run for hours"
+        },
+        "metrics-enabled": {
+          "type": "boolean",
+          "title": "Metrics enabled",
+          "description": "Hints to the test execution environment/validation service whether metrics from this test should be collected and stored"
+        },
+        "required-capabilities": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array",
+          "title": "Required capabilities",
+          "description": "Capability tokens the image must declare"
+        },
+        "lisa": {
+          "type": "object",
+          "title": "LISA config",
+          "description": "LISA-specific configuration"
+        },
+        "tmt": {
+          "type": "object",
+          "title": "TMT config",
+          "description": "TMT-specific configuration"
+        },
+        "pytest": {
+          "type": "object",
+          "title": "Pytest config",
+          "description": "pytest-specific configuration"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "type"
+      ]
+    },
+    "TestGroup": {
+      "properties": {
+        "description": {
+          "type": "string",
+          "title": "Description",
+          "description": "Description of this test group"
+        },
+        "tests": {
+          "items": {
+            "not": {
+              "required": [
+                "group"
+              ]
+            },
+            "properties": {
+              "name": {
+                "type": "string",
+                "minLength": 1,
+                "pattern": "^\\S",
+                "description": "Name of a test"
+              }
+            },
+            "type": "object",
+            "required": [
+              "name"
+            ]
+          },
+          "type": "array",
+          "title": "Tests",
+          "description": "Ordered test references for this group (name only)"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object"
+    },
+    "TestRef": {
+      "oneOf": [
+        {
+          "not": {
+            "required": [
+              "group"
+            ]
+          },
+          "required": [
+            "name"
+          ]
+        },
+        {
+          "not": {
+            "required": [
+              "name"
+            ]
+          },
+          "required": [
+            "group"
+          ]
+        }
+      ],
+      "properties": {
+        "name": {
+          "type": "string",
+          "minLength": 1,
+          "pattern": "^\\S",
+          "title": "Name",
+          "description": "Name of a test (mutually exclusive with group)"
+        },
+        "group": {
+          "type": "string",
+          "minLength": 1,
+          "pattern": "^\\S",
+          "title": "Group",
+          "description": "Name of a test group (mutually exclusive with name)"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object"
     },
     "TestSuiteConfig": {
       "properties": {


### PR DESCRIPTION
Adds a parse-only schema for declaring tests and reusable test groups in project TOML, plus matching per-component and per-image test reference lists. 
<!--
PR Title must follow Conventional Commits format. Available types:

- feat: A new feature
- fix: A bug fix
- docs: Documentation only changes
- style: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
- refactor: A code change that neither fixes a bug nor adds a feature
- perf: A code change that improves performance
- test: Adding missing tests or correcting existing tests
- build: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
- ci: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
- chore: Other changes that don't modify src or test files
- revert: Reverts a previous commit

Reference: https://www.conventionalcommits.org/en/v1.0.0/
-->
