### PR TITLE
feat(component): capture and persist upstream NEVR provenance

### DIFF
--- a/internal/app/azldev/cmds/component/update.go
+++ b/internal/app/azldev/cmds/component/update.go
@@ -141,11 +141,40 @@ type UpdateResult struct {
 	// Used as SourceIdentity input for fingerprint computation.
 	sourceIdentity string `json:"-" table:"-"`
 
+	// upstreamName / upstreamEpoch / upstreamVersion / upstreamRelease carry
+	// the NEVR values captured from the upstream spec at the resolved commit
+	// (or from the local spec for local components). Empty when the provider
+	// could not parse the spec. Written to the lock file so downstream specs
+	// can reference upstream provenance via the %azl_upstream_* macros.
+	upstreamName    string `json:"-" table:"-"`
+	upstreamEpoch   string `json:"-" table:"-"`
+	upstreamVersion string `json:"-" table:"-"`
+	upstreamRelease string `json:"-" table:"-"`
+
 	// upToDate is set by the freshness check (Case 1) when both the input
 	// fingerprint and resolution hash match the lock. Components marked
 	// upToDate are skipped by [saveComponentLocks] — no re-fingerprinting
 	// or lock rewrite is needed.
 	upToDate bool `json:"-" table:"-"`
+}
+
+// setUpstreamProvenanceFromLock copies the captured NEVR provenance from an
+// existing lock into the result. Used by the fast paths that reuse a locked
+// commit without re-resolving, so the values survive into the rewritten lock.
+func (r *UpdateResult) setUpstreamProvenanceFromLock(locked *projectconfig.ComponentLockData) {
+	r.upstreamName = locked.UpstreamName
+	r.upstreamEpoch = locked.UpstreamEpoch
+	r.upstreamVersion = locked.UpstreamVersion
+	r.upstreamRelease = locked.UpstreamRelease
+}
+
+// hasLockedUpstreamVersionRelease reports whether an upstream lock already has
+// the provenance fields required by the build macros used for SBAT versioning.
+// Older lock files predate these fields; those must take the resolver path so
+// update can backfill the captured upstream Version/Release without requiring a
+// separate manual rebase.
+func hasLockedUpstreamVersionRelease(locked *projectconfig.ComponentLockData) bool {
+	return locked != nil && locked.UpstreamVersion != "" && locked.UpstreamRelease != ""
 }
 
 // UpdateComponents resolves source identities for all selected components and
@@ -388,6 +417,15 @@ func updateComponentLock(env *azldev.Env, store *lockfile.Store, result *UpdateR
 	}
 
 	lock.UpstreamCommit = result.UpstreamCommit
+
+	// Update captured upstream provenance. These are always overwritten
+	// (even with empty strings) so a source-type transition or a spec-
+	// parse regression on a subsequent update doesn't leave stale values
+	// hanging around in the lock file.
+	lock.UpstreamName = result.upstreamName
+	lock.UpstreamEpoch = result.upstreamEpoch
+	lock.UpstreamVersion = result.upstreamVersion
+	lock.UpstreamRelease = result.upstreamRelease
 
 	// Clear upstream-only fields for local components so a source-type
 	// transition (upstream → local) doesn't leave stale data in the lock.
@@ -763,10 +801,12 @@ func classifyForResolution(
 		locked := comp.GetConfig().Locked
 		isUpstream := comp.GetConfig().Spec.SourceType == projectconfig.SpecSourceTypeUpstream
 
-		if isUpstream && locked != nil && locked.Freshness == projectconfig.FreshnessCurrent {
+		if isUpstream && locked != nil && locked.Freshness == projectconfig.FreshnessCurrent &&
+			hasLockedUpstreamVersionRelease(locked) {
 			// Case 1: fully up-to-date — skip.
 			results[idx].UpstreamCommit = locked.UpstreamCommit
 			results[idx].sourceIdentity = comp.GetConfig().EffectiveUpstreamCommit()
+			results[idx].setUpstreamProvenanceFromLock(locked)
 			results[idx].upToDate = true
 			syncCompleted++
 
@@ -774,12 +814,13 @@ func classifyForResolution(
 		}
 
 		if isUpstream && locked != nil && locked.Freshness == projectconfig.FreshnessStale &&
-			!locked.ResolutionStale && locked.UpstreamCommit != "" {
+			!locked.ResolutionStale && locked.UpstreamCommit != "" && hasLockedUpstreamVersionRelease(locked) {
 			// Case 2: build inputs changed but resolution inputs unchanged.
 			// Reuse the locked commit — re-resolving would yield the same hash.
 			results[idx].UpstreamCommit = locked.UpstreamCommit
 			results[idx].PreviousCommit = locked.UpstreamCommit
 			results[idx].sourceIdentity = comp.GetConfig().EffectiveUpstreamCommit()
+			results[idx].setUpstreamProvenanceFromLock(locked)
 			results[idx].config = comp.GetConfig()
 			syncCompleted++
 
@@ -819,13 +860,17 @@ func resolveAndRecordIdentity(
 		return
 	}
 
-	result.sourceIdentity = identity
+	result.sourceIdentity = identity.Identity
+	result.upstreamName = identity.Name
+	result.upstreamEpoch = identity.Epoch
+	result.upstreamVersion = identity.Version
+	result.upstreamRelease = identity.Release
 	result.config = comp.GetConfig()
 
 	// For upstream components, the identity IS the commit hash.
 	// For local components, UpstreamCommit stays empty.
 	if comp.GetConfig().Spec.SourceType == projectconfig.SpecSourceTypeUpstream {
-		result.UpstreamCommit = identity
+		result.UpstreamCommit = identity.Identity
 	}
 
 	// Check existing lock to determine if the component changed.
@@ -868,25 +913,29 @@ func resolveOneSourceIdentity(
 	ctx context.Context,
 	env *azldev.Env,
 	comp components.Component,
-) (string, error) {
+) (sourceproviders.SourceIdentity, error) {
 	componentName := comp.GetName()
 
 	distro, err := sourceproviders.ResolveDistro(env, comp)
 	if err != nil {
-		return "", fmt.Errorf("resolving distro for %#q:\n%w", componentName, err)
+		return sourceproviders.SourceIdentity{}, fmt.Errorf("resolving distro for %#q:\n%w", componentName, err)
 	}
 
 	sourceManager, err := sourceproviders.NewSourceManager(env, distro)
 	if err != nil {
-		return "", fmt.Errorf("creating source manager for %#q:\n%w", componentName, err)
+		return sourceproviders.SourceIdentity{}, fmt.Errorf("creating source manager for %#q:\n%w", componentName, err)
 	}
 
 	identity, err := sourceManager.ResolveSourceIdentity(ctx, comp)
 	if err != nil {
-		return "", fmt.Errorf("resolving identity for %#q:\n%w", componentName, err)
+		return sourceproviders.SourceIdentity{}, fmt.Errorf("resolving identity for %#q:\n%w", componentName, err)
 	}
 
-	slog.Debug("Resolved source identity", "component", componentName, "identity", identity)
+	slog.Debug("Resolved source identity", "component", componentName,
+		"identity", identity.Identity,
+		"upstreamName", identity.Name,
+		"upstreamVersion", identity.Version,
+		"upstreamRelease", identity.Release)
 
 	return identity, nil
 }

--- a/internal/app/azldev/cmds/component/update_freshness_test.go
+++ b/internal/app/azldev/cmds/component/update_freshness_test.go
@@ -67,6 +67,10 @@ func setupMockGitWithCounter(env *testutils.TestEnv, commitHash string) *atomic.
 			return commitHash, nil
 		}
 
+		if strings.Contains(strings.Join(cmd.Args, " "), " show ") {
+			return "Name: curl\nVersion: 8.7.0\nRelease: 3%{?dist}\n", nil
+		}
+
 		return "", nil
 	}
 

--- a/internal/app/azldev/cmds/component/update_internal_test.go
+++ b/internal/app/azldev/cmds/component/update_internal_test.go
@@ -188,6 +188,58 @@ func TestSaveComponentLocks_SkipsUpToDate(t *testing.T) {
 	assert.False(t, exists, "upToDate component should not get a lock file")
 }
 
+func TestClassifyForResolution_BackfillsMissingUpstreamProvenance(t *testing.T) {
+	tests := []struct {
+		name      string
+		freshness projectconfig.FreshnessStatus
+	}{
+		{name: "fresh lock", freshness: projectconfig.FreshnessCurrent},
+		{name: "build-input-only stale lock", freshness: projectconfig.FreshnessStale},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			config := baseConfig("curl")
+			config.Locked = &projectconfig.ComponentLockData{
+				UpstreamCommit:  "locked-commit",
+				Freshness:       tt.freshness,
+				ResolutionStale: false,
+			}
+
+			results := make([]UpdateResult, 1)
+			parallel, syncCompleted := classifyForResolution(
+				[]components.Component{newMockComp(t, "curl", config)}, results,
+			)
+
+			require.Len(t, parallel, 1)
+			assert.Zero(t, syncCompleted)
+			assert.False(t, results[0].upToDate,
+				"locks without upstream version/release must re-resolve to backfill provenance")
+		})
+	}
+}
+
+func TestClassifyForResolution_ReusesLockWithUpstreamProvenance(t *testing.T) {
+	config := baseConfig("curl")
+	config.Locked = &projectconfig.ComponentLockData{
+		UpstreamCommit:  "locked-commit",
+		UpstreamVersion: "8.7.0",
+		UpstreamRelease: "3%{?dist}",
+		Freshness:       projectconfig.FreshnessCurrent,
+	}
+
+	results := make([]UpdateResult, 1)
+	parallel, syncCompleted := classifyForResolution(
+		[]components.Component{newMockComp(t, "curl", config)}, results,
+	)
+
+	assert.Empty(t, parallel)
+	assert.EqualValues(t, 1, syncCompleted)
+	assert.True(t, results[0].upToDate)
+	assert.Equal(t, "8.7.0", results[0].upstreamVersion)
+	assert.Equal(t, "3%{?dist}", results[0].upstreamRelease)
+}
+
 func TestSaveComponentLocks_PreservesManualBump(t *testing.T) {
 	env := testutils.NewTestEnv(t)
 	store := newTestStore(t, env)

--- a/internal/app/azldev/core/components/resolver.go
+++ b/internal/app/azldev/core/components/resolver.go
@@ -615,6 +615,10 @@ func (r *Resolver) populateFromLock(config *projectconfig.ComponentConfig) {
 		ManualBump:          lock.ManualBump,
 		InputFingerprint:    lock.InputFingerprint,
 		ResolutionInputHash: lock.ResolutionInputHash,
+		UpstreamName:        lock.UpstreamName,
+		UpstreamEpoch:       lock.UpstreamEpoch,
+		UpstreamVersion:     lock.UpstreamVersion,
+		UpstreamRelease:     lock.UpstreamRelease,
 	}
 
 	if r.CheckFreshness {

--- a/internal/lockfile/lockfile.go
+++ b/internal/lockfile/lockfile.go
@@ -63,6 +63,31 @@ type ComponentLock struct {
 	//   - Hash matches → resolution inputs unchanged, reuse locked commit
 	//   - Hash differs → resolution inputs changed, re-resolve required
 	ResolutionInputHash string `toml:"resolution-input-hash,omitempty"`
+
+	// UpstreamName is the package Name: tag from the upstream spec at
+	// UpstreamCommit. Captured at update time so downstream specs can
+	// reference upstream provenance via the %azl_upstream_name macro
+	// without re-parsing the upstream spec at build time.
+	// Empty for local components or when upstream parsing fails.
+	UpstreamName string `toml:"upstream-name,omitempty"`
+
+	// UpstreamEpoch is the package Epoch: tag from the upstream spec at
+	// UpstreamCommit. Exposed via the %azl_upstream_epoch macro.
+	// Empty if the upstream spec has no Epoch tag or on parse failure.
+	UpstreamEpoch string `toml:"upstream-epoch,omitempty"`
+
+	// UpstreamVersion is the package Version: tag from the upstream spec at
+	// UpstreamCommit. Exposed via the %azl_upstream_version macro.
+	// Empty for local components or when upstream parsing fails.
+	UpstreamVersion string `toml:"upstream-version,omitempty"`
+
+	// UpstreamRelease is the raw Release: tag from the upstream spec at
+	// UpstreamCommit. Exposed via the %azl_upstream_release macro.
+	// The value is stored verbatim from the upstream spec and may contain
+	// unexpanded macros (notably %{?dist}). Callers that need a fully
+	// expanded form should handle macro substitution themselves.
+	// Empty for local components or when upstream parsing fails.
+	UpstreamRelease string `toml:"upstream-release,omitempty"`
 }
 
 // New creates a new empty component lock with the current format version.

--- a/internal/lockfile/lockfile_test.go
+++ b/internal/lockfile/lockfile_test.go
@@ -113,6 +113,10 @@ func TestSaveAndLoad(t *testing.T) {
 	original.ImportCommit = "0000111122223333444455556666777788889999"
 	original.ManualBump = 2
 	original.InputFingerprint = "sha256:abcdef1234567890"
+	original.UpstreamName = "curl"
+	original.UpstreamEpoch = "1"
+	original.UpstreamVersion = "8.7.0"
+	original.UpstreamRelease = "3%{?dist}"
 
 	require.NoError(t, original.Save(memFS, lockPath))
 
@@ -124,6 +128,11 @@ func TestSaveAndLoad(t *testing.T) {
 	assert.Equal(t, "0000111122223333444455556666777788889999", loaded.ImportCommit)
 	assert.Equal(t, 2, loaded.ManualBump)
 	assert.Equal(t, "sha256:abcdef1234567890", loaded.InputFingerprint)
+	assert.Equal(t, "curl", loaded.UpstreamName)
+	assert.Equal(t, "1", loaded.UpstreamEpoch)
+	assert.Equal(t, "8.7.0", loaded.UpstreamVersion)
+	assert.Equal(t, "3%{?dist}", loaded.UpstreamRelease,
+		"upstream release is stored raw; %{?dist} must survive the roundtrip verbatim")
 }
 
 func TestSaveCreatesDirectory(t *testing.T) {

--- a/internal/projectconfig/component.go
+++ b/internal/projectconfig/component.go
@@ -285,6 +285,22 @@ type ComponentLockData struct {
 	// distro ref, pin, upstream name). Used to determine if the locked commit
 	// needs re-resolution.
 	ResolutionInputHash string `json:"resolutionInputHash,omitempty"`
+	// UpstreamName is the package Name: tag captured from the upstream spec
+	// at the locked commit. Exposed to the build via the %azl_upstream_name
+	// macro. Empty for local components or when parsing failed.
+	UpstreamName string `json:"upstreamName,omitempty"`
+	// UpstreamEpoch is the package Epoch: tag captured from the upstream spec
+	// at the locked commit. Exposed via the %azl_upstream_epoch macro. Empty
+	// when the upstream spec has no Epoch tag.
+	UpstreamEpoch string `json:"upstreamEpoch,omitempty"`
+	// UpstreamVersion is the package Version: tag captured from the upstream
+	// spec at the locked commit. Exposed via the %azl_upstream_version macro.
+	UpstreamVersion string `json:"upstreamVersion,omitempty"`
+	// UpstreamRelease is the raw Release: tag captured from the upstream spec
+	// at the locked commit. Exposed via the %azl_upstream_release macro. The
+	// value is stored verbatim and may contain unexpanded macros such as
+	// %{?dist}.
+	UpstreamRelease string `json:"upstreamRelease,omitempty"`
 	// Freshness indicates whether the component's config matches its lock.
 	// Runtime-only — computed by the resolver when freshness checking is enabled.
 	Freshness FreshnessStatus `json:"-"`

--- a/internal/providers/sourceproviders/fedorasourceprovider.go
+++ b/internal/providers/sourceproviders/fedorasourceprovider.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"log/slog"
 	"path/filepath"
+	"strings"
 	"time"
 
 	"github.com/microsoft/azure-linux-dev-tools/internal/app/azldev/core/components"
@@ -253,15 +254,22 @@ func (g *FedoraSourcesProviderImpl) checkoutTargetCommit(
 // callers that want the cached locked commit should read
 // [projectconfig.ComponentLockData.UpstreamCommit] directly.
 //
-// When [projectconfig.SpecSource.UpstreamCommit] is pinned, returns that commit
-// directly without contacting upstream. Otherwise, clones the dist-git repo to
-// resolve the commit via snapshot time or branch HEAD.
+// In all cases the dist-git repo is cloned (metadata-only). For pinned commits
+// (see [projectconfig.SpecSource.UpstreamCommit]) the pinned hash is used as the
+// identity directly; for snapshot/HEAD cases the commit is resolved from the
+// clone. A clone failure is fatal in every case — the clone is required both to
+// resolve the commit and to read the upstream spec for provenance.
+//
+// After the commit is resolved, this method makes a best-effort attempt to parse
+// the upstream spec's Name/Epoch/Version/Release tags and populate the
+// corresponding fields on [SourceIdentity]. Spec read/parse failures are logged
+// at debug and treated as non-fatal — the identity itself is still returned.
 func (g *FedoraSourcesProviderImpl) ResolveIdentity(
 	ctx context.Context,
 	component components.Component,
-) (string, error) {
+) (SourceIdentity, error) {
 	if component.GetName() == "" {
-		return "", errors.New("component name cannot be empty")
+		return SourceIdentity{}, errors.New("component name cannot be empty")
 	}
 
 	upstreamName := component.GetConfig().Spec.UpstreamName
@@ -271,35 +279,103 @@ func (g *FedoraSourcesProviderImpl) ResolveIdentity(
 
 	gitRepoURL, err := fedorasource.BuildDistGitURL(g.distroGitBaseURI, upstreamName)
 	if err != nil {
-		return "", fmt.Errorf("failed to build dist-git URL for %#q:\n%w", upstreamName, err)
+		return SourceIdentity{}, fmt.Errorf("failed to build dist-git URL for %#q:\n%w", upstreamName, err)
 	}
 
-	return g.resolveCommit(ctx, gitRepoURL, upstreamName, component.GetConfig().Spec.UpstreamCommit)
+	commitHash, repoDir, cleanup, err := g.resolveCommit(
+		ctx, gitRepoURL, upstreamName, component.GetConfig().Spec.UpstreamCommit,
+	)
+	if cleanup != nil {
+		defer cleanup()
+	}
+
+	if err != nil {
+		return SourceIdentity{}, err
+	}
+
+	result := SourceIdentity{Identity: commitHash}
+
+	// Best-effort NEVR capture from the resolved upstream spec, read out of the
+	// clone that resolveCommit produced.
+	result.SpecEVR = g.captureUpstreamEVR(ctx, repoDir, commitHash, upstreamName, component.GetName())
+
+	return result, nil
+}
+
+// captureUpstreamEVR is a best-effort read of the upstream spec's NEVR tags at
+// the resolved commit. It reads the spec via 'git show' (which works on blobless
+// clones by fetching the blob on demand) and parses tag values. All errors are
+// logged at debug and swallowed — on any failure the zero [SpecEVR] is returned.
+func (g *FedoraSourcesProviderImpl) captureUpstreamEVR(
+	ctx context.Context,
+	repoDir, commitHash, upstreamName, componentName string,
+) SpecEVR {
+	specPath := upstreamName + ".spec"
+
+	contents, err := g.gitProvider.ShowFile(ctx, repoDir, commitHash, specPath)
+	if err != nil {
+		slog.Debug("Skipping upstream EVR capture: cannot read spec at commit",
+			"component", componentName, "commit", commitHash,
+			"spec", specPath, "error", err)
+
+		return SpecEVR{}
+	}
+
+	evr, parseErr := ParseSpecEVR(strings.NewReader(contents))
+	if parseErr != nil {
+		slog.Debug("Skipping upstream EVR capture: cannot parse spec",
+			"component", componentName, "commit", commitHash,
+			"spec", specPath, "error", parseErr)
+
+		return SpecEVR{}
+	}
+
+	return evr
 }
 
 // resolveCommit determines the effective commit via [resolveEffectiveCommitHash].
-// For pinned commits (case 1), it returns immediately without cloning. For snapshot
-// and HEAD cases, it performs a metadata-only clone to resolve the commit hash.
+// A metadata-only clone is always performed: for snapshot and HEAD cases it is
+// needed to resolve the commit, and for pinned commits it is needed so the
+// upstream spec can be read for provenance capture. It returns the temp clone
+// directory plus a cleanup function that the caller must invoke (typically via
+// defer) to remove that directory. The cleanup function is nil-safe and non-nil
+// whenever a temp directory was created.
 func (g *FedoraSourcesProviderImpl) resolveCommit(
 	ctx context.Context, gitRepoURL string, upstreamName string, upstreamCommit string,
-) (string, error) {
-	// Case 1: Explicit upstream commit hash specified per-component
-	if upstreamCommit != "" {
-		return g.resolveEffectiveCommitHash(ctx, "", upstreamCommit, slog.LevelDebug)
+) (commitHash string, repoDir string, cleanup func(), err error) {
+	tempDir, cleanup, err := g.cloneForIdentity(ctx, gitRepoURL, upstreamName)
+	if err != nil {
+		return "", tempDir, cleanup, err
 	}
 
-	// Cases 2 & 3: need a metadata-only clone to resolve snapshot or HEAD commit.
+	// A pinned upstreamCommit is returned as-is by resolveEffectiveCommitHash;
+	// snapshot/HEAD cases resolve the commit from the clone.
+	commitHash, err = g.resolveEffectiveCommitHash(ctx, tempDir, upstreamCommit, slog.LevelDebug)
+	if err != nil {
+		return "", tempDir, cleanup, fmt.Errorf("resolving commit for %#q:\n%w", upstreamName, err)
+	}
+
+	return commitHash, tempDir, cleanup, nil
+}
+
+// cloneForIdentity creates a temporary metadata-only clone used for source
+// identity resolution and best-effort provenance capture. The returned cleanup
+// function removes the temporary clone and should be deferred by the caller when
+// non-nil.
+func (g *FedoraSourcesProviderImpl) cloneForIdentity(
+	ctx context.Context, gitRepoURL string, upstreamName string,
+) (repoDir string, cleanup func(), err error) {
 	tempDir, err := fileutils.MkdirTempInTempDir(g.fs, "azldev-identity-snapshot-")
 	if err != nil {
-		return "", fmt.Errorf("creating temp directory for snapshot clone:\n%w", err)
+		return "", nil, fmt.Errorf("creating temp directory for snapshot clone:\n%w", err)
 	}
 
-	defer func() {
+	cleanup = func() {
 		if removeErr := g.fs.RemoveAll(tempDir); removeErr != nil {
 			slog.Debug("Failed to clean up snapshot clone temp directory",
 				"path", tempDir, "error", removeErr)
 		}
-	}()
+	}
 
 	// Clone a single branch to resolve the snapshot commit. We use a full
 	// (non-shallow) clone because not all git servers support --shallow-since
@@ -315,15 +391,10 @@ func (g *FedoraSourcesProviderImpl) resolveCommit(
 		)
 	})
 	if err != nil {
-		return "", fmt.Errorf("partial clone for identity of %#q:\n%w", upstreamName, err)
+		return tempDir, cleanup, fmt.Errorf("partial clone for identity of %#q:\n%w", upstreamName, err)
 	}
 
-	commitHash, err := g.resolveEffectiveCommitHash(ctx, tempDir, "", slog.LevelDebug)
-	if err != nil {
-		return "", fmt.Errorf("resolving commit for %#q:\n%w", upstreamName, err)
-	}
-
-	return commitHash, nil
+	return tempDir, cleanup, nil
 }
 
 // resolveEffectiveCommitHash is the single source of truth for which commit a

--- a/internal/providers/sourceproviders/identityprovider_test.go
+++ b/internal/providers/sourceproviders/identityprovider_test.go
@@ -121,11 +121,16 @@ func TestFedoraProvider_ResolveIdentity(t *testing.T) {
 		mockGitProvider.EXPECT().
 			GetCurrentCommit(gomock.Any(), gomock.Any()).
 			Return(expectedCommit, nil)
+		// Best-effort EVR fetch — return an error to exercise graceful
+		// degradation without asserting on the resulting empty fields.
+		mockGitProvider.EXPECT().
+			ShowFile(gomock.Any(), gomock.Any(), expectedCommit, testPackageName+".spec").
+			Return("", errors.New("blob unavailable"))
 
 		comp := newMockComp(ctrl, testPackageName)
 		identity, resolveErr := provider.ResolveIdentity(t.Context(), comp)
 		require.NoError(t, resolveErr)
-		assert.Equal(t, expectedCommit, identity)
+		assert.Equal(t, expectedCommit, identity.Identity)
 	})
 
 	t.Run("returns error on clone failure", func(t *testing.T) {
@@ -139,7 +144,7 @@ func TestFedoraProvider_ResolveIdentity(t *testing.T) {
 		assert.Contains(t, resolveErr.Error(), testPackageName)
 	})
 
-	t.Run("returns pinned commit without network call", func(t *testing.T) {
+	t.Run("returns pinned commit and captures EVR", func(t *testing.T) {
 		pinnedCommit := "deadbeef12345678"
 		comp := newMockCompWithConfig(ctrl, testPackageName, &projectconfig.ComponentConfig{
 			Name: testPackageName,
@@ -149,10 +154,38 @@ func TestFedoraProvider_ResolveIdentity(t *testing.T) {
 			},
 		})
 
-		// No LsRemoteHead expectation — the pinned commit should be returned directly.
+		mockGitProvider.EXPECT().
+			Clone(gomock.Any(), repoURL, gomock.Any(), gomock.Any()).
+			Return(nil)
+		mockGitProvider.EXPECT().
+			ShowFile(gomock.Any(), gomock.Any(), pinnedCommit, testPackageName+".spec").
+			Return("Name: test-package\nVersion: 2.12\nRelease: 42%{?dist}\n", nil)
+
 		identity, resolveErr := provider.ResolveIdentity(t.Context(), comp)
 		require.NoError(t, resolveErr)
-		assert.Equal(t, pinnedCommit, identity)
+		assert.Equal(t, pinnedCommit, identity.Identity)
+		assert.Equal(t, "2.12", identity.Version)
+		assert.Equal(t, "42%{?dist}", identity.Release)
+	})
+
+	t.Run("pinned commit fails on clone failure", func(t *testing.T) {
+		comp := newMockCompWithConfig(ctrl, testPackageName, &projectconfig.ComponentConfig{
+			Name: testPackageName,
+			Spec: projectconfig.SpecSource{
+				SourceType:     projectconfig.SpecSourceTypeUpstream,
+				UpstreamCommit: "deadbeef12345678",
+			},
+		})
+
+		// The clone is required even for a pinned commit so the upstream spec
+		// can be read for provenance; a clone failure is fatal.
+		mockGitProvider.EXPECT().
+			Clone(gomock.Any(), repoURL, gomock.Any(), gomock.Any()).
+			Return(errors.New("network error"))
+
+		_, resolveErr := provider.ResolveIdentity(t.Context(), comp)
+		require.Error(t, resolveErr)
+		assert.Contains(t, resolveErr.Error(), testPackageName)
 	})
 }
 
@@ -184,11 +217,20 @@ func TestFedoraProvider_ResolveIdentity_Snapshot(t *testing.T) {
 		mockGitProvider.EXPECT().
 			GetCommitHashBeforeDate(gomock.Any(), gomock.Any(), snapshotTime).
 			Return(expectedCommit, nil)
+		// Best-effort EVR fetch. Return a real spec here so we can verify the
+		// populated NEVR fields flow through.
+		mockGitProvider.EXPECT().
+			ShowFile(gomock.Any(), gomock.Any(), expectedCommit, testPackageName+".spec").
+			Return("Name: test-package\nVersion: 2.12\nRelease: 42%{?dist}\n", nil)
 
 		comp := newMockComp(ctrl, testPackageName)
 		identity, resolveErr := provider.ResolveIdentity(t.Context(), comp)
 		require.NoError(t, resolveErr)
-		assert.Equal(t, expectedCommit, identity)
+		assert.Equal(t, expectedCommit, identity.Identity)
+		assert.Equal(t, "test-package", identity.Name)
+		assert.Equal(t, "2.12", identity.Version)
+		assert.Equal(t, "42%{?dist}", identity.Release,
+			"Release is captured raw; %{?dist} is not expanded")
 	})
 
 	t.Run("pinned commit takes priority over snapshot", func(t *testing.T) {
@@ -201,10 +243,18 @@ func TestFedoraProvider_ResolveIdentity_Snapshot(t *testing.T) {
 			},
 		})
 
-		// No Clone/Deepen/GetCommitHashBeforeDate expectations — pinned commit is returned directly.
+		mockGitProvider.EXPECT().
+			Clone(gomock.Any(), repoURL, gomock.Any(), gomock.Any()).
+			Return(nil)
+		mockGitProvider.EXPECT().
+			ShowFile(gomock.Any(), gomock.Any(), pinnedCommit, testPackageName+".spec").
+			Return("Name: test-package\nVersion: 2.12\nRelease: 42%{?dist}\n", nil)
+
 		identity, resolveErr := provider.ResolveIdentity(t.Context(), comp)
 		require.NoError(t, resolveErr)
-		assert.Equal(t, pinnedCommit, identity)
+		assert.Equal(t, pinnedCommit, identity.Identity)
+		assert.Equal(t, "2.12", identity.Version)
+		assert.Equal(t, "42%{?dist}", identity.Release)
 	})
 }
 
@@ -227,7 +277,9 @@ func TestRPMProvider_ResolveIdentity(t *testing.T) {
 		comp := newMockComp(ctrl, "test-pkg")
 		identity, resolveErr := provider.ResolveIdentity(t.Context(), comp)
 		require.NoError(t, resolveErr)
-		assert.Equal(t, "sha256:"+sha256Hex(rpmContent), identity)
+		assert.Equal(t, "sha256:"+sha256Hex(rpmContent), identity.Identity)
+		assert.Empty(t, identity.Name,
+			"RPM provider does not eagerly parse NEVR from the SRPM")
 	})
 
 	t.Run("returns error on RPM download failure", func(t *testing.T) {
@@ -337,10 +389,14 @@ func TestFedoraProvider_ResolveIdentity_IgnoresLockedData(t *testing.T) {
 	mockGitProvider.EXPECT().
 		GetCurrentCommit(gomock.Any(), gomock.Any()).
 		Return(headCommit, nil)
+	// Best-effort EVR fetch — no assertion on the (empty) EVR fields.
+	mockGitProvider.EXPECT().
+		ShowFile(gomock.Any(), gomock.Any(), headCommit, testPackageName+".spec").
+		Return("", errors.New("blob unavailable"))
 
 	identity, resolveErr := provider.ResolveIdentity(t.Context(), comp)
 	require.NoError(t, resolveErr)
-	assert.Equal(t, headCommit, identity,
+	assert.Equal(t, headCommit, identity.Identity,
 		"should resolve from upstream, ignoring locked data")
 }
 
@@ -372,9 +428,17 @@ func TestFedoraProvider_ResolveIdentity_UsesConfigPin(t *testing.T) {
 		},
 	})
 
-	// No clone expected — pinned commit returned directly.
+	mockGitProvider.EXPECT().
+		Clone(gomock.Any(), repoURL, gomock.Any(), gomock.Any()).
+		Return(nil)
+	mockGitProvider.EXPECT().
+		ShowFile(gomock.Any(), gomock.Any(), "config-pinned-commit", testPackageName+".spec").
+		Return("Name: test-package\nVersion: 2.12\nRelease: 42%{?dist}\n", nil)
+
 	identity, resolveErr := provider.ResolveIdentity(t.Context(), comp)
 	require.NoError(t, resolveErr)
-	assert.Equal(t, "config-pinned-commit", identity,
+	assert.Equal(t, "config-pinned-commit", identity.Identity,
 		"config pin should be used for identity calculation")
+	assert.Equal(t, "2.12", identity.Version)
+	assert.Equal(t, "42%{?dist}", identity.Release)
 }

--- a/internal/providers/sourceproviders/rpmcontentsprovider.go
+++ b/internal/providers/sourceproviders/rpmcontentsprovider.go
@@ -80,17 +80,21 @@ func (r *RPMContentsProviderImpl) GetComponent(
 // ResolveIdentity implements [SourceIdentityProvider] by downloading the source RPM
 // and computing its SHA256 hash. This is a heavyweight operation since it requires a full
 // RPM download.
+//
+// The EVR metadata on the returned [SourceIdentity] is left empty because
+// extracting NEVR from the SRPM would require an additional decode step and
+// no consumer currently depends on it for this provider.
 func (r *RPMContentsProviderImpl) ResolveIdentity(
 	ctx context.Context,
 	component components.Component,
-) (identity string, err error) {
+) (result SourceIdentity, err error) {
 	if component.GetName() == "" {
-		return "", errors.New("component name cannot be empty")
+		return SourceIdentity{}, errors.New("component name cannot be empty")
 	}
 
 	rpmReader, err := r.rpmProvider.GetRPM(ctx, component.GetName(), nil)
 	if err != nil {
-		return "", fmt.Errorf("failed to get RPM for identity of component %#q:\n%w",
+		return SourceIdentity{}, fmt.Errorf("failed to get RPM for identity of component %#q:\n%w",
 			component.GetName(), err)
 	}
 
@@ -99,9 +103,11 @@ func (r *RPMContentsProviderImpl) ResolveIdentity(
 	hasher := sha256.New()
 
 	if _, err := io.Copy(hasher, rpmReader); err != nil {
-		return "", fmt.Errorf("failed to hash RPM for component %#q:\n%w",
+		return SourceIdentity{}, fmt.Errorf("failed to hash RPM for component %#q:\n%w",
 			component.GetName(), err)
 	}
 
-	return "sha256:" + hex.EncodeToString(hasher.Sum(nil)), nil
+	return SourceIdentity{
+		Identity: "sha256:" + hex.EncodeToString(hasher.Sum(nil)),
+	}, nil
 }

--- a/internal/providers/sourceproviders/sourcemanager.go
+++ b/internal/providers/sourceproviders/sourcemanager.go
@@ -56,12 +56,38 @@ type FileSourceProvider interface {
 // Consumers should treat the returned string as opaque; it is only meaningful for equality
 // comparison between two runs.
 type SourceIdentityProvider interface {
-	// ResolveIdentity returns a deterministic identity string for the component's source.
+	// ResolveIdentity returns a deterministic identity string for the component's source, plus
+	// any package-level metadata that the provider was able to capture cheaply.
 	// Returns an error if the identity cannot be determined (e.g., network failure for upstream sources).
-	// Upstream components must return the resolved commit hash from the dist-git provider, local components
-	// must return a content hash of the spec directory (must be stable, but exact format and algorithm
-	// are up to the provider).
-	ResolveIdentity(ctx context.Context, component components.Component) (string, error)
+	// Upstream components must return the resolved commit hash in [SourceIdentity.Identity]; local
+	// components must return a content hash of the spec directory.
+	//
+	// EVR fields ([SourceIdentity.Name], .Epoch, .Version, .Release) are best-effort:
+	// providers should populate them when the upstream metadata is available without incurring
+	// significant additional cost, but a provider may return empty strings for these fields
+	// when parsing fails or the source type does not carry an rpm spec at this stage
+	// (e.g., a raw SRPM download).
+	ResolveIdentity(ctx context.Context, component components.Component) (SourceIdentity, error)
+}
+
+// SourceIdentity is the return value of [SourceIdentityProvider.ResolveIdentity].
+// It bundles the opaque source identity string with package-level metadata parsed
+// from the upstream spec at the resolved point. The metadata fields are captured
+// so that downstream tooling (in particular the component lock file) can propagate
+// upstream provenance without re-parsing spec files at build time.
+type SourceIdentity struct {
+	// Identity is the deterministic identity string for the component's source.
+	// For upstream dist-git components this is the resolved commit hash; for
+	// local components it is a content hash of the spec directory; for SRPM-based
+	// components it is a hash of the downloaded RPM. Always populated on success.
+	Identity string
+
+	// SpecEVR carries the Name/Epoch/Version/Release tags captured from the
+	// upstream (or local) spec at the resolved point. Its fields are promoted,
+	// so callers can read them as SourceIdentity.Name, .Version, etc. All
+	// fields are best-effort and may be empty when the provider could not or
+	// did not parse a spec (e.g., the SRPM provider does not eagerly extract them).
+	SpecEVR
 }
 
 // FetchComponentOptions holds optional parameters for component fetching operations.
@@ -138,10 +164,14 @@ type SourceManager interface {
 		opts ...FetchComponentOption,
 	) error
 
-	// ResolveSourceIdentity returns a deterministic identity string for the component's source.
-	// For local components, this is a content hash of the spec directory.
-	// For upstream components, this is the resolved commit hash from the dist-git provider.
-	ResolveSourceIdentity(ctx context.Context, component components.Component) (string, error)
+	// ResolveSourceIdentity returns a deterministic identity string for the component's source
+	// plus any package-level metadata (Name, Epoch, Version, Release) that a provider could
+	// cheaply capture. For local components the identity is a content hash of the spec directory;
+	// for upstream components it is the resolved commit hash from the dist-git provider.
+	//
+	// The EVR fields are best-effort — see [SourceIdentityProvider.ResolveIdentity] — and may be
+	// empty even on success.
+	ResolveSourceIdentity(ctx context.Context, component components.Component) (SourceIdentity, error)
 }
 
 // ResolvedDistro holds the fully resolved distro configuration for a component.
@@ -606,9 +636,9 @@ func (m *sourceManager) FetchComponent(
 
 func (m *sourceManager) ResolveSourceIdentity(
 	ctx context.Context, component components.Component,
-) (string, error) {
+) (SourceIdentity, error) {
 	if component.GetName() == "" {
-		return "", errors.New("component name is empty")
+		return SourceIdentity{}, errors.New("component name is empty")
 	}
 
 	sourceType := component.GetConfig().Spec.SourceType
@@ -617,24 +647,41 @@ func (m *sourceManager) ResolveSourceIdentity(
 	case projectconfig.SpecSourceTypeLocal, projectconfig.SpecSourceTypeUnspecified:
 		specPath := component.GetConfig().Spec.Path
 		if specPath == "" {
-			return "", fmt.Errorf("component %#q has no spec path configured", component.GetName())
+			return SourceIdentity{}, fmt.Errorf("component %#q has no spec path configured", component.GetName())
 		}
 
-		return ResolveLocalSourceIdentity(m.fs, filepath.Dir(specPath))
+		identity, err := ResolveLocalSourceIdentity(m.fs, filepath.Dir(specPath))
+		if err != nil {
+			return SourceIdentity{}, err
+		}
+
+		result := SourceIdentity{Identity: identity}
+
+		// Best-effort NEVR extraction from the local spec. Failures here are
+		// non-fatal: the caller can still use the identity, and downstream macros
+		// simply won't be populated.
+		if evr, evrErr := ParseSpecEVRFromFile(m.fs, specPath); evrErr == nil {
+			result.SpecEVR = evr
+		} else {
+			slog.Debug("Skipping upstream EVR capture for local component",
+				"component", component.GetName(), "error", evrErr)
+		}
+
+		return result, nil
 
 	case projectconfig.SpecSourceTypeUpstream:
 		return m.resolveUpstreamSourceIdentity(ctx, component)
 	}
 
-	return "", fmt.Errorf("no identity provider for source type %#q on component %#q",
+	return SourceIdentity{}, fmt.Errorf("no identity provider for source type %#q on component %#q",
 		sourceType, component.GetName())
 }
 
 func (m *sourceManager) resolveUpstreamSourceIdentity(
 	ctx context.Context, component components.Component,
-) (string, error) {
+) (SourceIdentity, error) {
 	if len(m.upstreamComponentProviders) == 0 {
-		return "", fmt.Errorf("no upstream providers configured for component %#q",
+		return SourceIdentity{}, fmt.Errorf("no upstream providers configured for component %#q",
 			component.GetName())
 	}
 
@@ -649,7 +696,7 @@ func (m *sourceManager) resolveUpstreamSourceIdentity(
 		lastError = err
 	}
 
-	return "", fmt.Errorf("failed to resolve source identity for upstream component %#q:\n%w",
+	return SourceIdentity{}, fmt.Errorf("failed to resolve source identity for upstream component %#q:\n%w",
 		component.GetName(), lastError)
 }
 

--- a/internal/providers/sourceproviders/sourcemanager_test.go
+++ b/internal/providers/sourceproviders/sourcemanager_test.go
@@ -436,7 +436,11 @@ func TestSourceManager_ResolveSourceIdentity_LocalSuccess(t *testing.T) {
 
 	identity, err := sourceManager.ResolveSourceIdentity(t.Context(), component)
 	require.NoError(t, err)
-	assert.Contains(t, identity, "sha256:")
+	assert.Contains(t, identity.Identity, "sha256:")
+	assert.Equal(t, "test", identity.Name,
+		"local provider should populate Name from the on-disk spec")
+	assert.Equal(t, "1.0", identity.Version,
+		"local provider should populate Version from the on-disk spec")
 }
 
 func TestSourceManager_ResolveSourceIdentity_UpstreamNoProviders(t *testing.T) {

--- a/internal/providers/sourceproviders/sourceproviders_test/sourcemanager_mocks.go
+++ b/internal/providers/sourceproviders/sourceproviders_test/sourcemanager_mocks.go
@@ -76,10 +76,10 @@ func (mr *MockSourceManagerMockRecorder) FetchFiles(ctx, component, destDirPath 
 }
 
 // ResolveSourceIdentity mocks base method.
-func (m *MockSourceManager) ResolveSourceIdentity(ctx context.Context, component components.Component) (string, error) {
+func (m *MockSourceManager) ResolveSourceIdentity(ctx context.Context, component components.Component) (sourceproviders.SourceIdentity, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ResolveSourceIdentity", ctx, component)
-	ret0, _ := ret[0].(string)
+	ret0, _ := ret[0].(sourceproviders.SourceIdentity)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }

--- a/internal/providers/sourceproviders/specevr.go
+++ b/internal/providers/sourceproviders/specevr.go
@@ -1,0 +1,95 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+package sourceproviders
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"strings"
+
+	"github.com/microsoft/azure-linux-dev-tools/internal/global/opctx"
+	"github.com/microsoft/azure-linux-dev-tools/internal/rpm/spec"
+	"github.com/microsoft/azure-linux-dev-tools/internal/utils/defers"
+)
+
+// SpecEVR bundles the Name/Epoch/Version/Release tag values extracted from
+// the base package of an RPM spec file.
+//
+// The values are captured verbatim from the spec's tag lines; macros such as
+// %{?dist} are NOT expanded. Callers that need a fully expanded form are
+// responsible for macro substitution themselves.
+type SpecEVR struct {
+	Name    string
+	Epoch   string
+	Version string
+	Release string
+}
+
+// ParseSpecEVR parses NEVR tags from the base package of the spec content
+// read from reader.
+//
+// The parse is a lightweight tag-line scan (no rpmspec expansion). Returns
+// the captured tag values with macros preserved verbatim. It is not an error
+// for individual tags to be missing; missing tags simply yield empty strings
+// in the corresponding [SpecEVR] fields.
+func ParseSpecEVR(reader io.Reader) (SpecEVR, error) {
+	if reader == nil {
+		return SpecEVR{}, errors.New("reader cannot be nil")
+	}
+
+	parsed, err := spec.OpenSpec(reader)
+	if err != nil {
+		return SpecEVR{}, fmt.Errorf("parsing spec:\n%w", err)
+	}
+
+	var result SpecEVR
+
+	// VisitTagsPackage("") iterates tags in the base (unnamed) package. That
+	// is where Name/Epoch/Version/Release live for a well-formed spec.
+	visitErr := parsed.VisitTagsPackage("", func(tagLine *spec.TagLine, _ *spec.Context) error {
+		switch strings.ToLower(tagLine.Tag) {
+		case "name":
+			if result.Name == "" {
+				result.Name = strings.TrimSpace(tagLine.Value)
+			}
+		case "epoch":
+			if result.Epoch == "" {
+				result.Epoch = strings.TrimSpace(tagLine.Value)
+			}
+		case "version":
+			if result.Version == "" {
+				result.Version = strings.TrimSpace(tagLine.Value)
+			}
+		case "release":
+			if result.Release == "" {
+				result.Release = strings.TrimSpace(tagLine.Value)
+			}
+		}
+
+		return nil
+	})
+	if visitErr != nil {
+		return SpecEVR{}, fmt.Errorf("scanning spec tags:\n%w", visitErr)
+	}
+
+	return result, nil
+}
+
+// ParseSpecEVRFromFile is a convenience wrapper around [ParseSpecEVR] that
+// opens the given spec file from filesystem.
+func ParseSpecEVRFromFile(filesystem opctx.FS, path string) (result SpecEVR, err error) {
+	if path == "" {
+		return SpecEVR{}, errors.New("spec path cannot be empty")
+	}
+
+	file, openErr := filesystem.Open(path)
+	if openErr != nil {
+		return SpecEVR{}, fmt.Errorf("opening spec %#q:\n%w", path, openErr)
+	}
+
+	defer defers.HandleDeferError(file.Close, &err)
+
+	return ParseSpecEVR(file)
+}

--- a/internal/providers/sourceproviders/specevr_test.go
+++ b/internal/providers/sourceproviders/specevr_test.go
@@ -1,0 +1,98 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+package sourceproviders_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/microsoft/azure-linux-dev-tools/internal/providers/sourceproviders"
+	"github.com/microsoft/azure-linux-dev-tools/internal/utils/fileperms"
+	"github.com/microsoft/azure-linux-dev-tools/internal/utils/fileutils"
+	"github.com/spf13/afero"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseSpecEVR_BaseTags(t *testing.T) {
+	content := `Name: grub2
+Epoch: 1
+Version: 2.12
+Release: 42%{?dist}
+Summary: Bootloader
+
+%description
+Bootloader.
+`
+
+	evr, err := sourceproviders.ParseSpecEVR(strings.NewReader(content))
+	require.NoError(t, err)
+	assert.Equal(t, "grub2", evr.Name)
+	assert.Equal(t, "1", evr.Epoch)
+	assert.Equal(t, "2.12", evr.Version)
+	assert.Equal(t, "42%{?dist}", evr.Release,
+		"Release must be captured raw; %{?dist} preserved")
+}
+
+func TestParseSpecEVR_MissingEpochYieldsEmpty(t *testing.T) {
+	content := `Name: curl
+Version: 8.7.0
+Release: 3%{?dist}
+
+%description
+curl.
+`
+
+	evr, err := sourceproviders.ParseSpecEVR(strings.NewReader(content))
+	require.NoError(t, err)
+	assert.Equal(t, "curl", evr.Name)
+	assert.Empty(t, evr.Epoch,
+		"missing Epoch: tag must produce empty string, not an error")
+	assert.Equal(t, "8.7.0", evr.Version)
+}
+
+// TestParseSpecEVR_SubpackageTagsIgnored asserts we only pick up tags from the
+// base (unnamed) package, not from any %package subsection. This keeps the
+// captured values aligned with the top-level NEVR that would appear in the
+// SRPM filename.
+func TestParseSpecEVR_SubpackageTagsIgnored(t *testing.T) {
+	content := `Name: base
+Version: 1.0
+Release: 1
+
+%package devel
+Summary: Devel bits
+Version: 9.9.9
+
+%description
+base.
+
+%description devel
+devel.
+`
+
+	evr, err := sourceproviders.ParseSpecEVR(strings.NewReader(content))
+	require.NoError(t, err)
+	assert.Equal(t, "base", evr.Name)
+	assert.Equal(t, "1.0", evr.Version,
+		"only tags in the base package section should be captured")
+}
+
+func TestParseSpecEVRFromFile_OpensAndParses(t *testing.T) {
+	filesystem := afero.NewMemMapFs()
+
+	require.NoError(t, fileutils.WriteFile(filesystem, "/spec/foo.spec",
+		[]byte("Name: foo\nVersion: 1.2.3\nRelease: 4\n"), fileperms.PublicFile))
+
+	evr, err := sourceproviders.ParseSpecEVRFromFile(filesystem, "/spec/foo.spec")
+	require.NoError(t, err)
+	assert.Equal(t, "foo", evr.Name)
+	assert.Equal(t, "1.2.3", evr.Version)
+	assert.Equal(t, "4", evr.Release)
+}
+
+func TestParseSpecEVRFromFile_MissingFile(t *testing.T) {
+	_, err := sourceproviders.ParseSpecEVRFromFile(afero.NewMemMapFs(), "/nope.spec")
+	require.Error(t, err)
+}

--- a/internal/utils/git/git.go
+++ b/internal/utils/git/git.go
@@ -27,6 +27,11 @@ type GitProvider interface {
 	GetCommitHashBeforeDate(ctx context.Context, repoDir string, dateTime time.Time) (string, error)
 	// GetCurrentCommit returns the current commit hash of the repository at the given directory, regardless of the date.
 	GetCurrentCommit(ctx context.Context, repoDir string) (string, error)
+	// ShowFile returns the contents of the file at path in the tree of commit.
+	// This is the equivalent of 'git -C repoDir show commit:path'. Works even on
+	// blobless clones (--filter=blob:none): the requested blob will be fetched
+	// on demand.
+	ShowFile(ctx context.Context, repoDir, commit, path string) (string, error)
 }
 
 type GitProviderImpl struct {
@@ -187,6 +192,43 @@ func (g *GitProviderImpl) GetCommitHashBeforeDate(
 func (g *GitProviderImpl) GetCurrentCommit(ctx context.Context, repoDir string) (string, error) {
 	// Pass zero time to get the current commit
 	return g.GetCommitHashBeforeDate(ctx, repoDir, time.Time{})
+}
+
+// ShowFile returns the contents of the file at path in the tree of commit.
+// This is the equivalent of 'git -C repoDir show commit:path'. On a blobless
+// clone the blob will be fetched on demand.
+func (g *GitProviderImpl) ShowFile(
+	ctx context.Context, repoDir, commit, path string,
+) (string, error) {
+	if repoDir == "" {
+		return "", errors.New("repository directory cannot be empty")
+	}
+
+	if commit == "" {
+		return "", errors.New("commit cannot be empty")
+	}
+
+	if path == "" {
+		return "", errors.New("path cannot be empty")
+	}
+
+	var stderr bytes.Buffer
+
+	cmd := exec.CommandContext(ctx, "git", "-C", repoDir, "show", commit+":"+path)
+	cmd.Stderr = &stderr
+
+	wrappedCmd, err := g.cmdFactory.Command(cmd)
+	if err != nil {
+		return "", fmt.Errorf("failed to create git command:\n%w", err)
+	}
+
+	output, err := wrappedCmd.RunAndGetOutput(ctx)
+	if err != nil {
+		return "", fmt.Errorf("failed to read %#q at %#q in repo %#q:\n%s\n%w",
+			path, commit, repoDir, stderr.String(), err)
+	}
+
+	return output, nil
 }
 
 // resolveCloneOptions collects all [GitOptions] into a [cloneOptions] struct.

--- a/internal/utils/git/git_test.go
+++ b/internal/utils/git/git_test.go
@@ -232,6 +232,35 @@ func TestCloneWithMetadataOnly(t *testing.T) {
 	assert.DirExists(t, filepath.Join(destDir, testGitDir))
 	// --no-checkout means the working tree file should NOT be present.
 	assert.NoFileExists(t, filepath.Join(destDir, testRepoReadmeFile))
+
+	// ShowFile must still be able to read the blob on demand from the
+	// blobless clone. Use HEAD as a stable reference across upstream
+	// branch state changes.
+	contents, showErr := provider.ShowFile(t.Context(), destDir, "HEAD", testRepoReadmeFile)
+	require.NoError(t, showErr)
+	assert.NotEmpty(t, contents)
+}
+
+func TestShowFileValidation(t *testing.T) {
+	ctrl := gomock.NewController(t)
+
+	provider, err := git.NewGitProviderImpl(
+		opctx_test.NewMockEventListener(ctrl),
+		opctx_test.NewMockCmdFactory(ctrl),
+	)
+	require.NoError(t, err)
+
+	_, err = provider.ShowFile(context.Background(), "", "HEAD", "README")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "repository directory cannot be empty")
+
+	_, err = provider.ShowFile(context.Background(), "/repo", "", "README")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "commit cannot be empty")
+
+	_, err = provider.ShowFile(context.Background(), "/repo", "HEAD", "")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "path cannot be empty")
 }
 
 func TestGetCommitHashBeforeDate_FirstParentOnly(t *testing.T) {

--- a/internal/utils/git/git_test/git_mocks.go
+++ b/internal/utils/git/git_test/git_mocks.go
@@ -108,3 +108,18 @@ func (mr *MockGitProviderMockRecorder) GetCurrentCommit(ctx, repoDir any) *gomoc
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetCurrentCommit", reflect.TypeOf((*MockGitProvider)(nil).GetCurrentCommit), ctx, repoDir)
 }
+
+// ShowFile mocks base method.
+func (m *MockGitProvider) ShowFile(ctx context.Context, repoDir, commit, path string) (string, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ShowFile", ctx, repoDir, commit, path)
+	ret0, _ := ret[0].(string)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ShowFile indicates an expected call of ShowFile.
+func (mr *MockGitProviderMockRecorder) ShowFile(ctx, repoDir, commit, path any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ShowFile", reflect.TypeOf((*MockGitProvider)(nil).ShowFile), ctx, repoDir, commit, path)
+}


### PR DESCRIPTION
## Summary

First of a two-PR stack that lets downstream specs reference **upstream Fedora provenance** (Name/Epoch/Version/Release) instead of hardcoding it or shelling out to `rpmspec`. This PR is the **capture + persist** half; a follow-up exposes the values as `%azl_upstream_*` build macros.

## What this PR does

- **`git ShowFile`** — reads a file's contents at a commit (`git -C <dir> show <commit>:<path>`), working on blobless clones by fetching the blob on demand.
- **`specevr.go`** — best-effort parser for a spec's `Name`/`Epoch`/`Version`/`Release` tags.
- **`SourceIdentity` contract** — `ResolveIdentity` / `ResolveSourceIdentity` now return a `SourceIdentity` (commit identity + captured NEVR) instead of a bare commit string. Callers adapt in this PR since it's a compile-level signature change.
- **Fedora provider** — after resolving the commit, makes a best-effort read of the upstream spec and captures its NEVR. A clone is always performed (needed to read the spec); a **clone failure is fatal**, but a spec read/parse failure is non-fatal (identity still returned).
- **Lock schema** — additive `omitempty` `upstream-name/epoch/version/release` fields on `ComponentLock` / `ComponentLockData`. No schema-version bump.
- **`update` pipeline** — persists captured NEVR into the component lock, with **backfill** for pre-existing locks that predate these fields (they take the resolver path once so provenance gets populated).

## Not in this PR

The persisted provenance is **not yet consumed** — this is plumbing-first. The follow-up PR (`liunan/EVR_macros`, stacked on this branch) emits the `%azl_upstream_*` RPM macros and ships the user-facing docs.

## Testing

- `mage unit` passes with this branch checked out standalone (verified in isolation from the follow-up).
- New tests: `specevr_test.go`, git `ShowFile` validation + blob-on-demand, Fedora/RPM identity tests updated for `SourceIdentity`, pinned-commit EVR capture + clone-failure paths, lock roundtrip, and update backfill/reuse classification.
