### PR TITLE
fix(sources): clamp interleaved commit timestamps to keep %changelog descending

### DIFF
--- a/internal/app/azldev/core/sources/render_process.py
+++ b/internal/app/azldev/core/sources/render_process.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-# Copyright (c) Microsoft Corporation.
+# Copyright (c) 2026 Microsoft Corporation.
 # Licensed under the MIT License.
 
 r"""Run rpmautospec and spectool for each component inside a mock chroot.

--- a/internal/app/azldev/core/sources/synthistory.go
+++ b/internal/app/azldev/core/sources/synthistory.go
@@ -260,6 +260,13 @@ func buildInterleavedSequence(
 // commit (import-commit) is kept as-is; subsequent upstream commits are
 // recreated with updated parents. Synthetic commits are empty except for the
 // very last one, which carries the overlay tree.
+//
+// Commit timestamps are clamped forward so the replayed history is monotonic
+// non-decreasing in time (see [clampWhenForward]). Interleaving can place a
+// synthetic downstream commit (wall-clock later) before an upstream release
+// commit (wall-clock earlier); without clamping, rpmautospec would render a
+// %changelog whose entries are not date-descending, which rpmbuild rejects with
+// "%changelog not in descending chronological order".
 func replayInterleavedHistory(
 	repo *gogit.Repository,
 	sequence []interleavedEntry,
@@ -270,6 +277,7 @@ func replayInterleavedHistory(
 	var (
 		lastHash     plumbing.Hash
 		lastTreeHash plumbing.Hash
+		lastWhen     time.Time
 		syntheticIdx int
 	)
 
@@ -277,18 +285,20 @@ func replayInterleavedHistory(
 		if idx == 0 && entry.upstreamCommit != nil {
 			lastHash = entry.upstreamCommit.Hash
 			lastTreeHash = entry.upstreamCommit.TreeHash
+			lastWhen = laterTime(entry.upstreamCommit.Author.When, entry.upstreamCommit.Committer.When)
 
 			continue
 		}
 
 		if entry.upstreamCommit != nil {
-			hash, err := replayUpstreamCommit(repo, entry.upstreamCommit, lastHash)
+			hash, when, err := replayUpstreamCommit(repo, entry.upstreamCommit, lastHash, lastWhen)
 			if err != nil {
 				return err
 			}
 
 			lastHash = hash
 			lastTreeHash = entry.upstreamCommit.TreeHash
+			lastWhen = when
 
 			continue
 		}
@@ -302,14 +312,15 @@ func replayInterleavedHistory(
 			treeHash = overlayTreeHash
 		}
 
-		hash, err := createSyntheticCommit(repo, entry.syntheticChange, treeHash, lastHash,
-			syntheticIdx, syntheticCount)
+		hash, when, err := createSyntheticCommit(repo, entry.syntheticChange, treeHash, lastHash,
+			syntheticIdx, syntheticCount, lastWhen)
 		if err != nil {
 			return err
 		}
 
 		lastHash = hash
 		lastTreeHash = treeHash
+		lastWhen = when
 	}
 
 	if err := updateHead(repo, lastHash); err != nil {
@@ -326,39 +337,54 @@ func replayInterleavedHistory(
 // replayUpstreamCommit recreates an upstream commit with a new parent, preserving
 // tree content, author, committer, and message. Merge commits (multiple parents)
 // are linearized by replaying them as single-parent commits — the tree hash is
-// preserved so the merged content is retained.
+// preserved so the merged content is retained. The author and committer
+// timestamps are clamped forward to minWhen so the replayed history stays
+// monotonic in time; the later of the two resulting timestamps is returned so
+// the caller can advance its running minimum.
 func replayUpstreamCommit(
 	repo *gogit.Repository,
 	commit *object.Commit,
 	parentHash plumbing.Hash,
-) (plumbing.Hash, error) {
+	minWhen time.Time,
+) (plumbing.Hash, time.Time, error) {
 	if len(commit.ParentHashes) > 1 {
 		slog.Debug("Linearizing merge commit in upstream history",
 			"commit", commit.Hash,
 			"parentCount", len(commit.ParentHashes))
 	}
 
+	author := clampWhenForward(commit.Author, minWhen)
+	committer := clampWhenForward(commit.Committer, minWhen)
+
 	hash, err := createCommitObject(repo, commit.TreeHash, parentHash,
-		commit.Author, commit.Committer, commit.Message)
+		author, committer, commit.Message)
 	if err != nil {
-		return plumbing.ZeroHash, fmt.Errorf("failed to replay upstream commit:\n%w", err)
+		return plumbing.ZeroHash, time.Time{}, fmt.Errorf("failed to replay upstream commit:\n%w", err)
 	}
 
-	return hash, nil
+	return hash, laterTime(author.When, committer.When), nil
 }
 
 // createSyntheticCommit creates a synthetic commit from a [FingerprintChange],
-// logging progress information.
+// logging progress information. The commit timestamp is clamped forward to
+// minWhen so the replayed history stays monotonic in time; the resulting
+// timestamp is returned so the caller can advance its running minimum.
 func createSyntheticCommit(
 	repo *gogit.Repository,
 	change *FingerprintChange,
 	treeHash, parentHash plumbing.Hash,
 	syntheticIdx, syntheticCount int,
-) (plumbing.Hash, error) {
+	minWhen time.Time,
+) (plumbing.Hash, time.Time, error) {
+	when := unixToTime(change.Timestamp)
+	if when.Before(minWhen) {
+		when = minWhen
+	}
+
 	author := object.Signature{
 		Name:  change.Author,
 		Email: change.AuthorEmail,
-		When:  unixToTime(change.Timestamp),
+		When:  when,
 	}
 
 	message := fmt.Sprintf("%s\n\nProject commit: %s", change.Message, change.Hash)
@@ -373,10 +399,31 @@ func createSyntheticCommit(
 
 	hash, err := createCommitObject(repo, treeHash, parentHash, author, author, message)
 	if err != nil {
-		return plumbing.ZeroHash, fmt.Errorf("failed to create synthetic commit %d:\n%w", syntheticIdx, err)
+		return plumbing.ZeroHash, time.Time{}, fmt.Errorf("failed to create synthetic commit %d:\n%w", syntheticIdx, err)
 	}
 
-	return hash, nil
+	return hash, when, nil
+}
+
+// laterTime returns the later of two timestamps.
+func laterTime(a, b time.Time) time.Time {
+	if a.After(b) {
+		return a
+	}
+
+	return b
+}
+
+// clampWhenForward returns a copy of sig whose [object.Signature.When] is no
+// earlier than minWhen. It is used to enforce a monotonic non-decreasing
+// timeline across the replayed interleaved history so that the rpmautospec
+// generated %changelog is in descending chronological order.
+func clampWhenForward(sig object.Signature, minWhen time.Time) object.Signature {
+	if sig.When.Before(minWhen) {
+		sig.When = minWhen
+	}
+
+	return sig
 }
 
 // countSyntheticEntries returns the number of synthetic entries in the sequence.

--- a/internal/app/azldev/core/sources/synthistory_test.go
+++ b/internal/app/azldev/core/sources/synthistory_test.go
@@ -231,6 +231,170 @@ func TestCommitInterleavedHistory_Interleaved(t *testing.T) {
 	assert.Contains(t, logCommits[3].Message, "upstream: v1.0") // import-commit (kept)
 }
 
+func TestCommitInterleavedHistory_ClampsInvertedTimestamps(t *testing.T) {
+	// A synthetic change referencing an older upstream commit can carry a
+	// wall-clock timestamp that is LATER than a subsequent upstream release
+	// commit (e.g. a downstream infra commit lands after upstream cut a new
+	// release, then the component is pinned back to that older-dated release).
+	// Interleaving places the synthetic before the newer-versioned/older-dated
+	// upstream commit, which would produce a non-monotonic timeline and, in
+	// turn, an rpmautospec %changelog that is not in descending chronological
+	// order (rpmbuild rejects that). The replay must clamp timestamps forward so
+	// the resulting history is monotonic non-decreasing.
+	memFS := memfs.New()
+	storer := memory.NewStorage()
+
+	repo, err := gogit.Init(storer, memFS)
+	require.NoError(t, err)
+
+	worktree, err := repo.Worktree()
+	require.NoError(t, err)
+
+	// Upstream commit 1 (v1.0), Jan 2024.
+	file1, err := memFS.Create("package.spec")
+	require.NoError(t, err)
+
+	_, err = file1.Write([]byte("Name: package\nVersion: 1.0\n"))
+	require.NoError(t, err)
+	require.NoError(t, file1.Close())
+
+	_, err = worktree.Add("package.spec")
+	require.NoError(t, err)
+
+	upstream1, err := worktree.Commit("upstream: v1.0", &gogit.CommitOptions{
+		Author: &object.Signature{
+			Name:  "Upstream",
+			Email: "upstream@fedora.org",
+			When:  time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC),
+		},
+	})
+	require.NoError(t, err)
+
+	// Upstream commit 2 (v2.0) released Apr 14 2026 — EARLIER in wall-clock
+	// time than the synthetic change for v1.0 below. Give it a committer date
+	// distinct from (and later than) its author date — but still earlier than
+	// the inverting synthetic — so the test detects removal of EITHER the author
+	// or the committer clamp. rpmautospec keys the %changelog date off the
+	// committer timestamp (pkg_history.py uses commit.commit_time), so the
+	// committer assertion below is the one that mirrors real build behavior.
+	upstream2AuthorWhen := time.Date(2026, 4, 14, 0, 0, 0, 0, time.UTC)
+	upstream2CommitterWhen := time.Date(2026, 4, 15, 0, 0, 0, 0, time.UTC)
+
+	file2, err := memFS.Create("package.spec")
+	require.NoError(t, err)
+
+	_, err = file2.Write([]byte("Name: package\nVersion: 2.0\n"))
+	require.NoError(t, err)
+	require.NoError(t, file2.Close())
+
+	_, err = worktree.Add("package.spec")
+	require.NoError(t, err)
+
+	upstream2, err := worktree.Commit("upstream: v2.0", &gogit.CommitOptions{
+		Author: &object.Signature{
+			Name:  "Upstream",
+			Email: "upstream@fedora.org",
+			When:  upstream2AuthorWhen,
+		},
+		Committer: &object.Signature{
+			Name:  "Upstream",
+			Email: "upstream@fedora.org",
+			When:  upstream2CommitterWhen,
+		},
+	})
+	require.NoError(t, err)
+
+	// Simulate overlay modification in working tree.
+	specFile, err := memFS.Create("package.spec")
+	require.NoError(t, err)
+
+	_, err = specFile.Write([]byte("Name: package\nVersion: 2.0\n# overlays\n"))
+	require.NoError(t, err)
+	require.NoError(t, specFile.Close())
+
+	// Synthetic change for v1.0 dated Apr 30 2026 — AFTER upstream2's Apr 14
+	// release date. This is the inversion the clamp must fix.
+	invertedWhen := time.Date(2026, 4, 30, 0, 0, 0, 0, time.UTC)
+
+	changes := []sources.FingerprintChange{
+		{
+			CommitMetadata: sources.CommitMetadata{
+				Hash:        "proj-aaa",
+				Author:      "Alice",
+				AuthorEmail: "alice@example.com",
+				Timestamp:   invertedWhen.Unix(),
+				Message:     "Infra change while pinned to v1.0",
+			},
+			UpstreamCommit: upstream1.String(), // references older upstream.
+		},
+		{
+			CommitMetadata: sources.CommitMetadata{
+				Hash:        "proj-bbb",
+				Author:      "Bob",
+				AuthorEmail: "bob@example.com",
+				Timestamp:   time.Date(2026, 7, 24, 0, 0, 0, 0, time.UTC).Unix(),
+				Message:     "Pin to v2.0",
+			},
+			UpstreamCommit: upstream2.String(), // references latest upstream.
+		},
+	}
+
+	err = sources.CommitInterleavedHistory(repo, changes, upstream1.String())
+	require.NoError(t, err)
+
+	head, err := repo.Head()
+	require.NoError(t, err)
+
+	commitIter, err := repo.Log(&gogit.LogOptions{From: head.Hash()})
+	require.NoError(t, err)
+
+	var logCommits []*object.Commit
+
+	err = commitIter.ForEach(func(c *object.Commit) error {
+		logCommits = append(logCommits, c)
+
+		return nil
+	})
+	require.NoError(t, err)
+
+	require.Len(t, logCommits, 4, "should have 2 upstream + 2 synthetic commits")
+
+	// Order (newest first) is preserved by version, not wall-clock.
+	assert.Contains(t, logCommits[0].Message, "Pin to v2.0")    // top synthetic
+	assert.Contains(t, logCommits[1].Message, "upstream: v2.0") // replayed upstream 2
+	assert.Contains(t, logCommits[2].Message, "Infra change while pinned to v1.0")
+	assert.Contains(t, logCommits[3].Message, "upstream: v1.0") // import-commit (kept)
+
+	// The replayed upstream v2.0 commit (author Apr 14 / committer Apr 15) must
+	// have BOTH timestamps clamped forward to the preceding synthetic's Apr 30
+	// date so the timeline is not inverted. The committer clamp is what actually
+	// fixes the rendered %changelog (rpmautospec uses committer time); the author
+	// clamp keeps the commit object internally consistent.
+	assert.True(t, logCommits[1].Committer.When.Equal(invertedWhen),
+		"upstream v2.0 committer timestamp should be clamped forward to %v, got %v",
+		invertedWhen, logCommits[1].Committer.When)
+	assert.True(t, logCommits[1].Author.When.Equal(invertedWhen),
+		"upstream v2.0 author timestamp should be clamped forward to %v, got %v",
+		invertedWhen, logCommits[1].Author.When)
+
+	// The whole timeline must be monotonic non-decreasing (oldest → newest),
+	// i.e. non-increasing when read newest-first. Assert on BOTH the committer
+	// timeline (the one rpmautospec renders) and the author timeline.
+	for idx := range len(logCommits) - 1 {
+		newerCommitter := logCommits[idx].Committer.When
+		olderCommitter := logCommits[idx+1].Committer.When
+		assert.Falsef(t, newerCommitter.Before(olderCommitter),
+			"committer timeline inverted: commit %d (%v) is earlier than older commit %d (%v)",
+			idx, newerCommitter, idx+1, olderCommitter)
+
+		newerAuthor := logCommits[idx].Author.When
+		olderAuthor := logCommits[idx+1].Author.When
+		assert.Falsef(t, newerAuthor.Before(olderAuthor),
+			"author timeline inverted: commit %d (%v) is earlier than older commit %d (%v)",
+			idx, newerAuthor, idx+1, olderAuthor)
+	}
+}
+
 func TestCommitInterleavedHistory_MultipleCyclesAutoreleaseLifecycle(t *testing.T) {
 	// Simulates a realistic autorelease/autochangelog lifecycle:
 	//   upstream₁ → us₁(overlay) → us₂(manual-bump) → upstream₂ → us₃(overlay)


### PR DESCRIPTION
## Summary
When azldev rebuilds a component's synthetic dist-git history, it interleaves synthetic downstream commits (from lock-file fingerprint changes) with upstream commits. A synthetic commit that references an **older** upstream pin but has a **later** wall-clock date can be placed *before* a newer-versioned upstream release commit with an *earlier* date, making the replayed history **non-monotonic in time**.

rpmautospec dates each `%changelog` entry from the git **committer** timestamp (`pkg_history.py` uses `commit.commit_time`), so a non-monotonic timeline renders a `%changelog` whose dates are not in descending order. `rpmbuild` then fails the build with:

```
error: %changelog not in descending chronological order
```

## Fix
In `replayInterleavedHistory`, track a running `lastWhen` and clamp each replayed commit's **author and committer** timestamps forward to that maximum (`clampWhenForward` / `laterTime`). This guarantees the replayed history is monotonic non-decreasing, so the generated changelog is always in descending order.

- Only activates in the inversion case; normal renders (synthetics newest) are unaffected.
- Equal adjacent dates are accepted by `rpmbuild`, so ties introduced by clamping are fine.
- The synthetic history is ephemeral (used only to feed rpmautospec), so clamped dates do not affect lock fingerprints.

## Test
Adds `TestCommitInterleavedHistory_ClampsInvertedTimestamps`, which reproduces the inversion using an upstream commit with **distinct author/committer dates** (both earlier than the inverting synthetic) and asserts both timelines are monotonic and clamped. The committer assertion mirrors the date rpmautospec actually renders; verified the test fails if either the author- or committer-clamp is removed.

## Validation
- `mage check all` (mod, lint, editorconfig, static, licenses) — pass
- `go test ./internal/app/azldev/core/sources/` — pass (all 8 interleave tests)
- End-to-end: rebuilt `azldev` and re-rendered a real component whose changelog was date-inverted; the rendered `%changelog` is now valid descending order and passes `rpmbuild -bs` (no descending-order error). Render is deterministic (byte-identical across runs).

## Notes
This is the root-cause fix for a downstream libjcat build failure where a f43 `0.2.6` pin (Apr 14) sat after a repo-wide lock-file infra commit (Apr 30) in the interleaved history.

## Note: Python lint fix
Also adds a year to `render_process.py`'s copyright header. This lint failure predates my change and is unrelated to it — Ruff's `CPY001` requires a 4-digit year, so the year-less header fails CI (`main` is already red on the same rule).

