### PR TITLE
feat(config): add optional metadata to component groups

### DIFF
--- a/docs/user/reference/config/component-groups.md
+++ b/docs/user/reference/config/component-groups.md
@@ -7,10 +7,32 @@ Component groups organize related components together and let you apply shared d
 | Field | TOML Key | Type | Required | Description |
 |-------|----------|------|----------|-------------|
 | Description | `description` | string | No | Human-readable description of this group |
+| Metadata | `metadata` | [OverlayMetadata](overlays.md) | No | Optional documentation metadata describing the group's intent and provenance |
 | Components | `components` | string array | No | List of component names that belong to this group |
 | Specs | `specs` | string array | No | Glob patterns for discovering local spec files to include as group members |
 | Excluded paths | `excluded-paths` | string array | No | Glob patterns for paths to exclude from spec discovery |
 | Default component config | `default-component-config` | [ComponentConfig](components.md) | No | Default configuration inherited by all components in this group |
+
+## Metadata
+
+The optional `[component-groups.<name>.metadata]` table documents the group's intent and provenance. It shares exactly the same fields and validation rules as [overlay metadata](overlays.md): a required `category`, plus optional commit/bug links and an upstreamable assessment. It is documentation only — it does not affect how members are resolved or built.
+
+| Field | TOML Key | Type | Required | Description |
+|-------|----------|------|----------|-------------|
+| Category | `category` | enum | **Yes** | Classification of the group's intent (e.g. `backport-dist-git`, `azl-disable-flaky-tests`) |
+| Commits | `commits` | string array (URLs) | No | Upstream commit URLs this group references; required when `category = "backport-dist-git"` |
+| Bugs | `bugs` | array of `{ url = "..." }` tables | No | References to related issue-tracker entries; see [Bug references](overlays.md#bug-references) |
+| Upstreamable | `upstreamable` | boolean | No | Whether the group's change can be upstreamed (`true`/`false`); omit when not yet assessed |
+
+```toml
+[component-groups.check-skip-initial-failures]
+description = "Components with check failures during initial distro bringup"
+components = ["bats", "dnf", "git"]
+
+[component-groups.check-skip-initial-failures.metadata]
+category = "azl-disable-flaky-tests"
+# upstreamable omitted: upstreamability for this group has not been assessed yet.
+```
 
 ## Component Membership
 

--- a/internal/projectconfig/component.go
+++ b/internal/projectconfig/component.go
@@ -110,6 +110,11 @@ type ComponentGroupConfig struct {
 	// A human-friendly description of this component group.
 	Description string `toml:"description,omitempty" json:"description,omitempty" jsonschema:"title=Description,description=Description of this component group"`
 
+	// Optional documentation metadata describing this component group's intent and provenance.
+	// It reuses the overlay metadata schema (see [OverlayMetadata]) and does not affect how the
+	// group's members are resolved or built.
+	Metadata *OverlayMetadata `toml:"metadata,omitempty" json:"metadata,omitempty" jsonschema:"title=Metadata,description=Optional documentation metadata for this component group"`
+
 	// List of explicitly included components, identified by name.
 	Components []string `toml:"components,omitempty" json:"components,omitempty" jsonschema:"title=Components,description=List of component names that are members of this group"`
 

--- a/internal/projectconfig/configfile.go
+++ b/internal/projectconfig/configfile.go
@@ -97,6 +97,11 @@ func (f ConfigFile) Validate() error {
 		}
 	}
 
+	// Validate component group metadata.
+	if err := validateComponentGroupMetadata(f.ComponentGroups); err != nil {
+		return err
+	}
+
 	// Per-component snapshot timestamps are not allowed. Components inherit
 	// the snapshot from the distro/group default-component-config or the
 	// project's default-distro. Per-component snapshots would create
@@ -144,6 +149,22 @@ func (f ConfigFile) Validate() error {
 
 		if err := suite.Validate(); err != nil {
 			return fmt.Errorf("invalid test suite %#q:\n%w", suiteName, err)
+		}
+	}
+
+	return nil
+}
+
+// validateComponentGroupMetadata validates the optional documentation metadata declared
+// on each component group.
+func validateComponentGroupMetadata(groups map[string]ComponentGroupConfig) error {
+	for groupName, group := range groups {
+		if group.Metadata == nil {
+			continue
+		}
+
+		if err := group.Metadata.Validate(); err != nil {
+			return fmt.Errorf("invalid metadata on component group %#q:\n%w", groupName, err)
 		}
 	}
 

--- a/internal/projectconfig/loader_test.go
+++ b/internal/projectconfig/loader_test.go
@@ -485,6 +485,52 @@ specs = ["SPECS/**/*.spec"]
 	assert.Equal(t, []string{"core"}, config.GroupsByComponent["bar"])
 }
 
+func TestLoadAndResolveProjectConfig_ComponentGroupWithMetadata(t *testing.T) {
+	const configContents = `
+[component-groups.core]
+specs = ["SPECS/**/*.spec"]
+
+[component-groups.core.metadata]
+category = "backport-dist-git"
+commits = ["https://example.com/commit/abc"]
+bugs = [{ url = "https://example.com/bug/1" }]
+upstreamable = true
+`
+
+	ctx := testctx.NewCtx()
+	require.NoError(t, fileutils.WriteFile(ctx.FS(), testConfigPath, []byte(configContents), fileperms.PrivateFile))
+
+	config, err := loadAndResolveProjectConfig(ctx.FS(), false, testConfigPath)
+	require.NoError(t, err)
+
+	if assert.Contains(t, config.ComponentGroups, "core") {
+		group := config.ComponentGroups["core"]
+		require.NotNil(t, group.Metadata)
+		assert.Equal(t, OverlayCategoryBackportDistGit, group.Metadata.Category)
+		assert.Equal(t, []string{"https://example.com/commit/abc"}, group.Metadata.Commits)
+		assert.Equal(t, []BugRef{{URL: "https://example.com/bug/1"}}, group.Metadata.Bugs)
+		require.NotNil(t, group.Metadata.Upstreamable)
+		assert.True(t, *group.Metadata.Upstreamable)
+	}
+}
+
+func TestLoadAndResolveProjectConfig_ComponentGroupMetadataMissingCategory(t *testing.T) {
+	const configContents = `
+[component-groups.core]
+specs = ["SPECS/**/*.spec"]
+
+[component-groups.core.metadata]
+bugs = [{ url = "https://example.com/bug/1" }]
+`
+
+	ctx := testctx.NewCtx()
+	require.NoError(t, fileutils.WriteFile(ctx.FS(), testConfigPath, []byte(configContents), fileperms.PrivateFile))
+
+	config, err := loadAndResolveProjectConfig(ctx.FS(), false, testConfigPath)
+	require.Error(t, err)
+	assert.Nil(t, config)
+}
+
 func TestLoadAndResolveProjectConfig_GroupsByComponent_MultipleGroups(t *testing.T) {
 	testFiles := []struct {
 		path     string

--- a/scenario/__snapshots__/TestSnapshotsContainer_config_generate-schema_stdout_1.snap
+++ b/scenario/__snapshots__/TestSnapshotsContainer_config_generate-schema_stdout_1.snap
@@ -185,6 +185,11 @@
           "title": "Description",
           "description": "Description of this component group"
         },
+        "metadata": {
+          "$ref": "#/$defs/OverlayMetadata",
+          "title": "Metadata",
+          "description": "Optional documentation metadata for this component group"
+        },
         "components": {
           "items": {
             "type": "string"

--- a/scenario/__snapshots__/TestSnapshots_config_generate-schema_stdout_1.snap
+++ b/scenario/__snapshots__/TestSnapshots_config_generate-schema_stdout_1.snap
@@ -185,6 +185,11 @@
           "title": "Description",
           "description": "Description of this component group"
         },
+        "metadata": {
+          "$ref": "#/$defs/OverlayMetadata",
+          "title": "Metadata",
+          "description": "Optional documentation metadata for this component group"
+        },
         "components": {
           "items": {
             "type": "string"

--- a/schemas/azldev.schema.json
+++ b/schemas/azldev.schema.json
@@ -185,6 +185,11 @@
           "title": "Description",
           "description": "Description of this component group"
         },
+        "metadata": {
+          "$ref": "#/$defs/OverlayMetadata",
+          "title": "Metadata",
+          "description": "Optional documentation metadata for this component group"
+        },
         "components": {
           "items": {
             "type": "string"


### PR DESCRIPTION
## Summary

This PR is the second PR for adding metadata support, adding an optional `[component-groups.<name>.metadata]` block that reuses the existing `OverlayMetadata` schema — the required `category` plus optional `commits`, `bugs`, and `upstreamable`.

Metadata is **documentation only**: it does not affect how group members are resolved, filtered, or built. It gives component groups the same provenance-tracking surface that overlays already have, so consumers can record *why* a group exists (e.g. `azl-pruning`, `backport-dist-git`) and link back to commits / bugs.

## Changes

- `internal/projectconfig/component.go` — reuse `OverlayMetadata` on `ComponentGroup`.
- `internal/projectconfig/configfile.go` — wire group-metadata validation into `ConfigFile.Validate`.
- `internal/projectconfig/loader_test.go` — coverage for the new field.
- `docs/user/reference/config/component-groups.md` — reference doc updates.
- `schemas/azldev.schema.json` + scenario snapshots — regenerated via `mage docs`.

## Testing

- `mage docs` — schema and CLI docs regenerate cleanly (no diff after commit).
- Unit tests updated in `loader_test.go`.

## Notes

- Metadata is excluded from component fingerprints, consistent with how overlay metadata is handled — editing it never invalidates build caches.
- No behavioral change to resolution or build.
