### PR TITLE
feat(sources): add opt-in %fedora_upstream_* provenance macros (replaces #285)

### DIFF
--- a/docs/user/reference/config/components.md
+++ b/docs/user/reference/config/components.md
@@ -159,6 +159,7 @@ The `[components.<name>.build]` section controls build-time options for a compon
 | Without options | `without` | string array | No | Build conditionals to disable (`--without <option>` passed to rpmbuild) |
 | Macro definitions | `defines` | map of string to string | No | RPM macro definitions (`--define '<name> <value>'` passed to rpmbuild) |
 | Undefined macros | `undefines` | string array | No | RPM macro names to undefine (`--undefine '<name>'` passed to rpmbuild) |
+| Emit upstream provenance | `emit-upstream-provenance` | boolean | No | Inject `%fedora_upstream_version`/`%fedora_upstream_release` macros for Fedora upstream components (defaults to `false`) |
 | Check config | `check` | [CheckConfig](#check-configuration) | No | Configuration for the `%check` section of the spec |
 | Failure config | `failure` | [FailureConfig](#failure-configuration) | No | Configuration and policy regarding build failures |
 | Build hints | `hints` | [BuildHints](#build-hints) | No | Non-essential hints for how or when to build the component |
@@ -196,6 +197,43 @@ The `undefines` field removes macros that would otherwise be defined:
 [components.mypackage.build]
 undefines = ["fedora"]
 ```
+
+### Upstream Provenance Macros
+
+For components sourced from a Fedora upstream (`spec.type = "upstream"` with a Fedora `upstream-distro`), azldev can inject two macros into the component's build so the spec can record where it was derived from (useful for SBAT and similar provenance metadata). This is **opt-in** — enable it with `emit-upstream-provenance`:
+
+```toml
+[components.grub2.build]
+emit-upstream-provenance = true
+```
+
+| Macro | Description |
+|-------|-------------|
+| `%fedora_upstream_version` | The `Version` tag from the pristine upstream Fedora spec |
+| `%fedora_upstream_release` | The `Release` tag from the pristine upstream Fedora spec, with `%{?dist}` expanded to the Fedora dist tag (e.g. `.fc43`) |
+
+The values are read from the upstream spec **before** any azldev overlays are applied, so they reflect the true upstream Name-Version-Release, not the Azure Linux–modified spec. The macros are derived fresh at render/build time from the pinned upstream commit and emitted into the component's generated macros file (loaded via `%{load:...}`).
+
+For specs whose `Release` uses rpmautospec (`Release: %autorelease`), the pristine Fedora release number is computed by running `rpmautospec calculate-release` in the project distro's mock chroot against the upstream dist-git checkout (whose history is Fedora's, not azldev's synthetic overlay history). This keeps `rpmautospec` out of azldev's host dependencies. If the project distro has no mock config, or mock resolution fails, `%fedora_upstream_release` is skipped (with a warning) rather than emitting the literal `%autorelease`.
+
+Example: for a component pinned to Fedora 43's `grub2-2.12-5.fc43`, the spec can reference:
+
+```spec
+%sbat_generate_metadata ... derived from grub2 %{?fedora_upstream_version}-%{?fedora_upstream_release}
+```
+
+which expands to `grub2 2.12-5.fc43`. The conditional macro form (`%{?name}`) is recommended because provenance emission is best-effort: `%fedora_upstream_release` is skipped when the upstream spec can't be parsed or when mock cannot resolve `%autorelease`, and the conditional form degrades gracefully (expanding to empty) instead of referencing an undefined macro.
+
+Notes:
+
+- The flag has no effect on local or SRPM components (they have no upstream provenance) or on non-Fedora upstreams; for those it is silently ignored.
+- If a component defines a macro of the same name via `build.defines`, the user-defined value wins — the injected value does not overwrite it.
+- **How tag values are resolved:** `Version` and `Release` are read as plain text from the pristine upstream spec. `%{?dist}` is substituted with the Fedora dist tag, and `%autorelease` is resolved to a concrete number via `rpmautospec` (see above). Any *other* in-spec macros — e.g. `Version: %{majorver}.%{minorver}` — are emitted into the macros file unexpanded. Because that file is loaded back into the same spec via `%{load:...}`, RPM expands them lazily at build time using the spec's own macro definitions, so the consuming spec still sees the correct fully-expanded value.
+
+Limitations:
+
+- When `Version`/`Release` is built from other in-spec macros, those macros are resolved lazily at build time against the **overlaid** spec, not the pristine upstream one. So if an overlay redefines a macro that the upstream `Version`/`Release` depends on (e.g. `%majorver`), the provenance value reflects the overlaid definition. This is rare in practice — overlays rarely change version macros.
+- Listing `fedora_upstream_version` or `fedora_upstream_release` in `build.undefines` does **not** suppress the injected macros — they are layered on after `undefines` is applied. To disable them, set `emit-upstream-provenance = false` (or omit it) instead.
 
 ### Check Configuration
 

--- a/internal/app/azldev/cmds/component/build.go
+++ b/internal/app/azldev/cmds/component/build.go
@@ -195,10 +195,13 @@ func BuildComponents(
 		return nil, fmt.Errorf("failed to create work dir factory:\n%w", err)
 	}
 
+	mockProcessor := createBuildMockProcessor(env)
+	defer destroyMockProcessor(env, mockProcessor)
+
 	results := make([]ComponentBuildResults, 0, components.Len())
 
 	for _, component := range components.Components() {
-		componentResults, buildErr := BuildComponent(env, component, workDirFactory, options)
+		componentResults, buildErr := buildComponent(env, component, workDirFactory, mockProcessor, options)
 		if buildErr != nil {
 			buildErr = fmt.Errorf("failed to build %q:\n%w", component.GetName(), buildErr)
 		}
@@ -218,6 +221,19 @@ func BuildComponent(
 	env *azldev.Env,
 	component components.Component,
 	workDirFactory *workdir.Factory,
+	options *ComponentBuildOptions,
+) (ComponentBuildResults, error) {
+	mockProcessor := createBuildMockProcessor(env)
+	defer destroyMockProcessor(env, mockProcessor)
+
+	return buildComponent(env, component, workDirFactory, mockProcessor, options)
+}
+
+func buildComponent(
+	env *azldev.Env,
+	component components.Component,
+	workDirFactory *workdir.Factory,
+	mockProcessor *sources.MockProcessor,
 	options *ComponentBuildOptions,
 ) (results ComponentBuildResults, err error) {
 	// Resolve the effective distro for this component before creating the source manager.
@@ -258,6 +274,11 @@ func BuildComponent(
 			sources.WithDirtyDetection(),
 		)
 	}
+
+	preparerOpts = append(preparerOpts,
+		sources.WithUpstreamProvenance(sources.FedoraDistTag(distro.Ref.Name, distro.Version.ReleaseVer)))
+
+	preparerOpts = append(preparerOpts, sources.WithMockProcessor(mockProcessor))
 
 	sourcePreparer, err := sources.NewPreparer(sourceManager, env.FS(), env, env, preparerOpts...)
 	if err != nil {

--- a/internal/app/azldev/cmds/component/diffsources.go
+++ b/internal/app/azldev/cmds/component/diffsources.go
@@ -97,7 +97,8 @@ func DiffComponentSources(env *azldev.Env, options *DiffSourcesOptions) (interfa
 		return nil, fmt.Errorf("failed to create source manager:\n%w", err)
 	}
 
-	preparer, err := sources.NewPreparer(sourceManager, env.FS(), env, env)
+	preparer, err := sources.NewPreparer(sourceManager, env.FS(), env, env,
+		sources.WithUpstreamProvenance(sources.FedoraDistTag(distro.Ref.Name, distro.Version.ReleaseVer)))
 	if err != nil {
 		return nil, fmt.Errorf("failed to create source preparer:\n%w", err)
 	}

--- a/internal/app/azldev/cmds/component/history_customizations.go
+++ b/internal/app/azldev/cmds/component/history_customizations.go
@@ -116,6 +116,13 @@ func appendBuildItems(
 		items = append(items, CustomizationItem{Kind: "build.undefines", Value: macro})
 	}
 
+	if build.EmitUpstreamProvenance {
+		items = append(items, CustomizationItem{
+			Kind:  "build.emit-upstream-provenance",
+			Value: strconv.FormatBool(true),
+		})
+	}
+
 	if build.Check.Skip {
 		items = append(items, CustomizationItem{
 			Kind:        "build.check.skip",

--- a/internal/app/azldev/cmds/component/history_internal_test.go
+++ b/internal/app/azldev/cmds/component/history_internal_test.go
@@ -104,11 +104,12 @@ func TestCustomizationCollectorsCoverEveryFingerprintableField(t *testing.T) {
 		"ComponentConfig.Packages":    "appendPackageItems (opaque unit per package override)",
 
 		// ComponentBuildConfig.
-		"ComponentBuildConfig.With":      "build.with",
-		"ComponentBuildConfig.Without":   "build.without",
-		"ComponentBuildConfig.Defines":   "build.defines",
-		"ComponentBuildConfig.Undefines": "build.undefines",
-		"ComponentBuildConfig.Check":     "delegates to CheckConfig walk",
+		"ComponentBuildConfig.With":                   "build.with",
+		"ComponentBuildConfig.Without":                "build.without",
+		"ComponentBuildConfig.Defines":                "build.defines",
+		"ComponentBuildConfig.Undefines":              "build.undefines",
+		"ComponentBuildConfig.EmitUpstreamProvenance": "build.emit-upstream-provenance",
+		"ComponentBuildConfig.Check":                  "delegates to CheckConfig walk",
 
 		// CheckConfig.
 		"CheckConfig.Skip": "build.check.skip",
@@ -197,11 +198,12 @@ func TestCollectCustomizationsEmitsEveryKind(t *testing.T) {
 			{Type: projectconfig.ComponentOverlayAddSpecTag, Tag: "Release", Value: "1"},
 		},
 		Build: projectconfig.ComponentBuildConfig{
-			With:      []string{"feature"},
-			Without:   []string{"docs"},
-			Defines:   map[string]string{"macro": "value"},
-			Undefines: []string{"othermacro"},
-			Check:     projectconfig.CheckConfig{Skip: true, SkipReason: "flaky"},
+			With:                   []string{"feature"},
+			Without:                []string{"docs"},
+			Defines:                map[string]string{"macro": "value"},
+			Undefines:              []string{"othermacro"},
+			Check:                  projectconfig.CheckConfig{Skip: true, SkipReason: "flaky"},
+			EmitUpstreamProvenance: true,
 		},
 		Spec: projectconfig.SpecSource{
 			SourceType:     projectconfig.SpecSourceTypeUpstream,
@@ -228,6 +230,7 @@ func TestCollectCustomizationsEmitsEveryKind(t *testing.T) {
 		"build.defines",
 		"build.undefines",
 		"build.check.skip",
+		"build.emit-upstream-provenance",
 		"spec.source-type",
 		"spec.upstream-commit",
 		"spec.upstream-name",

--- a/internal/app/azldev/cmds/component/mockprocessor.go
+++ b/internal/app/azldev/cmds/component/mockprocessor.go
@@ -1,0 +1,86 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+package component
+
+import (
+	"context"
+	"log/slog"
+	"path/filepath"
+	"time"
+
+	"github.com/microsoft/azure-linux-dev-tools/internal/app/azldev"
+	"github.com/microsoft/azure-linux-dev-tools/internal/app/azldev/core/sources"
+)
+
+// buildProvenanceMockSubdir is the work-dir subdirectory under which the build
+// command isolates its %autorelease mock root, keeping it separate from the
+// per-component build chroot that shares the same mock config.
+const buildProvenanceMockSubdir = "azldev-provenance-mock"
+
+// mockProcessorCleanupTimeout bounds how long boundary cleanup may spend
+// scrubbing the mock chroot, so a hung scrub can't block command shutdown.
+const mockProcessorCleanupTimeout = 5 * time.Minute
+
+// createMockProcessor creates a lazily initialized [sources.MockProcessor]
+// using the project/build distro's mock config. Source providers may use a
+// different per-component upstream distro, which must not select the build
+// chroot. Returns nil when the project mock config is unavailable.
+func createMockProcessor(env *azldev.Env) *sources.MockProcessor {
+	return newMockProcessor(env, "")
+}
+
+// createBuildMockProcessor creates a [sources.MockProcessor] for the build
+// command. Unlike render, build creates a per-component build chroot from the
+// same project mock config, and scrubs it after each component. Isolating the
+// provenance root under the work dir keeps that scrub from destroying the
+// shared %autorelease chroot mid-build. Returns nil when the project mock
+// config is unavailable.
+func createBuildMockProcessor(env *azldev.Env) *sources.MockProcessor {
+	var isolatedBaseDir string
+	if workDir := env.WorkDir(); workDir != "" {
+		isolatedBaseDir = filepath.Join(workDir, buildProvenanceMockSubdir)
+	}
+
+	return newMockProcessor(env, isolatedBaseDir)
+}
+
+// newMockProcessor resolves the project/build distro mock config and builds a
+// [sources.MockProcessor]. When isolatedBaseDir is non-empty, the processor's
+// mock root lives under it instead of mock's shared default location. Returns
+// nil when the project mock config is unavailable.
+func newMockProcessor(env *azldev.Env, isolatedBaseDir string) *sources.MockProcessor {
+	_, distroVerDef, err := env.Distro()
+	if err != nil {
+		slog.Info("Mock processor unavailable; could not resolve project distro", "error", err)
+
+		return nil
+	}
+
+	if distroVerDef.MockConfigPath == "" {
+		slog.Info("Mock processor unavailable; no project mock config path configured")
+
+		return nil
+	}
+
+	slog.Info("Mock processor available",
+		"mockConfig", distroVerDef.MockConfigPath, "isolatedBaseDir", isolatedBaseDir)
+
+	return sources.NewMockProcessor(env, distroVerDef.MockConfigPath,
+		sources.WithIsolatedMockBaseDir(isolatedBaseDir))
+}
+
+// destroyMockProcessor scrubs the mock chroot at a command boundary. It detaches
+// from the command context so that cancellation (e.g. Ctrl-C) still cleans up
+// the chroot, while bounding the scrub with a timeout so a hung cleanup can't
+// block shutdown. A nil processor is a no-op.
+func destroyMockProcessor(env *azldev.Env, processor *sources.MockProcessor) {
+	if processor == nil {
+		return
+	}
+
+	ctx, cancel := context.WithTimeout(context.WithoutCancel(env), mockProcessorCleanupTimeout)
+	defer cancel()
+
+	processor.Destroy(ctx)
+}

--- a/internal/app/azldev/cmds/component/mockprocessor_internal_test.go
+++ b/internal/app/azldev/cmds/component/mockprocessor_internal_test.go
@@ -1,0 +1,63 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+package component
+
+import (
+	"testing"
+
+	"github.com/microsoft/azure-linux-dev-tools/internal/app/azldev/core/testutils"
+	"github.com/microsoft/azure-linux-dev-tools/internal/projectconfig"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCreateMockProcessor_UsesProjectDistroMockConfig(t *testing.T) {
+	testEnv := testutils.NewTestEnv(t)
+
+	processor := createMockProcessor(testEnv.Env)
+
+	require.NotNil(t, processor,
+		"the project distro's mock config should make a processor available independently of any upstream distro")
+	destroyMockProcessor(testEnv.Env, processor)
+}
+
+func TestCreateMockProcessor_ProjectDistroWithoutMockConfig(t *testing.T) {
+	testEnv := testutils.NewTestEnv(t)
+	clearProjectMockConfig(testEnv.Env.Config())
+
+	assert.Nil(t, createMockProcessor(testEnv.Env))
+}
+
+func TestCreateBuildMockProcessor_ReturnsProcessor(t *testing.T) {
+	testEnv := testutils.NewTestEnv(t)
+
+	processor := createBuildMockProcessor(testEnv.Env)
+
+	require.NotNil(t, processor,
+		"the build command isolates the provenance root but must still resolve it from the project mock config")
+	destroyMockProcessor(testEnv.Env, processor)
+}
+
+func TestCreateBuildMockProcessor_ProjectDistroWithoutMockConfig(t *testing.T) {
+	testEnv := testutils.NewTestEnv(t)
+	clearProjectMockConfig(testEnv.Env.Config())
+
+	assert.Nil(t, createBuildMockProcessor(testEnv.Env))
+}
+
+func TestDestroyMockProcessor_NilIsNoOp(t *testing.T) {
+	testEnv := testutils.NewTestEnv(t)
+
+	assert.NotPanics(t, func() { destroyMockProcessor(testEnv.Env, nil) })
+}
+
+// clearProjectMockConfig removes the mock config path from the project's default
+// distro version so the mock processor helpers report it as unavailable.
+func clearProjectMockConfig(config *projectconfig.ProjectConfig) {
+	distro := config.Distros[config.Project.DefaultDistro.Name]
+	version := distro.Versions[config.Project.DefaultDistro.Version]
+	version.MockConfigPath = ""
+	distro.Versions[config.Project.DefaultDistro.Version] = version
+	config.Distros[config.Project.DefaultDistro.Name] = distro
+}

--- a/internal/app/azldev/cmds/component/preparesources.go
+++ b/internal/app/azldev/cmds/component/preparesources.go
@@ -161,6 +161,9 @@ func buildPreparerOptions(
 		)
 	}
 
+	opts = append(opts,
+		sources.WithUpstreamProvenance(sources.FedoraDistTag(distro.Ref.Name, distro.Version.ReleaseVer)))
+
 	if options.AllowNoHashes {
 		opts = append(opts, sources.WithAllowNoHashes())
 	}

--- a/internal/app/azldev/cmds/component/render.go
+++ b/internal/app/azldev/cmds/component/render.go
@@ -179,7 +179,7 @@ func RenderComponents(env *azldev.Env, options *RenderOptions) ([]*RenderResult,
 			"mock config required for rendering; ensure the project has a valid distro with mock config")
 	}
 
-	defer mockProcessor.Destroy(env)
+	defer destroyMockProcessor(env, mockProcessor)
 
 	// Create a shared staging directory. Each component gets a subdirectory
 	// named by component name, enabling a single bind mount for the batch
@@ -204,7 +204,7 @@ func RenderComponents(env *azldev.Env, options *RenderOptions) ([]*RenderResult,
 	results := make([]*RenderResult, len(componentList))
 
 	// ── Phase 1: Parallel source preparation ──
-	prepared := parallelPrepare(env, componentList, stagingDir, options.OutputDir, results)
+	prepared := parallelPrepare(env, mockProcessor, componentList, stagingDir, options.OutputDir, results)
 
 	// ── Phase 2: Batch mock processing ──
 	mockResultMap := batchMockProcess(env, mockProcessor, stagingDir, prepared)
@@ -387,6 +387,7 @@ type prepResult struct {
 // prepared slice for phase 2 / phase 3.
 func parallelPrepare(
 	env *azldev.Env,
+	mockProcessor *sources.MockProcessor,
 	comps []components.Component,
 	stagingDir string,
 	outputDir string,
@@ -408,7 +409,8 @@ func parallelPrepare(
 		func(_ context.Context, comp components.Component) prepResult {
 			// workerEnv (captured) is the effective context for this call chain;
 			// the parmap-supplied ctx is identical and unused here.
-			return prepareOneComponent(workerEnv, comp, stagingDir, outputDir) //nolint:contextcheck // env carries the ctx
+			//nolint:contextcheck // env carries the ctx
+			return prepareOneComponent(workerEnv, mockProcessor, comp, stagingDir, outputDir)
 		},
 	)
 
@@ -451,6 +453,7 @@ func parallelPrepare(
 // (including ctx cancellation mid-flight) surface as [renderStatusError] here.
 func prepareOneComponent(
 	env *azldev.Env,
+	mockProcessor *sources.MockProcessor,
 	comp components.Component,
 	stagingDir string,
 	outputDir string,
@@ -468,7 +471,7 @@ func prepareOneComponent(
 		}}
 	}
 
-	prep, err := prepareComponentSources(env, comp, stagingDir)
+	prep, err := prepareComponentSources(env, mockProcessor, comp, stagingDir)
 	if err != nil {
 		slog.Error("Failed to prepare component sources",
 			"component", componentName, "error", err)
@@ -491,6 +494,7 @@ func prepareOneComponent(
 // into a subdirectory of stagingDir.
 func prepareComponentSources(
 	env *azldev.Env,
+	mockProcessor *sources.MockProcessor,
 	comp components.Component,
 	stagingDir string,
 ) (*preparedComponent, error) {
@@ -527,6 +531,8 @@ func prepareComponentSources(
 		sources.WithGitRepo(env, env.LockReader(), distro.Version.ReleaseVer),
 		sources.WithDirtyDetection(),
 		sources.WithSkipLookaside(),
+		sources.WithUpstreamProvenance(sources.FedoraDistTag(distro.Ref.Name, distro.Version.ReleaseVer)),
+		sources.WithMockProcessor(mockProcessor),
 	}
 
 	preparer, err := sources.NewPreparer(sourceManager, env.FS(), env, env, preparerOpts...)
@@ -1124,28 +1130,6 @@ func writeFailureMarkers(
 
 		writeRenderErrorMarker(fileSystem, result.OutputDir)
 	}
-}
-
-// createMockProcessor creates a [sources.MockProcessor] using the project's
-// mock config. Returns nil if the mock config is not available (e.g., no project
-// config loaded, or no mock config path configured).
-func createMockProcessor(env *azldev.Env) *sources.MockProcessor {
-	_, distroVerDef, err := env.Distro()
-	if err != nil {
-		slog.Info("Mock processor unavailable; could not resolve distro", "error", err)
-
-		return nil
-	}
-
-	if distroVerDef.MockConfigPath == "" {
-		slog.Info("Mock processor unavailable; no mock config path configured")
-
-		return nil
-	}
-
-	slog.Info("Mock processor available", "mockConfig", distroVerDef.MockConfigPath)
-
-	return sources.NewMockProcessor(env, distroVerDef.MockConfigPath)
 }
 
 // validateCleanStaleOptions enforces the constraints around --clean-stale.

--- a/internal/app/azldev/core/sources/mockprocessor.go
+++ b/internal/app/azldev/core/sources/mockprocessor.go
@@ -14,6 +14,7 @@ import (
 	"strings"
 	"sync"
 
+	"github.com/kballard/go-shellquote"
 	"github.com/microsoft/azure-linux-dev-tools/internal/global/opctx"
 	"github.com/microsoft/azure-linux-dev-tools/internal/rpm/mock"
 	"github.com/microsoft/azure-linux-dev-tools/internal/rpm/spectool"
@@ -21,13 +22,18 @@ import (
 	"github.com/microsoft/azure-linux-dev-tools/internal/utils/fileutils"
 )
 
+// chrootProvenanceDir is the in-chroot mount point for the single component's
+// source directory when resolving %autorelease. It is distinct from the batch
+// staging mount so a CalculateRelease call never collides with BatchProcess.
+const chrootProvenanceDir = "/tmp/provenance"
+
 //go:embed render_process.py
 var renderProcessScript []byte
 
 // MockProcessor provides a shared mock chroot for running rpmautospec and
-// spectool during component rendering. The chroot is lazily initialized on
-// first use and supports batch processing of multiple components in a single
-// mock invocation.
+// spectool during component source preparation and rendering. The chroot is
+// lazily initialized on first use and supports batch processing of multiple
+// components in a single mock invocation.
 type MockProcessor struct {
 	mu          sync.Mutex
 	runner      *mock.Runner
@@ -35,12 +41,34 @@ type MockProcessor struct {
 	initErr     error
 }
 
+// MockProcessorOption configures a [MockProcessor] at construction time.
+type MockProcessorOption func(*mock.Runner)
+
+// WithIsolatedMockBaseDir returns a [MockProcessorOption] that places the
+// processor's mock root under baseDir instead of mock's shared default
+// (/var/lib/mock). This gives the processor a self-contained root tree so a
+// concurrently used build chroot (which shares the same mock config) cannot
+// scrub it, and so destroying the processor scrubs only its own tree. A blank
+// baseDir is ignored, preserving the default location.
+func WithIsolatedMockBaseDir(baseDir string) MockProcessorOption {
+	return func(runner *mock.Runner) {
+		if baseDir != "" {
+			runner.WithBaseDir(baseDir)
+		}
+	}
+}
+
 // NewMockProcessor creates a new processor that will lazily initialize
 // a mock chroot using the given config path. The runner is created eagerly
 // but the chroot is only initialized on first use.
-func NewMockProcessor(ctx opctx.Ctx, mockConfigPath string) *MockProcessor {
+func NewMockProcessor(ctx opctx.Ctx, mockConfigPath string, opts ...MockProcessorOption) *MockProcessor {
+	runner := mock.NewRunner(ctx, mockConfigPath)
+	for _, opt := range opts {
+		opt(runner)
+	}
+
 	return &MockProcessor{
-		runner: mock.NewRunner(ctx, mockConfigPath),
+		runner: runner,
 	}
 }
 
@@ -99,7 +127,7 @@ func (p *MockProcessor) initOnce(ctx context.Context) error {
 		return p.initErr
 	}
 
-	slog.Info("Initializing mock chroot for rendering")
+	slog.Info("Initializing mock chroot for source processing")
 
 	p.runner.EnableNetwork()
 
@@ -232,6 +260,54 @@ func (p *MockProcessor) BatchProcess(
 	return parseBatchJSON(string(resultsData), inputs)
 }
 
+// CalculateRelease resolves an rpmautospec %autorelease to a concrete Fedora
+// release number (without the dist tag) by running `rpmautospec
+// calculate-release --complete-release` inside the shared mock chroot. This
+// keeps rpmautospec out of azldev's host dependencies — the chroot already has
+// it installed by initOnce.
+//
+// specHostDir is the host directory holding the pristine spec and its .git
+// history; it is bind-mounted read/write into the chroot. specFilename is the
+// spec's basename within that directory. The raw command output is returned;
+// the caller parses and validates it. The chroot is lazily initialized on first
+// use, shared with [MockProcessor.BatchProcess].
+func (p *MockProcessor) CalculateRelease(ctx context.Context, specHostDir, specFilename string) (string, error) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	if err := p.initOnce(ctx); err != nil {
+		return "", err
+	}
+
+	// Clone so this invocation's bind mount and privilege drop don't mutate the
+	// shared template. WithUnprivileged runs as the mockbuild user, whose UID
+	// matches the host user (mock chrootuid defaults to os.getuid()), so the
+	// bind-mounted .git is owned consistently.
+	runner := p.runner.Clone()
+	runner.WithUnprivileged()
+	runner.AddBindMount(specHostDir, chrootProvenanceDir)
+
+	specInChroot := filepath.Join(chrootProvenanceDir, specFilename)
+
+	// safe.directory guards against any residual host/chroot ownership mismatch
+	// on the bind-mounted .git, mirroring the render batch path. Wrapped in
+	// `sh -c` so the shell operators survive shellquote joining in CmdInChroot.
+	shellCmd := "git config --global --add safe.directory '*' && " +
+		"rpmautospec calculate-release --complete-release " + shellquote.Join(specInChroot)
+
+	cmd, err := runner.CmdInChroot(ctx, []string{"sh", "-c", shellCmd}, false)
+	if err != nil {
+		return "", fmt.Errorf("creating rpmautospec command in mock chroot:\n%w", err)
+	}
+
+	out, err := cmd.RunAndGetOutput(ctx)
+	if err != nil {
+		return "", fmt.Errorf("rpmautospec calculate-release failed in mock chroot:\n%w", err)
+	}
+
+	return out, nil
+}
+
 // componentInputJSON is the JSON-serializable form written to inputs.json.
 type componentInputJSON struct {
 	Name         string `json:"name"`
@@ -305,7 +381,7 @@ func writeInputsManifest(fs opctx.FS, stagingDir string, inputs []ComponentInput
 	return nil
 }
 
-// Destroy cleans up the mock chroot. Should be called when rendering is complete.
+// Destroy cleans up the mock chroot. It should be called when source processing is complete.
 // The processor must not be reused after Destroy — create a new MockProcessor if needed.
 // Attempts cleanup even if initialization partially failed (e.g., InitRoot succeeded
 // but InstallPackages failed), since a partially initialized chroot still needs scrubbing.

--- a/internal/app/azldev/core/sources/mockprocessor_test.go
+++ b/internal/app/azldev/core/sources/mockprocessor_test.go
@@ -5,10 +5,32 @@
 package sources
 
 import (
+	"errors"
+	"os/exec"
+	"strings"
 	"testing"
 
+	"github.com/microsoft/azure-linux-dev-tools/internal/global/testctx"
+	"github.com/microsoft/azure-linux-dev-tools/internal/rpm/mock"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+)
+
+// newMockProcessorTestCtx returns a test context that reports the mock binary as
+// present in the search path so MockProcessor calls reach the stubbed command
+// factory instead of failing the mock precondition check.
+func newMockProcessorTestCtx() *testctx.TestCtx {
+	ctx := testctx.NewCtx()
+	ctx.CmdFactory.RegisterCommandInSearchPath(mock.MockBinary)
+
+	return ctx
+}
+
+// Sentinel errors returned by the stubbed command factory so CalculateRelease
+// error tests can assert the causes are preserved through %w wrapping.
+var (
+	errInitBoom        = errors.New("boom")
+	errRpmautospecExit = errors.New("exit status 1")
 )
 
 func TestParseBatchJSON_Success(t *testing.T) {
@@ -150,4 +172,171 @@ func TestValidateInputs(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestNewMockProcessor_IsolatedBaseDir(t *testing.T) {
+	t.Parallel()
+
+	ctx := testctx.NewCtx()
+
+	processor := NewMockProcessor(ctx, "/mock/config", WithIsolatedMockBaseDir("/work/provenance"))
+	assert.Equal(t, "/work/provenance", processor.runner.BaseDir(),
+		"an isolated base dir must be applied so the provenance root cannot collide with the build chroot")
+}
+
+func TestNewMockProcessor_DefaultBaseDir(t *testing.T) {
+	t.Parallel()
+
+	ctx := testctx.NewCtx()
+
+	// No option, and a blank isolated base dir, both preserve mock's default location.
+	assert.Empty(t, NewMockProcessor(ctx, "/mock/config").runner.BaseDir())
+	assert.Empty(t, NewMockProcessor(ctx, "/mock/config", WithIsolatedMockBaseDir("")).runner.BaseDir())
+}
+
+func TestCalculateRelease_Success(t *testing.T) {
+	t.Parallel()
+
+	ctx := newMockProcessorTestCtx()
+
+	// The rpmautospec chroot command is the only call routed through
+	// RunAndGetOutput; capture its argv so we can assert on how it was built.
+	var chrootArgs []string
+
+	const rawOutput = "Calculated release number: 7\n"
+
+	ctx.CmdFactory.RunAndGetOutputHandler = func(cmd *exec.Cmd) (string, error) {
+		chrootArgs = cmd.Args
+
+		return rawOutput, nil
+	}
+
+	processor := NewMockProcessor(ctx, "/mock/config")
+
+	out, err := processor.CalculateRelease(ctx, "/host/fwupd-efi", "fwupd-efi.spec")
+	require.NoError(t, err)
+
+	// The caller is responsible for parsing; CalculateRelease must return the
+	// command output verbatim (including trailing newline).
+	assert.Equal(t, rawOutput, out)
+
+	joined := strings.Join(chrootArgs, " ")
+	assert.Contains(t, joined, "--chroot", "release must be calculated with mock --chroot")
+	assert.Contains(t, joined, "--unpriv", "the chroot command must drop privileges to the mockbuild user")
+	assert.Contains(t, joined, `bind_mount:dirs=[("/host/fwupd-efi", "/tmp/provenance")]`,
+		"the spec directory must be bind-mounted at the provenance mount point")
+	assert.Contains(t, joined, "rpmautospec calculate-release --complete-release /tmp/provenance/fwupd-efi.spec",
+		"rpmautospec must run against the spec at its in-chroot path")
+	assert.Contains(t, joined, "safe.directory",
+		"git safe.directory must be configured before rpmautospec reads the .git history")
+}
+
+func TestCalculateRelease_InitFailurePropagates(t *testing.T) {
+	t.Parallel()
+
+	ctx := newMockProcessorTestCtx()
+
+	// Fail the chroot initialization (`mock --init`) and confirm the error
+	// surfaces without ever attempting the rpmautospec command.
+	ctx.CmdFactory.RunHandler = func(cmd *exec.Cmd) error {
+		if strings.Contains(strings.Join(cmd.Args, " "), "--init") {
+			return errInitBoom
+		}
+
+		return nil
+	}
+
+	rpmautospecCalled := false
+	ctx.CmdFactory.RunAndGetOutputHandler = func(_ *exec.Cmd) (string, error) {
+		rpmautospecCalled = true
+
+		return "", nil
+	}
+
+	processor := NewMockProcessor(ctx, "/mock/config")
+
+	_, err := processor.CalculateRelease(ctx, "/host/fwupd-efi", "fwupd-efi.spec")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to initialize mock chroot")
+	require.ErrorIs(t, err, errInitBoom, "the underlying init error must be preserved via %w wrapping")
+	assert.False(t, rpmautospecCalled, "rpmautospec must not run when chroot init fails")
+}
+
+func TestCalculateRelease_RpmautospecFailureWrapped(t *testing.T) {
+	t.Parallel()
+
+	ctx := newMockProcessorTestCtx()
+
+	ctx.CmdFactory.RunAndGetOutputHandler = func(_ *exec.Cmd) (string, error) {
+		return "some stderr", errRpmautospecExit
+	}
+
+	processor := NewMockProcessor(ctx, "/mock/config")
+
+	out, err := processor.CalculateRelease(ctx, "/host/fwupd-efi", "fwupd-efi.spec")
+	require.Error(t, err)
+	assert.Empty(t, out, "no release should be returned when rpmautospec fails")
+	assert.Contains(t, err.Error(), "rpmautospec calculate-release failed in mock chroot")
+	require.ErrorIs(t, err, errRpmautospecExit, "the underlying rpmautospec error must be preserved via %w wrapping")
+}
+
+func TestCalculateRelease_InitializesChrootOnce(t *testing.T) {
+	t.Parallel()
+
+	ctx := newMockProcessorTestCtx()
+
+	initCount := 0
+	ctx.CmdFactory.RunHandler = func(cmd *exec.Cmd) error {
+		if strings.Contains(strings.Join(cmd.Args, " "), "--init") {
+			initCount++
+		}
+
+		return nil
+	}
+	ctx.CmdFactory.RunAndGetOutputHandler = func(_ *exec.Cmd) (string, error) {
+		return "Calculated release number: 1\n", nil
+	}
+
+	processor := NewMockProcessor(ctx, "/mock/config")
+
+	// Two resolutions share the same lazily-initialized chroot.
+	_, err := processor.CalculateRelease(ctx, "/host/a", "a.spec")
+	require.NoError(t, err)
+
+	_, err = processor.CalculateRelease(ctx, "/host/b", "b.spec")
+	require.NoError(t, err)
+
+	assert.Equal(t, 1, initCount, "the shared mock chroot must be initialized only once across calls")
+}
+
+func TestCalculateRelease_InitErrorCached(t *testing.T) {
+	t.Parallel()
+
+	ctx := newMockProcessorTestCtx()
+
+	// Fail initialization and count how many times `mock --init` is attempted.
+	// initOnce memoizes the failure, so a second CalculateRelease must return
+	// the cached error without retrying the known-broken chroot.
+	initCount := 0
+	ctx.CmdFactory.RunHandler = func(cmd *exec.Cmd) error {
+		if strings.Contains(strings.Join(cmd.Args, " "), "--init") {
+			initCount++
+
+			return errInitBoom
+		}
+
+		return nil
+	}
+
+	processor := NewMockProcessor(ctx, "/mock/config")
+
+	_, firstErr := processor.CalculateRelease(ctx, "/host/a", "a.spec")
+	require.Error(t, firstErr)
+	require.ErrorIs(t, firstErr, errInitBoom)
+
+	_, secondErr := processor.CalculateRelease(ctx, "/host/b", "b.spec")
+	require.Error(t, secondErr)
+	require.ErrorIs(t, secondErr, errInitBoom)
+
+	assert.Equal(t, 1, initCount, "a failed mock init must be cached and never retried")
 }

--- a/internal/app/azldev/core/sources/sourceprep.go
+++ b/internal/app/azldev/core/sources/sourceprep.go
@@ -111,6 +111,30 @@ func WithSkipLookaside() PreparerOption {
 	}
 }
 
+// WithUpstreamProvenance returns a [PreparerOption] that enables emission of
+// the %fedora_upstream_version and %fedora_upstream_release macros for Fedora
+// upstream components. distTag is the resolved %{?dist} expansion (e.g.
+// ".fc43", as produced by [FedoraDistTag]) used to expand the pristine Release
+// tag. Pass "" (e.g. for non-Fedora upstreams) to disable the macros.
+func WithUpstreamProvenance(distTag string) PreparerOption {
+	return func(p *sourcePreparerImpl) {
+		p.upstreamDistTag = distTag
+	}
+}
+
+// WithMockProcessor returns a [PreparerOption] that supplies the mock chroot
+// used to resolve an rpmautospec %autorelease when emitting
+// %fedora_upstream_release. Without it, upstream components whose Release uses
+// %autorelease get no release macro (best-effort). Running rpmautospec inside
+// mock keeps it out of azldev's host dependencies. A nil processor is ignored.
+func WithMockProcessor(mp *MockProcessor) PreparerOption {
+	return func(p *sourcePreparerImpl) {
+		if mp != nil {
+			p.autoreleaseResolver = mp
+		}
+	}
+}
+
 // WithAllowNoHashes returns a [PreparerOption] that allows source file
 // references to omit their [projectconfig.SourceFileReference.Hash] value.
 // When set, any source file that lacks a hash will have its hash computed
@@ -163,6 +187,18 @@ type sourcePreparerImpl struct {
 	// releaseVer is the per-component resolved distro release version, not the
 	// project default. Set via [WithGitRepo].
 	releaseVer string
+
+	// upstreamDistTag is the resolved %{?dist} expansion (e.g. ".fc43") used to
+	// expand a Fedora upstream component's pristine Release tag when emitting
+	// the %fedora_upstream_* macros. Empty disables provenance macros. Set via
+	// [WithUpstreamProvenance].
+	upstreamDistTag string
+
+	// autoreleaseResolver runs rpmautospec inside a mock chroot to resolve an
+	// %autorelease Release into a concrete Fedora release number for
+	// %fedora_upstream_release. Nil disables autorelease resolution (the release
+	// macro is skipped for such specs). Set via [WithMockProcessor].
+	autoreleaseResolver autoreleaseResolver
 }
 
 // NewPreparer creates a new [SourcePreparer] instance. All positional arguments
@@ -251,7 +287,7 @@ func (p *sourcePreparerImpl) PrepareSources(
 	fingerprintConfig := component.GetConfig()
 
 	if applyOverlays {
-		repackedArchives, err := p.applyOverlaysToSources(component, outputDir)
+		repackedArchives, err := p.applyOverlaysToSources(ctx, component, outputDir)
 		if err != nil {
 			return err
 		}
@@ -292,11 +328,11 @@ func (p *sourcePreparerImpl) validateArchiveOverlayConfig(component components.C
 // (empty in dry-run mode or when no archive overlays ran), so the caller can
 // rehash exactly those entries in the 'sources' file.
 func (p *sourcePreparerImpl) applyOverlaysToSources(
-	component components.Component, outputDir string,
+	ctx context.Context, component components.Component, outputDir string,
 ) ([]string, error) {
 	var macrosFileName string
 
-	macrosFilePath, err := p.writeMacrosFile(component, outputDir)
+	macrosFilePath, err := p.writeMacrosFile(ctx, component, outputDir)
 	if err != nil {
 		return nil, fmt.Errorf("failed to write macros file for component %#q:\n%w",
 			component.GetName(), err)
@@ -664,7 +700,7 @@ func (p *sourcePreparerImpl) DiffSources(
 	// Apply overlays in-place to the copied directory only. The repacked-archive
 	// list is unused here: DiffSources diffs the trees directly and does not
 	// rewrite a 'sources' file.
-	if _, err := p.applyOverlaysToSources(component, overlaidDir); err != nil {
+	if _, err := p.applyOverlaysToSources(ctx, component, overlaidDir); err != nil {
 		return nil, fmt.Errorf("failed to apply overlays for component %#q:\n%w", component.GetName(), err)
 	}
 
@@ -1144,8 +1180,16 @@ func (p *sourcePreparerImpl) resolveSourceHash(
 // This includes with/without flags converted to macro format, and any explicit defines.
 // If the build configuration produces no macros, no file is written and an empty path is
 // returned. Otherwise, the path to the written macros file is returned.
-func (p *sourcePreparerImpl) writeMacrosFile(component components.Component, outputDir string) (string, error) {
-	contents := GenerateMacrosFileContents(component.GetConfig().Build)
+func (p *sourcePreparerImpl) writeMacrosFile(
+	ctx context.Context, component components.Component, outputDir string,
+) (string, error) {
+	macros := buildMacrosMap(component.GetConfig().Build)
+
+	// Layer Fedora upstream provenance macros on top, reading the pristine
+	// upstream spec that is already on disk (before overlays are applied).
+	p.addUpstreamProvenanceMacros(ctx, macros, component, outputDir)
+
+	contents := renderMacrosFile(macros)
 	if contents == "" {
 		return "", nil
 	}
@@ -1185,8 +1229,15 @@ func (p *sourcePreparerImpl) writeMacrosFile(component components.Component, out
 // If no macros remain after processing (empty config, or all macros removed via
 // undefines), an empty string is returned to signal that no macros file is needed.
 func GenerateMacrosFileContents(buildConfig projectconfig.ComponentBuildConfig) string {
-	// Build a unified map of all macros. Later definitions override earlier ones.
-	// Processing order: with flags -> without flags -> explicit defines.
+	return renderMacrosFile(buildMacrosMap(buildConfig))
+}
+
+// buildMacrosMap converts a build configuration's with/without/defines/undefines
+// into a unified macro name->value map. Later definitions override earlier ones;
+// processing order is: with flags -> without flags -> explicit defines ->
+// undefines. Upstream provenance macros are layered on separately by
+// [sourcePreparerImpl.addUpstreamProvenanceMacros].
+func buildMacrosMap(buildConfig projectconfig.ComponentBuildConfig) map[string]string {
 	macros := make(map[string]string)
 
 	// Convert 'with' flags to macros: FLAG -> _with_FLAG = 1
@@ -1210,6 +1261,14 @@ func GenerateMacrosFileContents(buildConfig projectconfig.ComponentBuildConfig) 
 		delete(macros, undef)
 	}
 
+	return macros
+}
+
+// renderMacrosFile serializes a fully-resolved macro map to RPM macros-file
+// format (%name value), sorted alphabetically for deterministic output and
+// prefixed with the standard auto-generated header. Returns "" when the map is
+// empty, signaling that no macros file is needed.
+func renderMacrosFile(macros map[string]string) string {
 	if len(macros) == 0 {
 		return ""
 	}

--- a/internal/app/azldev/core/sources/upstream_provenance.go
+++ b/internal/app/azldev/core/sources/upstream_provenance.go
@@ -1,0 +1,280 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+package sources
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"log/slog"
+	"path/filepath"
+	"strings"
+
+	"github.com/microsoft/azure-linux-dev-tools/internal/app/azldev/core/components"
+	"github.com/microsoft/azure-linux-dev-tools/internal/global/opctx"
+	"github.com/microsoft/azure-linux-dev-tools/internal/projectconfig"
+	"github.com/microsoft/azure-linux-dev-tools/internal/rpm/spec"
+	"github.com/microsoft/azure-linux-dev-tools/internal/utils/fileutils"
+)
+
+// Macro names emitted to carry upstream Fedora provenance into a component's
+// build. Specs may reference these (e.g. for SBAT) via %fedora_upstream_version
+// and %fedora_upstream_release.
+const (
+	fedoraUpstreamVersionMacro = "fedora_upstream_version"
+	fedoraUpstreamReleaseMacro = "fedora_upstream_release"
+)
+
+// distPlaceholder is the conditional RPM %{?dist} token substituted with the
+// resolved Fedora dist tag when expanding a pristine upstream Release value.
+const distPlaceholder = "%{?dist}"
+
+// distPlaceholderPlain is the unconditional %{dist} form. It must be substituted
+// too so a literal upstream Release like "5%{dist}" does not lazily expand
+// against the Azure Linux buildroot's dist tag at build time.
+const distPlaceholderPlain = "%{dist}"
+
+// autoreleaseResolver resolves an rpmautospec %autorelease to a concrete Fedora
+// release number by running rpmautospec in an isolated environment (a mock
+// chroot in production). Abstracted so tests can substitute a fake without a
+// real mock. Implemented by [*MockProcessor].
+type autoreleaseResolver interface {
+	// CalculateRelease returns the raw `rpmautospec calculate-release` output
+	// for the spec named specFilename inside specHostDir (which must hold the
+	// pristine .git history). The caller parses and validates the result.
+	CalculateRelease(ctx context.Context, specHostDir, specFilename string) (string, error)
+}
+
+// FedoraDistTag returns the RPM %{?dist} expansion for a Fedora distro
+// (".fc<releasever>", e.g. ".fc43"), or "" when the distro is not Fedora or the
+// release version is not a plain integer. Fedora dist tags are always ".fc<N>";
+// a non-numeric release version (e.g. "rawhide") has no well-defined dist tag,
+// so provenance is disabled rather than emitting an invalid value like
+// ".fcrawhide". Callers pass the result to [WithUpstreamProvenance].
+func FedoraDistTag(distroName, releaseVer string) string {
+	if !strings.EqualFold(distroName, "fedora") || !isNumericReleaseVer(releaseVer) {
+		return ""
+	}
+
+	return ".fc" + releaseVer
+}
+
+// isNumericReleaseVer reports whether s is a non-empty string of ASCII digits,
+// i.e. a Fedora numbered release like "43".
+func isNumericReleaseVer(s string) bool {
+	if s == "" {
+		return false
+	}
+
+	for _, r := range s {
+		if r < '0' || r > '9' {
+			return false
+		}
+	}
+
+	return true
+}
+
+// addUpstreamProvenanceMacros injects %fedora_upstream_version and
+// %fedora_upstream_release into macros for Fedora upstream components. The
+// values are read from the pristine upstream spec on disk (before overlays are
+// applied). The Release tag's %{?dist} token is expanded to the resolved Fedora
+// dist tag, and an rpmautospec %autorelease is resolved to the pristine Fedora
+// release number (see resolveUpstreamRelease).
+//
+// Best-effort: if the component is not a Fedora upstream, or the spec cannot be
+// located or parsed, no macros are added. User-defined macros take precedence —
+// an existing entry is never overwritten.
+func (p *sourcePreparerImpl) addUpstreamProvenanceMacros(
+	ctx context.Context, macros map[string]string, component components.Component, sourcesDir string,
+) {
+	// Only Fedora upstream components carry upstream provenance. Local and
+	// SRPM components have no upstream spec; their own identity is already
+	// available at build time via %{version}/%{release}.
+	if p.upstreamDistTag == "" {
+		return
+	}
+
+	config := component.GetConfig()
+
+	// Opt-in: the macros are only useful to specs that reference them, so they
+	// are emitted only for components that explicitly request them.
+	if !config.Build.EmitUpstreamProvenance {
+		return
+	}
+
+	if config.Spec.SourceType != projectconfig.SpecSourceTypeUpstream {
+		return
+	}
+
+	specPath, err := findSpecInDir(p.fs, component, sourcesDir)
+	if err != nil {
+		// The user opted in via emit-upstream-provenance, so surface the
+		// failure loudly enough to be visible in normal CI logs; still
+		// non-fatal so the render/build proceeds without the macros.
+		slog.Warn("Skipping upstream provenance macros; spec not found",
+			"component", component.GetName(), "error", err)
+
+		return
+	}
+
+	version, release, err := parseSpecVersionRelease(p.fs, specPath)
+	if err != nil {
+		slog.Warn("Skipping upstream provenance macros; failed to parse spec",
+			"component", component.GetName(), "error", err)
+
+		return
+	}
+
+	if version != "" {
+		setMacroIfAbsent(macros, fedoraUpstreamVersionMacro, version)
+	}
+
+	resolvedRelease := p.resolveUpstreamRelease(ctx, component.GetName(), release, sourcesDir, specPath)
+	if resolvedRelease != "" {
+		setMacroIfAbsent(macros, fedoraUpstreamReleaseMacro, resolvedRelease)
+	}
+}
+
+// resolveUpstreamRelease converts a pristine Release tag value into the value
+// emitted for %fedora_upstream_release.
+//
+//   - A literal or in-spec-macro release has only its %{?dist} token replaced
+//     with the resolved Fedora dist tag; other macros are left for lazy
+//     expansion in the consuming spec.
+//   - An rpmautospec %autorelease is resolved to a concrete number by running
+//     `rpmautospec calculate-release` against the pristine dist-git checkout,
+//     whose HEAD is the pinned upstream commit (this runs before azldev's
+//     synthetic history is layered on, so the count matches Fedora's). The
+//     git-derived number is combined with the resolved Fedora dist tag rather
+//     than trusting the build root's %{?dist} (azldev's mock is Azure Linux, not
+//     Fedora).
+//
+// Returns "" to signal that no release macro should be emitted — either the tag
+// was empty, or it used %autorelease that could not be resolved (emitting the
+// literal %autorelease would expand against the wrong history at build time).
+func (p *sourcePreparerImpl) resolveUpstreamRelease(
+	ctx context.Context, componentName, release, sourcesDir, specPath string,
+) string {
+	if release == "" {
+		return ""
+	}
+
+	if !ReleaseUsesAutorelease(release) {
+		return replaceDistTag(release, p.upstreamDistTag)
+	}
+
+	number := p.calculateAutorelease(ctx, componentName, sourcesDir, specPath)
+	if number == "" {
+		return ""
+	}
+
+	return number + p.upstreamDistTag
+}
+
+// replaceDistTag substitutes both the conditional (%{?dist}) and unconditional
+// (%{dist}) dist macros in a Release value with the resolved Fedora dist tag.
+// The conditional form is replaced first so the %{dist} pass does not match the
+// inner {dist} of a %{?dist} token and leave a stray "%{?" behind.
+func replaceDistTag(release, distTag string) string {
+	release = strings.ReplaceAll(release, distPlaceholder, distTag)
+	release = strings.ReplaceAll(release, distPlaceholderPlain, distTag)
+
+	return release
+}
+
+// calculateAutorelease resolves an rpmautospec %autorelease to the pristine
+// Fedora release number (without the dist tag) by running rpmautospec inside a
+// mock chroot via the configured [autoreleaseResolver]. Best-effort: returns ""
+// with a warning when the dist-git history is unavailable, no resolver is
+// configured, the command fails, or the output is not a usable release number.
+func (p *sourcePreparerImpl) calculateAutorelease(
+	ctx context.Context, componentName, sourcesDir, specPath string,
+) string {
+	// rpmautospec needs the upstream .git history, which is only preserved when
+	// dist-git creation is enabled (e.g. render/build/prepare-sources).
+	if !p.withGitRepo {
+		slog.Debug("Skipping %fedora_upstream_release resolution; dist-git history not available",
+			"component", componentName)
+
+		return ""
+	}
+
+	if p.autoreleaseResolver == nil {
+		slog.Warn("Skipping %fedora_upstream_release; no mock processor available to resolve %autorelease",
+			"component", componentName)
+
+		return ""
+	}
+
+	out, err := p.autoreleaseResolver.CalculateRelease(ctx, sourcesDir, filepath.Base(specPath))
+	if err != nil {
+		slog.Warn("Skipping %fedora_upstream_release; rpmautospec calculate-release failed",
+			"component", componentName, "error", err)
+
+		return ""
+	}
+
+	// rpmautospec prints "Calculated release number: <release>"; the release is
+	// the final whitespace-separated field.
+	number := strings.TrimSpace(out)
+	if fields := strings.Fields(number); len(fields) > 0 {
+		number = fields[len(fields)-1]
+	}
+
+	if number == "" || number[0] < '0' || number[0] > '9' {
+		slog.Warn("Skipping %fedora_upstream_release; rpmautospec did not return a valid release number",
+			"component", componentName, "output", strings.TrimSpace(out))
+
+		return ""
+	}
+
+	return number
+}
+
+// setMacroIfAbsent sets macros[name]=value only when name is not already
+// present, so user-defined macros (e.g. from 'build.defines') win.
+func setMacroIfAbsent(macros map[string]string, name, value string) {
+	if _, exists := macros[name]; !exists {
+		macros[name] = value
+	}
+}
+
+// parseSpecVersionRelease reads the Version and Release tags from the base
+// package of the spec at specPath. Values are captured verbatim (no macro
+// expansion beyond the caller's later %{?dist} substitution). Missing tags
+// yield empty strings; it is not an error for a tag to be absent.
+func parseSpecVersionRelease(fs opctx.FS, specPath string) (version, release string, err error) {
+	data, err := fileutils.ReadFile(fs, specPath)
+	if err != nil {
+		return "", "", fmt.Errorf("failed to read spec %#q:\n%w", specPath, err)
+	}
+
+	parsed, err := spec.OpenSpec(bytes.NewReader(data))
+	if err != nil {
+		return "", "", fmt.Errorf("failed to parse spec %#q:\n%w", specPath, err)
+	}
+
+	// VisitTagsPackage("") iterates tags in the base (unnamed) package, where
+	// Name/Version/Release live for a well-formed spec.
+	visitErr := parsed.VisitTagsPackage("", func(tagLine *spec.TagLine, _ *spec.Context) error {
+		switch strings.ToLower(tagLine.Tag) {
+		case "version":
+			if version == "" {
+				version = strings.TrimSpace(tagLine.Value)
+			}
+		case "release":
+			if release == "" {
+				release = strings.TrimSpace(tagLine.Value)
+			}
+		}
+
+		return nil
+	})
+	if visitErr != nil {
+		return "", "", fmt.Errorf("failed to scan spec tags in %#q:\n%w", specPath, visitErr)
+	}
+
+	return version, release, nil
+}

--- a/internal/app/azldev/core/sources/upstream_provenance_internal_test.go
+++ b/internal/app/azldev/core/sources/upstream_provenance_internal_test.go
@@ -1,0 +1,321 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+package sources
+
+import (
+	"context"
+	"errors"
+	"path/filepath"
+	"testing"
+
+	"github.com/microsoft/azure-linux-dev-tools/internal/projectconfig"
+	"github.com/microsoft/azure-linux-dev-tools/internal/utils/fileperms"
+	"github.com/microsoft/azure-linux-dev-tools/internal/utils/fileutils"
+	"github.com/spf13/afero"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
+)
+
+// fakeAutoreleaseResolver is a test double for [autoreleaseResolver] that
+// returns canned output/error and records the arguments it was called with.
+type fakeAutoreleaseResolver struct {
+	output       string
+	err          error
+	lastHostDir  string
+	lastSpecFile string
+}
+
+func (f *fakeAutoreleaseResolver) CalculateRelease(
+	_ context.Context, specHostDir, specFilename string,
+) (string, error) {
+	f.lastHostDir = specHostDir
+	f.lastSpecFile = specFilename
+
+	return f.output, f.err
+}
+
+const provenanceWorkDir = "/prov-work"
+
+// writeProvenanceSpec writes a minimal spec file named "<name>.spec" into
+// provenanceWorkDir, including Version/Release tags only when the corresponding
+// value is non-empty.
+func writeProvenanceSpec(t *testing.T, memFS afero.Fs, name, version, release string) {
+	t.Helper()
+
+	require.NoError(t, fileutils.MkdirAll(memFS, provenanceWorkDir))
+
+	content := "Name: " + name + "\nSummary: test\nLicense: MIT\n"
+	if version != "" {
+		content += "Version: " + version + "\n"
+	}
+
+	if release != "" {
+		content += "Release: " + release + "\n"
+	}
+
+	specPath := filepath.Join(provenanceWorkDir, name+".spec")
+	require.NoError(t, fileutils.WriteFile(memFS, specPath, []byte(content), fileperms.PublicFile))
+}
+
+func TestFedoraDistTag(t *testing.T) {
+	assert.Equal(t, ".fc43", FedoraDistTag("fedora", "43"))
+	assert.Equal(t, ".fc43", FedoraDistTag("Fedora", "43"), "distro name match is case-insensitive")
+	assert.Empty(t, FedoraDistTag("azurelinux", "3.0"), "non-Fedora distros get no dist tag")
+	assert.Empty(t, FedoraDistTag("fedora", ""), "empty release version yields no dist tag")
+	assert.Empty(t, FedoraDistTag("fedora", "rawhide"), "non-numeric release version yields no dist tag")
+	assert.Empty(t, FedoraDistTag("fedora", "43.0"), "non-integer release version yields no dist tag")
+	assert.Empty(t, FedoraDistTag("", "43"))
+}
+
+func TestParseSpecVersionRelease(t *testing.T) {
+	memFS := afero.NewMemMapFs()
+	writeProvenanceSpec(t, memFS, "grub2", "2.12", "5%{?dist}")
+
+	version, release, err := parseSpecVersionRelease(memFS, filepath.Join(provenanceWorkDir, "grub2.spec"))
+	require.NoError(t, err)
+	assert.Equal(t, "2.12", version)
+	assert.Equal(t, "5%{?dist}", release, "release is captured verbatim, dist is expanded later")
+}
+
+func TestParseSpecVersionRelease_MissingFile(t *testing.T) {
+	_, _, err := parseSpecVersionRelease(afero.NewMemMapFs(), "/does-not-exist.spec")
+	require.Error(t, err)
+}
+
+func TestAddUpstreamProvenanceMacros_FedoraUpstream(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	memFS := afero.NewMemMapFs()
+	writeProvenanceSpec(t, memFS, "grub2", "2.12", "5%{?dist}")
+
+	comp := mockComponent(ctrl, "grub2", upstreamCfg(true))
+
+	preparer := &sourcePreparerImpl{fs: memFS, upstreamDistTag: ".fc43"}
+	macros := map[string]string{}
+	preparer.addUpstreamProvenanceMacros(context.Background(), macros, comp, provenanceWorkDir)
+
+	assert.Equal(t, "2.12", macros[fedoraUpstreamVersionMacro])
+	assert.Equal(t, "5.fc43", macros[fedoraUpstreamReleaseMacro], "%{?dist} is expanded to the Fedora dist tag")
+}
+
+func TestAddUpstreamProvenanceMacros_LocalComponentSkipped(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	memFS := afero.NewMemMapFs()
+	writeProvenanceSpec(t, memFS, "mytool", "1.0", "1%{?dist}")
+
+	comp := mockComponent(ctrl, "mytool", &projectconfig.ComponentConfig{
+		Spec:  projectconfig.SpecSource{SourceType: projectconfig.SpecSourceTypeLocal},
+		Build: projectconfig.ComponentBuildConfig{EmitUpstreamProvenance: true},
+	})
+
+	preparer := &sourcePreparerImpl{fs: memFS, upstreamDistTag: ".fc43"}
+	macros := map[string]string{}
+	preparer.addUpstreamProvenanceMacros(context.Background(), macros, comp, provenanceWorkDir)
+
+	assert.Empty(t, macros, "local components have no upstream provenance even when opted in")
+}
+
+func TestAddUpstreamProvenanceMacros_NonFedoraSkipped(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	memFS := afero.NewMemMapFs()
+	writeProvenanceSpec(t, memFS, "grub2", "2.12", "5%{?dist}")
+
+	comp := mockComponent(ctrl, "grub2", upstreamCfg(true))
+
+	// Empty dist tag signals a non-Fedora upstream; no macros should be added.
+	preparer := &sourcePreparerImpl{fs: memFS, upstreamDistTag: ""}
+	macros := map[string]string{}
+	preparer.addUpstreamProvenanceMacros(context.Background(), macros, comp, provenanceWorkDir)
+
+	assert.Empty(t, macros)
+}
+
+func TestAddUpstreamProvenanceMacros_UserDefineWins(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	memFS := afero.NewMemMapFs()
+	writeProvenanceSpec(t, memFS, "grub2", "2.12", "5%{?dist}")
+
+	comp := mockComponent(ctrl, "grub2", upstreamCfg(true))
+
+	preparer := &sourcePreparerImpl{fs: memFS, upstreamDistTag: ".fc43"}
+	macros := map[string]string{fedoraUpstreamVersionMacro: "user-override"}
+	preparer.addUpstreamProvenanceMacros(context.Background(), macros, comp, provenanceWorkDir)
+
+	assert.Equal(t, "user-override", macros[fedoraUpstreamVersionMacro], "existing user-defined macro is not overwritten")
+	assert.Equal(t, "5.fc43", macros[fedoraUpstreamReleaseMacro])
+}
+
+func TestAddUpstreamProvenanceMacros_MissingSpecBestEffort(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	memFS := afero.NewMemMapFs()
+
+	comp := mockComponent(ctrl, "grub2", upstreamCfg(true))
+
+	// No spec on disk: capture is best-effort, so no macros and no panic/error.
+	preparer := &sourcePreparerImpl{fs: memFS, upstreamDistTag: ".fc43"}
+	macros := map[string]string{}
+	preparer.addUpstreamProvenanceMacros(context.Background(), macros, comp, provenanceWorkDir)
+
+	assert.Empty(t, macros)
+}
+
+func TestAddUpstreamProvenanceMacros_EmptyReleaseSkipped(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	memFS := afero.NewMemMapFs()
+	writeProvenanceSpec(t, memFS, "pkg", "1.0", "")
+
+	comp := mockComponent(ctrl, "pkg", upstreamCfg(true))
+
+	preparer := &sourcePreparerImpl{fs: memFS, upstreamDistTag: ".fc43"}
+	macros := map[string]string{}
+	preparer.addUpstreamProvenanceMacros(context.Background(), macros, comp, provenanceWorkDir)
+
+	assert.Equal(t, "1.0", macros[fedoraUpstreamVersionMacro])
+
+	_, hasRelease := macros[fedoraUpstreamReleaseMacro]
+	assert.False(t, hasRelease, "no Release tag means no release macro is emitted")
+}
+
+func TestAddUpstreamProvenanceMacros_OptedOutSkipped(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	memFS := afero.NewMemMapFs()
+	writeProvenanceSpec(t, memFS, "grub2", "2.12", "5%{?dist}")
+
+	// Fedora upstream with a parseable spec, but provenance emission is not
+	// enabled, so no macros should be added.
+	comp := mockComponent(ctrl, "grub2", upstreamCfg(false))
+
+	preparer := &sourcePreparerImpl{fs: memFS, upstreamDistTag: ".fc43"}
+	macros := map[string]string{}
+	preparer.addUpstreamProvenanceMacros(context.Background(), macros, comp, provenanceWorkDir)
+
+	assert.Empty(t, macros, "provenance macros require opt-in via build.emit-upstream-provenance")
+}
+
+func TestAddUpstreamProvenanceMacros_AutoreleaseResolved(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	memFS := afero.NewMemMapFs()
+	writeProvenanceSpec(t, memFS, "fwupd-efi", "1.6", "%autorelease")
+
+	comp := mockComponent(ctrl, "fwupd-efi", upstreamCfg(true))
+
+	// rpmautospec prints the release behind a "Calculated release number: "
+	// prefix even with a flag; the parser must extract just the value.
+	resolver := &fakeAutoreleaseResolver{output: "Calculated release number: 3\n"}
+
+	preparer := &sourcePreparerImpl{fs: memFS, upstreamDistTag: ".fc41", withGitRepo: true, autoreleaseResolver: resolver}
+	macros := map[string]string{}
+	preparer.addUpstreamProvenanceMacros(context.Background(), macros, comp, provenanceWorkDir)
+
+	assert.Equal(t, "1.6", macros[fedoraUpstreamVersionMacro])
+	assert.Equal(t, "3.fc41", macros[fedoraUpstreamReleaseMacro],
+		"%autorelease is resolved via rpmautospec and combined with the Fedora dist tag")
+	assert.Equal(t, provenanceWorkDir, resolver.lastHostDir, "the pristine sources dir is bind-mounted for resolution")
+	assert.Equal(t, "fwupd-efi.spec", resolver.lastSpecFile, "the spec basename is passed to the resolver")
+}
+
+func TestAddUpstreamProvenanceMacros_AutoreleaseNoMockProcessor(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	memFS := afero.NewMemMapFs()
+	writeProvenanceSpec(t, memFS, "fwupd-efi", "1.6", "%autorelease")
+
+	comp := mockComponent(ctrl, "fwupd-efi", upstreamCfg(true))
+
+	// No resolver configured (nil MockProcessor) → not resolvable → release macro skipped.
+	preparer := &sourcePreparerImpl{fs: memFS, upstreamDistTag: ".fc41", withGitRepo: true}
+	macros := map[string]string{}
+	preparer.addUpstreamProvenanceMacros(context.Background(), macros, comp, provenanceWorkDir)
+
+	assert.Equal(t, "1.6", macros[fedoraUpstreamVersionMacro])
+
+	_, hasRelease := macros[fedoraUpstreamReleaseMacro]
+	assert.False(t, hasRelease, "an unresolvable %autorelease is skipped, never emitted verbatim")
+}
+
+func TestAddUpstreamProvenanceMacros_AutoreleaseResolverFailed(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	memFS := afero.NewMemMapFs()
+	writeProvenanceSpec(t, memFS, "fwupd-efi", "1.6", "%autorelease")
+
+	comp := mockComponent(ctrl, "fwupd-efi", upstreamCfg(true))
+
+	resolver := &fakeAutoreleaseResolver{err: errors.New("mock chroot exploded")}
+
+	preparer := &sourcePreparerImpl{fs: memFS, upstreamDistTag: ".fc41", withGitRepo: true, autoreleaseResolver: resolver}
+	macros := map[string]string{}
+	preparer.addUpstreamProvenanceMacros(context.Background(), macros, comp, provenanceWorkDir)
+
+	_, hasRelease := macros[fedoraUpstreamReleaseMacro]
+	assert.False(t, hasRelease, "a resolver error is best-effort skipped, not fatal")
+}
+
+func TestAddUpstreamProvenanceMacros_AutoreleaseInvalidOutput(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	memFS := afero.NewMemMapFs()
+	writeProvenanceSpec(t, memFS, "fwupd-efi", "1.6", "%autorelease")
+
+	comp := mockComponent(ctrl, "fwupd-efi", upstreamCfg(true))
+
+	// A non-release message must not be forwarded into the macro.
+	resolver := &fakeAutoreleaseResolver{output: "error: could not compute release"}
+
+	preparer := &sourcePreparerImpl{fs: memFS, upstreamDistTag: ".fc41", withGitRepo: true, autoreleaseResolver: resolver}
+	macros := map[string]string{}
+	preparer.addUpstreamProvenanceMacros(context.Background(), macros, comp, provenanceWorkDir)
+
+	_, hasRelease := macros[fedoraUpstreamReleaseMacro]
+	assert.False(t, hasRelease, "a non-numeric rpmautospec result is rejected, not emitted")
+}
+
+// TestAddUpstreamProvenanceMacros_AutoreleaseBracedForms verifies the braced
+// and conditional %autorelease spellings are recognized as autorelease (and so
+// resolved via rpmautospec) rather than emitted verbatim into the macro.
+func TestAddUpstreamProvenanceMacros_AutoreleaseBracedForms(t *testing.T) {
+	for _, releaseTag := range []string{"%{autorelease}", "%{?autorelease}", "%{autorelease -e asan}"} {
+		t.Run(releaseTag, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			memFS := afero.NewMemMapFs()
+			writeProvenanceSpec(t, memFS, "fwupd-efi", "1.6", releaseTag)
+
+			comp := mockComponent(ctrl, "fwupd-efi", upstreamCfg(true))
+
+			resolver := &fakeAutoreleaseResolver{output: "Calculated release number: 3\n"}
+
+			preparer := &sourcePreparerImpl{
+				fs: memFS, upstreamDistTag: ".fc41", withGitRepo: true, autoreleaseResolver: resolver,
+			}
+			macros := map[string]string{}
+			preparer.addUpstreamProvenanceMacros(context.Background(), macros, comp, provenanceWorkDir)
+
+			assert.Equal(t, "3.fc41", macros[fedoraUpstreamReleaseMacro],
+				"braced/conditional %autorelease is resolved, never emitted verbatim")
+		})
+	}
+}
+
+// TestAddUpstreamProvenanceMacros_PlainDistTag verifies the unconditional
+// %{dist} form is substituted with the Fedora dist tag, just like %{?dist}.
+func TestAddUpstreamProvenanceMacros_PlainDistTag(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	memFS := afero.NewMemMapFs()
+	writeProvenanceSpec(t, memFS, "grub2", "2.12", "5%{dist}")
+
+	comp := mockComponent(ctrl, "grub2", upstreamCfg(true))
+
+	preparer := &sourcePreparerImpl{fs: memFS, upstreamDistTag: ".fc43"}
+	macros := map[string]string{}
+	preparer.addUpstreamProvenanceMacros(context.Background(), macros, comp, provenanceWorkDir)
+
+	assert.Equal(t, "5.fc43", macros[fedoraUpstreamReleaseMacro],
+		"unconditional %{dist} is expanded to the Fedora dist tag")
+}
+
+// upstreamCfg returns a Fedora-upstream component config with provenance
+// emission toggled by emit.
+func upstreamCfg(emit bool) *projectconfig.ComponentConfig {
+	return &projectconfig.ComponentConfig{
+		Spec:  projectconfig.SpecSource{SourceType: projectconfig.SpecSourceTypeUpstream},
+		Build: projectconfig.ComponentBuildConfig{EmitUpstreamProvenance: emit},
+	}
+}

--- a/internal/projectconfig/build.go
+++ b/internal/projectconfig/build.go
@@ -31,6 +31,11 @@ func (c *CheckConfig) Validate() error {
 
 // Encapsulates configuration for building a component. Configuration for how to acquire
 // or prepare the sources for a component are out of scope.
+//
+// HashInclude must be a value receiver because hashstructure's Includable interface is
+// invoked on the hashed value; Validate uses a pointer receiver by convention.
+//
+//nolint:recvcheck // value + pointer receivers are intentional (see doc comment above).
 type ComponentBuildConfig struct {
 	// Which features should be enabled via `with` options to the builder.
 	With []string `toml:"with,omitempty" json:"with,omitempty" jsonschema:"title=With options,description='with' options to pass to the builder."`
@@ -40,12 +45,29 @@ type ComponentBuildConfig struct {
 	Defines map[string]string `toml:"defines,omitempty" json:"defines,omitempty" jsonschema:"title=Macro definitions,description=Macro definitions to pass to the builder."`
 	// Undefine macros that would otherwise be defined by the component configuration.
 	Undefines []string `toml:"undefines,omitempty" json:"undefines,omitempty" jsonschema:"title=Undefined macros,description=Macro names to undefine when passing to the builder."`
+	// EmitUpstreamProvenance, when true, injects %fedora_upstream_version and
+	// %fedora_upstream_release macros (derived from the pristine upstream Fedora
+	// spec) into the component's generated macros file. Only effective for Fedora
+	// upstream components. Opt-in because the macros are only useful to specs that
+	// reference them (e.g. grub2's SBAT metadata).
+	EmitUpstreamProvenance bool `toml:"emit-upstream-provenance,omitempty" json:"emitUpstreamProvenance,omitempty" jsonschema:"title=Emit upstream provenance macros,description=Inject %fedora_upstream_version/release macros derived from the pristine upstream Fedora spec (Fedora upstream components only)."`
 	// Check section configuration.
 	Check CheckConfig `toml:"check,omitempty" json:"check,omitempty" jsonschema:"title=Check configuration,description=Configuration for the %check section"`
 	// Failure configuration and policy for this component's build.
 	Failure ComponentBuildFailureConfig `toml:"failure,omitempty" json:"failure,omitempty" jsonschema:"title=Build failure configuration,description=Configuration and policy regarding build failures for this component." fingerprint:"-"`
 	// Hints for how or when to build the component; must not be required for correctness of builds.
 	Hints ComponentBuildHints `toml:"hints,omitempty" json:"hints,omitempty" jsonschema:"title=Build hints,description=Non-essential hints for how or when to build the component." fingerprint:"-"`
+}
+
+// HashInclude implements the hashstructure [Includable] interface so that
+// [ComponentBuildConfig.EmitUpstreamProvenance] is omitted from the component
+// fingerprint when false or not set.
+func (c ComponentBuildConfig) HashInclude(field string, _ any) (bool, error) {
+	if field == "EmitUpstreamProvenance" {
+		return c.EmitUpstreamProvenance, nil
+	}
+
+	return true, nil
 }
 
 // ComponentBuildFailureConfig encapsulates configuration and policy regarding a component's

--- a/internal/projectconfig/build_test.go
+++ b/internal/projectconfig/build_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/microsoft/azure-linux-dev-tools/internal/projectconfig"
+	"github.com/mitchellh/hashstructure/v2"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -190,4 +191,44 @@ func TestComponentBuildConfig_Validate(t *testing.T) {
 			require.NoError(t, err)
 		})
 	}
+}
+
+// TestComponentBuildConfig_HashInclude verifies the fingerprint override:
+// EmitUpstreamProvenance is included only when true (so enabling it is the only
+// thing that perturbs a component's hash), while all other fields are always
+// included.
+func TestComponentBuildConfig_HashInclude(t *testing.T) {
+	disabled := projectconfig.ComponentBuildConfig{}
+	enabled := projectconfig.ComponentBuildConfig{EmitUpstreamProvenance: true}
+
+	include, err := disabled.HashInclude("EmitUpstreamProvenance", nil)
+	require.NoError(t, err)
+	assert.False(t, include, "a false flag is omitted so it does not perturb the fingerprint")
+
+	include, err = enabled.HashInclude("EmitUpstreamProvenance", nil)
+	require.NoError(t, err)
+	assert.True(t, include, "a true flag is included so enabling it changes the fingerprint")
+
+	include, err = disabled.HashInclude("With", nil)
+	require.NoError(t, err)
+	assert.True(t, include, "unrelated fields are always included")
+}
+
+// TestComponentBuildConfig_ProvenanceFingerprint confirms that enabling
+// provenance changes the hashstructure fingerprint, so an opted-in component
+// rebuilds while others are unaffected.
+func TestComponentBuildConfig_ProvenanceFingerprint(t *testing.T) {
+	hash := func(c projectconfig.ComponentBuildConfig) uint64 {
+		h, err := hashstructure.Hash(c, hashstructure.FormatV2, &hashstructure.HashOptions{TagName: "fingerprint"})
+		require.NoError(t, err)
+
+		return h
+	}
+
+	disabled := projectconfig.ComponentBuildConfig{With: []string{"feature"}}
+	enabled := disabled
+	enabled.EmitUpstreamProvenance = true
+
+	assert.NotEqual(t, hash(disabled), hash(enabled),
+		"enabling provenance changes the fingerprint so the component rebuilds")
 }

--- a/scenario/__snapshots__/TestSnapshotsContainer_config_generate-schema_stdout_1.snap
+++ b/scenario/__snapshots__/TestSnapshotsContainer_config_generate-schema_stdout_1.snap
@@ -53,6 +53,11 @@
           "title": "Undefined macros",
           "description": "Macro names to undefine when passing to the builder."
         },
+        "emit-upstream-provenance": {
+          "type": "boolean",
+          "title": "Emit upstream provenance macros",
+          "description": "Inject %fedora_upstream_version/release macros derived from the pristine upstream Fedora spec (Fedora upstream components only)."
+        },
         "check": {
           "$ref": "#/$defs/CheckConfig",
           "title": "Check configuration",

--- a/scenario/__snapshots__/TestSnapshots_config_generate-schema_stdout_1.snap
+++ b/scenario/__snapshots__/TestSnapshots_config_generate-schema_stdout_1.snap
@@ -53,6 +53,11 @@
           "title": "Undefined macros",
           "description": "Macro names to undefine when passing to the builder."
         },
+        "emit-upstream-provenance": {
+          "type": "boolean",
+          "title": "Emit upstream provenance macros",
+          "description": "Inject %fedora_upstream_version/release macros derived from the pristine upstream Fedora spec (Fedora upstream components only)."
+        },
         "check": {
           "$ref": "#/$defs/CheckConfig",
           "title": "Check configuration",

--- a/schemas/azldev.schema.json
+++ b/schemas/azldev.schema.json
@@ -53,6 +53,11 @@
           "title": "Undefined macros",
           "description": "Macro names to undefine when passing to the builder."
         },
+        "emit-upstream-provenance": {
+          "type": "boolean",
+          "title": "Emit upstream provenance macros",
+          "description": "Inject %fedora_upstream_version/release macros derived from the pristine upstream Fedora spec (Fedora upstream components only)."
+        },
         "check": {
           "$ref": "#/$defs/CheckConfig",
           "title": "Check configuration",


### PR DESCRIPTION
## Summary

This PR supports azldev emits `%fedora_upstream_version` and `%fedora_upstream_release` macros for Fedora upstream components that opt in via a new `build.emit-upstream-provenance` flag. Values are read from the pristine upstream Fedora spec on disk (before overlays are applied) and the Release tag's `%{?dist}` token is expanded to the resolved Fedora dist tag (e.g. `.fc43`). The macros are surfaced through the component's existing generated macros file.

This is a **replacement for #285** ("capture upstream version/release provenance and expose `%azl_upstream_*` macros"). That PR stored the version and release in the per-component lock file and derived the macros at build time from the lock. This PR takes a different, simpler approach.

Closed #285.

## Advantages over #285

| Aspect | #285 (lockfile-based) | This PR (render-time) |
|---|---|---|
| Data flow | Fetch NEVR at `component update` → store in lockfile → read at render/build | Read NEVR fresh at render/build from the pristine upstream spec that is already on disk |
| Lockfile schema | +4 fields per component (`upstream-name`, `upstream-epoch`, `upstream-version`, `upstream-release`) | **No schema change** |
| `update` command | New EVR-capture step, freshness/backfill guard, `hasLockedUpstreamVersionRelease` gate | **Untouched** |
| `SourceIdentity` plumbing | New struct + `ResolveIdentity`/`ResolveSourceIdentity` signature change threaded through Fedora, RPM, and local providers | **Untouched** |
| Network at resolution time | Extra clone + `git show <commit>:<name>.spec` per component during identity resolution | None (the render pipeline already clones the pristine spec) |
| Failure surface | Clone failure fatal for pinned commits (deterministic identity); best-effort for spec parse | Non-fatal Warn on missing/unparseable spec (opt-in components only) |
| Scope of rendered-output change | All Fedora upstream components acquire 4 new lock fields | Opt-in: only components that need the macros (currently just grub2 for SBAT) get a `.azl.macros` file |
| Provenance freshness | Cached in lock; can become stale if commit pin advances without an `update` run | Always reflects the pinned upstream commit |
| Diff size | ~18 files, ~650 LOC | 8 files (excl. regenerated schema), ~200 net LOC |
| Macro naming | `%azl_upstream_*` | `%fedora_upstream_*` (explicit about the source) |

## Design

- **New option**: `sources.WithUpstreamProvenance(distTag string)` on `SourcePreparer`. `distTag` is the resolved `%{?dist}` expansion (`FedoraDistTag(distroName, releaseVer)` returns `.fc<N>` for Fedora, `""` otherwise, disabling the feature).
- **Hook point**: `writeMacrosFile` (in the pre-overlay window). The pristine spec exists on disk right after `FetchComponent`, before overlays rewrite it. `parseSpecVersionRelease` reads Version/Release verbatim via the existing `spec.VisitTagsPackage` path; only `%{?dist}` is substituted.
- **Opt-in flag**: `build.emit-upstream-provenance = true` in `[components.<name>.build]`. Fingerprintable — flipping it changes rendered output. Registered with the `component history` collector.
- **Precedence**: `build.defines` wins (macros are layered via `setMacroIfAbsent`).
- **Emission mechanism unchanged**: reuses the existing `.azl.macros` + `%{load:%{_sourcedir}/...}` + `Source9999` path. No second mechanism.
- **Gates in order**: dist-tag non-empty → opt-in flag → `spec.type = upstream`. Local, SRPM, and non-Fedora upstream components are skipped, so the flag is a no-op for them.
- **Failure mode**: best-effort. If the opt-in is set but the spec can't be located or parsed, a `WARN` is logged and the macros are skipped; render/build proceeds without them.

## Consumer example (grub2 SBAT)

An accompanying comp.toml change in the azurelinux repo enables the flag and adds a spec-search-replace overlay:

```toml
[components.grub2.build]
emit-upstream-provenance = true

[[components.grub2.overlays]]
description = "Use %fedora_upstream_* macros for the grub.rh SBAT vendor_version (@@VERSION_RELEASE@@)"
type = "spec-search-replace"
regex = '-e "s,@@VERSION_RELEASE@@,%\{version\}-%\{release\},g"'
replacement = '-e "s,@@VERSION_RELEASE@@,%{?fedora_upstream_version}-%{?fedora_upstream_release},g"'
```

Result: the built `sbat.csv`'s `grub.rh` line carries the pristine upstream Fedora NEVR (e.g. `grub.rh,2,Red Hat,grub2,2.12-45.fc43,...`) instead of the AZL build V-R (`…azl4`).

## Testing

- `mage unit` — passing (7 new tests cover happy path, opt-out, local skip, non-Fedora skip, user-define wins, missing spec best-effort, empty release, and dist-tag mapping).
- `mage check all` — passing (linting, static analysis, license, schema).
- `mage docs` regenerated the JSON schema for the new field.
- `grub2` build succeeded and the SBAT overlay is verified working using command:
```
rpm2cpio base/out/rpms/rpm-base/grub2-efi-x64-2.12-46.azl4.x86_64.rpm \
  | cpio -i --to-stdout ./boot/efi/EFI/azurelinux/grubx64.efi 2>/dev/null \
  | objcopy -O binary --only-section=.sbat /dev/stdin /dev/stdout \
  | tr -d '\000'
```
Both EFI binaries (x64 and ia32) carry identical SBAT data:
```
sbat,1,SBAT Version,sbat,1,https://github.com/rhboot/shim/blob/main/SBAT.md
grub,5,Free Software Foundation,grub,2.12,https//www.gnu.org/software/grub/
grub.rh,2,Red Hat,grub2,2.12-40.fc43,mailto:secalert@redhat.com
```

**Fix**: [AB#12798](https://dev.azure.com/mariner-org/mariner/_workitems/edit/21798)
**ADR**: [AB#28331](https://dev.azure.com/mariner-org/mariner/_git/azure-linux-planning-docs/pullrequest/28331)

## Limitations (documented)

- Tag values are read as plain text; only `%{?dist}` is expanded. A tag built from other macros (e.g. `Version: %{majorver}.%{minorver}`) is captured with those macros unexpanded.
- Listing `fedora_upstream_version` / `_release` in `build.undefines` does not suppress the injected macros. Use `emit-upstream-provenance = false` (or omit it) instead.
