### PR TITLE
fix: filter noise from license checks

### DIFF
--- a/magefiles/magebuild/magebuild.go
+++ b/magefiles/magebuild/magebuild.go
@@ -367,8 +367,14 @@ func collectLicenses() error {
 
 	env := map[string]string{"GOROOT": goRoot}
 
-	err = sh.RunWith(env, cmdAbsPath, "save", "--save_path", mageutil.LicenseDir(), "--force", "./...")
-	if err != nil {
+	// go-licenses spews a benign glog warning to stderr for every dependency that contains non-Go
+	// (assembly) code. Capture stderr, strip those warnings, and only surface what's left on failure.
+	var stderr strings.Builder
+
+	if _, err := sh.Exec(env, os.Stdout, &stderr, cmdAbsPath,
+		"save", "--save_path", mageutil.LicenseDir(), "--force", "./..."); err != nil {
+		mageutil.PrintLicenseOutput(stderr.String())
+
 		return mageutil.PrintAndReturnError(errorText, ErrLicenses, err)
 	}
 

--- a/magefiles/magecheckfix/checkfix.go
+++ b/magefiles/magecheckfix/checkfix.go
@@ -6,7 +6,6 @@ package magecheckfix
 import (
 	"errors"
 	"fmt"
-	"io"
 	"os"
 	"path"
 	"strings"
@@ -246,12 +245,9 @@ func licenseCheck() error {
 	mageutil.MagePrintln(mageutil.MsgStart, "Checking licenses...")
 
 	outFilePath := path.Join(mageutil.OutDir(), "licenses.csv")
-
 	errorText := "Failed to check licenses."
-	successText := "License check complete, results written to " + outFilePath
 
-	err := sh.Run(mg.GoCmd(), "mod", "download")
-	if err != nil {
+	if err := sh.Run(mg.GoCmd(), "mod", "download"); err != nil {
 		return mageutil.PrintAndReturnError(errorText, ErrCheck, err)
 	}
 
@@ -259,9 +255,6 @@ func licenseCheck() error {
 	if err != nil {
 		return mageutil.PrintAndReturnError(errorText, ErrCheck, err)
 	}
-
-	// per https://github.com/google/go-licenses?tab=readme-ov-file#check
-	disallowedLicenseTypes := []string{"unknown", "forbidden", "restricted"}
 
 	commonOptions := []string{
 		// Ignore golang.org/x dependencies to avoid spurious errors about .s files that can't be checked
@@ -274,9 +267,6 @@ func licenseCheck() error {
 		"./...",
 	}
 
-	checkArgs := append([]string{"check", "--disallowed_types=" + strings.Join(disallowedLicenseTypes, ",")},
-		commonOptions...)
-
 	// go-licenses complains about various standard library .go files unless we explicitly
 	// set the right GOROOT. We invoke "go env" to find the correct GOROOT and then run
 	// go-licenses in an environment with it set.
@@ -285,19 +275,50 @@ func licenseCheck() error {
 		return mageutil.PrintAndReturnError(errorText, ErrCheck, err)
 	}
 
+	if err := runLicenseCheck(cmdAbsPath, goRoot, commonOptions); err != nil {
+		return err
+	}
+
+	if err := runLicenseReport(cmdAbsPath, goRoot, commonOptions, outFilePath); err != nil {
+		return err
+	}
+
+	mageutil.MagePrintln(mageutil.MsgSuccess, "License check complete, results written to "+outFilePath)
+
+	return nil
+}
+
+// runLicenseCheck runs "go-licenses check" for disallowed license types, suppressing the benign
+// non-Go-code warnings on success and only surfacing real errors on failure.
+func runLicenseCheck(cmdAbsPath, goRoot string, commonOptions []string) error {
+	// per https://github.com/google/go-licenses?tab=readme-ov-file#check
+	disallowedLicenseTypes := []string{"unknown", "forbidden", "restricted"}
+
+	checkArgs := append([]string{"check", "--disallowed_types=" + strings.Join(disallowedLicenseTypes, ",")},
+		commonOptions...)
+
+	// go-licenses spews a glog warning for every dependency that contains non-Go (assembly) code.
+	// These are benign and constant, so capture the combined output, strip those warnings, and only
+	// surface what's left (real errors) when the check fails.
 	env := map[string]string{"GOROOT": goRoot}
 
-	err = sh.RunWithV(env, cmdAbsPath, checkArgs...)
-	if err != nil {
-		return mageutil.PrintAndReturnError(errorText, ErrCheck, err)
+	var out strings.Builder
+
+	if _, err := sh.Exec(env, &out, &out, cmdAbsPath, checkArgs...); err != nil {
+		mageutil.PrintLicenseOutput(out.String())
+
+		return mageutil.PrintAndReturnError("Failed to check licenses.", ErrCheck, err)
 	}
+
+	return nil
+}
+
+// runLicenseReport runs "go-licenses report" and writes the resulting CSV to outFilePath. The same
+// non-Go-code warnings are emitted to stderr; they are captured and only surfaced on failure.
+func runLicenseReport(cmdAbsPath, goRoot string, commonOptions []string, outFilePath string) error {
+	errorText := "Failed to check licenses."
 
 	reportArgs := append([]string{"report"}, commonOptions...)
-
-	report, err := sh.OutputWith(env, cmdAbsPath, reportArgs...)
-	if err != nil {
-		return mageutil.PrintAndReturnError(errorText, ErrCheck, err)
-	}
 
 	outFile, err := os.Create(outFilePath)
 	if err != nil {
@@ -305,12 +326,17 @@ func licenseCheck() error {
 	}
 	defer outFile.Close()
 
-	_, err = io.WriteString(outFile, report)
-	if err != nil {
+	// Stream stdout (the CSV) straight to the file and capture stderr separately so the benign
+	// non-Go-code warnings never reach the terminal; only surface them on failure.
+	env := map[string]string{"GOROOT": goRoot}
+
+	var stderr strings.Builder
+
+	if _, err := sh.Exec(env, outFile, &stderr, cmdAbsPath, reportArgs...); err != nil {
+		mageutil.PrintLicenseOutput(stderr.String())
+
 		return mageutil.PrintAndReturnError(errorText, ErrCheck, err)
 	}
-
-	mageutil.MagePrintln(mageutil.MsgSuccess, successText)
 
 	return nil
 }

--- a/magefiles/mageutil/mageutil.go
+++ b/magefiles/mageutil/mageutil.go
@@ -128,6 +128,44 @@ func CreateLicenseDir() error {
 	return createDir(LicenseDir())
 }
 
+// PrintLicenseOutput filters benign go-licenses warnings out of output and prints whatever remains.
+func PrintLicenseOutput(output string) {
+	filtered := FilterLicenseNoise(output)
+	if filtered == "" {
+		return
+	}
+
+	for _, line := range strings.Split(filtered, "\n") {
+		MagePrintln(MsgInfo, line)
+	}
+}
+
+// FilterLicenseNoise strips go-licenses' benign "contains non-Go code" glog warnings (and their
+// following file-path continuation lines) from the given output, returning the remaining lines.
+func FilterLicenseNoise(output string) string {
+	var kept []string
+
+	skipping := false
+
+	for _, line := range strings.Split(output, "\n") {
+		switch {
+		case strings.Contains(line, "contains non-Go code that can't be inspected"):
+			// Start of a warning block; drop this line and its path continuation lines.
+			skipping = true
+		case skipping && strings.HasPrefix(line, "/"):
+			// Continuation file path under the current warning; drop it.
+		default:
+			skipping = false
+
+			if strings.TrimSpace(line) != "" {
+				kept = append(kept, line)
+			}
+		}
+	}
+
+	return strings.Join(kept, "\n")
+}
+
 // getCallerFunctionName returns the name of the function that called the function that called it.
 // fnDepth is the number of functions to go back in the call stack to find the user's function name.
 func getCallerFunctionName(fnDepth int) string {


### PR DESCRIPTION
Filter out:
```
🚀 collectLicenses: Collecting licenses
W0604 10:03:13.741344 3396429 library.go:141] "golang.org/x/sys/unix" contains non-Go code that can't be inspected for further dependencies:
/home/damcilva/go/pkg/mod/golang.org/x/sys@v0.44.0/unix/asm_linux_amd64.s
W0604 10:03:13.741542 3396429 library.go:141] "github.com/klauspost/compress/zstd" contains non-Go code that can't be inspected for further dependencies:
/home/damcilva/go/pkg/mod/github.com/klauspost/compress@v1.18.6/zstd/fse_decoder_amd64.s
/home/damcilva/go/pkg/mod/github.com/klauspost/compress@v1.18.6/zstd/matchlen_amd64.s
/home/damcilva/go/pkg/mod/github.com/klauspost/compress@v1.18.6/zstd/seqdec_amd64.s
W0604 10:03:13.741597 3396429 library.go:141] "github.com/klauspost/compress/huff0" contains non-Go code that can't be inspected for further dependencies:
/home/damcilva/go/pkg/mod/github.com/klauspost/compress@v1.18.6/huff0/decompress_amd64.s
...
```