### PR TITLE
refactor: use xorriso for ISO creation

### DIFF
--- a/docs/user/reference/cli/azldev_image_boot.md
+++ b/docs/user/reference/cli/azldev_image_boot.md
@@ -30,7 +30,7 @@ must support serial console interaction.
 
 Requirements:
   - qemu-system-x86_64/qemu-system-aarch64 (QEMU emulator)
-  - genisoimage (only when cloud-init credentials are provided)
+  - xorriso (only when cloud-init credentials are provided)
   - qemu-img (only when creating an empty disk for '--iso')
   - sudo (for running QEMU with KVM)
   - OVMF firmware (for UEFI boot)

--- a/docs/user/reference/cli/azldev_image_boot.md
+++ b/docs/user/reference/cli/azldev_image_boot.md
@@ -30,7 +30,7 @@ must support serial console interaction.
 
 Requirements:
   - qemu-system-x86_64/qemu-system-aarch64 (QEMU emulator)
-  - genisoimage (only when cloud-init credentials are provided)
+  - xorriso (only when credentials or an explicit '--test-user' are provided)
   - qemu-img (only when creating an empty disk for '--iso')
   - sudo (for running QEMU with KVM)
   - OVMF firmware (for UEFI boot)

--- a/internal/app/azldev/cmds/image/boot.go
+++ b/internal/app/azldev/cmds/image/boot.go
@@ -133,9 +133,10 @@ type ImageBootOptions struct {
 	// Disk behavior.
 	UseDiskRW bool // --rwdisk: persist writes to the source disk image.
 
-	// Cloud-init configuration. If any credential is provided, a seed ISO is generated
-	// and attached. Whether the booted system consumes it depends on cloud-init being
-	// installed and enabled in the guest (same caveat applies to disk and ISO images).
+	// Cloud-init configuration. If credentials or an explicit '--test-user' are
+	// provided, a seed ISO is generated and attached. Whether the booted system
+	// consumes it depends on cloud-init being installed and enabled in the guest
+	// (same caveat applies to disk and ISO images).
 	TestUserName            string
 	TestUserPassword        string
 	TestUserPasswordFile    string
@@ -171,7 +172,7 @@ must support serial console interaction.
 
 Requirements:
   - qemu-system-x86_64/qemu-system-aarch64 (QEMU emulator)
-  - genisoimage (only when cloud-init credentials are provided)
+  - xorriso (only when credentials or an explicit '--test-user' are provided)
   - qemu-img (only when creating an empty disk for '--iso')
   - sudo (for running QEMU with KVM)
   - OVMF firmware (for UEFI boot)`
@@ -530,7 +531,7 @@ func runQEMUBoot(
 		}
 	}
 
-	// Build the cloud-init seed ISO if any cloud-init credentials were provided.
+	// Build the cloud-init seed ISO if user provisioning was requested.
 	cloudInitISOPath := ""
 
 	if needCloudInit {
@@ -770,7 +771,7 @@ func ResolveImageByName(env *azldev.Env, imageName string) (*projectconfig.Image
 	)
 }
 
-func checkBootPrerequisites(env *azldev.Env, arch string, needQEMUImg, needGenisoimage bool) error {
+func checkBootPrerequisites(env *azldev.Env, arch string, needQEMUImg, needXorriso bool) error {
 	if err := qemu.CheckPrerequisites(env, arch); err != nil {
 		return fmt.Errorf("checking QEMU prerequisites:\n%w", err)
 	}
@@ -781,9 +782,9 @@ func checkBootPrerequisites(env *azldev.Env, arch string, needQEMUImg, needGenis
 		}
 	}
 
-	if needGenisoimage {
+	if needXorriso {
 		if err := iso.CheckPrerequisites(env); err != nil {
-			return fmt.Errorf("checking genisoimage prerequisites:\n%w", err)
+			return fmt.Errorf("checking xorriso prerequisites:\n%w", err)
 		}
 	}
 

--- a/internal/app/azldev/cmds/image/boot.go
+++ b/internal/app/azldev/cmds/image/boot.go
@@ -171,7 +171,7 @@ must support serial console interaction.
 
 Requirements:
   - qemu-system-x86_64/qemu-system-aarch64 (QEMU emulator)
-  - genisoimage (only when cloud-init credentials are provided)
+  - xorriso (only when cloud-init credentials are provided)
   - qemu-img (only when creating an empty disk for '--iso')
   - sudo (for running QEMU with KVM)
   - OVMF firmware (for UEFI boot)`
@@ -770,7 +770,7 @@ func ResolveImageByName(env *azldev.Env, imageName string) (*projectconfig.Image
 	)
 }
 
-func checkBootPrerequisites(env *azldev.Env, arch string, needQEMUImg, needGenisoimage bool) error {
+func checkBootPrerequisites(env *azldev.Env, arch string, needQEMUImg, needXorriso bool) error {
 	if err := qemu.CheckPrerequisites(env, arch); err != nil {
 		return fmt.Errorf("checking QEMU prerequisites:\n%w", err)
 	}
@@ -781,9 +781,9 @@ func checkBootPrerequisites(env *azldev.Env, arch string, needQEMUImg, needGenis
 		}
 	}
 
-	if needGenisoimage {
+	if needXorriso {
 		if err := iso.CheckPrerequisites(env); err != nil {
-			return fmt.Errorf("checking genisoimage prerequisites:\n%w", err)
+			return fmt.Errorf("checking xorriso prerequisites:\n%w", err)
 		}
 	}
 

--- a/internal/utils/iso/iso.go
+++ b/internal/utils/iso/iso.go
@@ -14,8 +14,8 @@ import (
 )
 
 const (
-	// GenisoimageBinary is the name of the genisoimage executable.
-	GenisoimageBinary = "genisoimage"
+	// XorrisoBinary is the name of the xorriso executable.
+	XorrisoBinary = "xorriso"
 )
 
 // Runner encapsulates options and dependencies for creating ISO images.
@@ -53,6 +53,7 @@ type CreateISOOptions struct {
 // CreateISO creates an ISO image from the specified input files.
 func (r *Runner) CreateISO(ctx context.Context, options CreateISOOptions) error {
 	args := []string{
+		"-as", "mkisofs",
 		"-output", options.OutputPath,
 		"-volid", options.VolumeID,
 	}
@@ -67,11 +68,11 @@ func (r *Runner) CreateISO(ctx context.Context, options CreateISOOptions) error 
 
 	args = append(args, options.InputFiles...)
 
-	isoCmd := exec.CommandContext(ctx, GenisoimageBinary, args...)
+	isoCmd := exec.CommandContext(ctx, XorrisoBinary, args...)
 
 	cmd, err := r.cmdFactory.Command(isoCmd)
 	if err != nil {
-		return fmt.Errorf("failed to create genisoimage command:\n%w", err)
+		return fmt.Errorf("failed to create xorriso command:\n%w", err)
 	}
 
 	description := options.Description
@@ -87,13 +88,13 @@ func (r *Runner) CreateISO(ctx context.Context, options CreateISOOptions) error 
 	return nil
 }
 
-// CheckPrerequisites verifies that genisoimage is available.
+// CheckPrerequisites verifies that xorriso is available.
 func CheckPrerequisites(ctx opctx.Ctx) error {
-	if err := prereqs.RequireExecutable(ctx, GenisoimageBinary, &prereqs.PackagePrereq{
-		AzureLinuxPackages: []string{"cdrkit"},
-		FedoraPackages:     []string{"genisoimage"},
+	if err := prereqs.RequireExecutable(ctx, XorrisoBinary, &prereqs.PackagePrereq{
+		AzureLinuxPackages: []string{"xorriso"},
+		FedoraPackages:     []string{"xorriso"},
 	}); err != nil {
-		return fmt.Errorf("genisoimage prerequisite check failed:\n%w", err)
+		return fmt.Errorf("xorriso prerequisite check failed:\n%w", err)
 	}
 
 	return nil

--- a/internal/utils/iso/iso_test.go
+++ b/internal/utils/iso/iso_test.go
@@ -49,7 +49,8 @@ func TestCreateISO(t *testing.T) {
 				InputFiles: []string{"/input/file1", "/input/file2"},
 			},
 			wantArgs: []string{
-				iso.GenisoimageBinary,
+				iso.XorrisoBinary,
+				"-as", "mkisofs",
 				"-output", "/output/test.iso",
 				"-volid", "MYVOLUME",
 				"/input/file1", "/input/file2",
@@ -65,7 +66,8 @@ func TestCreateISO(t *testing.T) {
 				UseJoliet:  true,
 			},
 			wantArgs: []string{
-				iso.GenisoimageBinary,
+				iso.XorrisoBinary,
+				"-as", "mkisofs",
 				"-output", "/output/test.iso",
 				"-volid", "MYVOLUME",
 				"-joliet",
@@ -82,7 +84,8 @@ func TestCreateISO(t *testing.T) {
 				UseRockRidge: true,
 			},
 			wantArgs: []string{
-				iso.GenisoimageBinary,
+				iso.XorrisoBinary,
+				"-as", "mkisofs",
 				"-output", "/output/test.iso",
 				"-volid", "MYVOLUME",
 				"-rock",
@@ -100,7 +103,8 @@ func TestCreateISO(t *testing.T) {
 				UseRockRidge: true,
 			},
 			wantArgs: []string{
-				iso.GenisoimageBinary,
+				iso.XorrisoBinary,
+				"-as", "mkisofs",
 				"-output", "/output/test.iso",
 				"-volid", "MYVOLUME",
 				"-joliet",
@@ -118,7 +122,8 @@ func TestCreateISO(t *testing.T) {
 				Description: "Creating cloud-init ISO",
 			},
 			wantArgs: []string{
-				iso.GenisoimageBinary,
+				iso.XorrisoBinary,
+				"-as", "mkisofs",
 				"-output", "/output/test.iso",
 				"-volid", "MYVOLUME",
 				"/input/file1",
@@ -132,7 +137,7 @@ func TestCreateISO(t *testing.T) {
 				VolumeID:   "MYVOLUME",
 				InputFiles: []string{"/input/file1"},
 			},
-			runErr:         errors.New("genisoimage failed"),
+			runErr:         errors.New("xorriso failed"),
 			wantErr:        true,
 			wantErrContain: "failed to create ISO image",
 		},
@@ -231,11 +236,11 @@ func TestCreateISO_MultipleInputFiles(t *testing.T) {
 func TestCheckPrerequisites(t *testing.T) {
 	t.Parallel()
 
-	t.Run("genisoimage available", func(t *testing.T) {
+	t.Run("xorriso available", func(t *testing.T) {
 		t.Parallel()
 
 		ctx := testctx.NewCtx()
-		ctx.CmdFactory.RegisterCommandInSearchPath(iso.GenisoimageBinary)
+		ctx.CmdFactory.RegisterCommandInSearchPath(iso.XorrisoBinary)
 		ctx.DryRunValue = true
 
 		err := iso.CheckPrerequisites(ctx)
@@ -243,7 +248,7 @@ func TestCheckPrerequisites(t *testing.T) {
 		require.NoError(t, err)
 	})
 
-	t.Run("genisoimage not available and prompts disallowed", func(t *testing.T) {
+	t.Run("xorriso not available and prompts disallowed", func(t *testing.T) {
 		t.Parallel()
 
 		ctx := testctx.NewCtx()
@@ -254,10 +259,10 @@ func TestCheckPrerequisites(t *testing.T) {
 		err := iso.CheckPrerequisites(ctx)
 
 		require.Error(t, err)
-		assert.Contains(t, err.Error(), "genisoimage prerequisite check failed")
+		assert.Contains(t, err.Error(), "xorriso prerequisite check failed")
 	})
 
-	t.Run("genisoimage not available with auto-install on azurelinux", func(t *testing.T) {
+	t.Run("xorriso not available with auto-install on azurelinux", func(t *testing.T) {
 		t.Parallel()
 
 		ctx := testctx.NewCtx()
@@ -272,23 +277,23 @@ func TestCheckPrerequisites(t *testing.T) {
 		// Mock the install command
 		ctx.CmdFactory.RunHandler = func(cmd *exec.Cmd) error {
 			args := strings.Join(cmd.Args, " ")
-			assert.Contains(t, args, "cdrkit",
-				"install command should include cdrkit package")
+			assert.Contains(t, args, "xorriso",
+				"install command should include xorriso package")
 
 			return nil
 		}
 
 		err = iso.CheckPrerequisites(ctx)
-		// Note: Still errors because genisoimage won't be in path after mock install
+		// Note: Still errors because xorriso won't be in path after mock install
 		require.Error(t, err)
 	})
 }
 
-func TestGenisoimageBinaryConstant(t *testing.T) {
+func TestXorrisoBinaryConstant(t *testing.T) {
 	t.Parallel()
 
 	// Verify the binary constant matches expected value
-	assert.Equal(t, "genisoimage", iso.GenisoimageBinary)
+	assert.Equal(t, "xorriso", iso.XorrisoBinary)
 }
 
 // indexOf returns the index of the first occurrence of value in slice, or -1 if not found.


### PR DESCRIPTION
genisoimage/cdrkit seem older and less well maintained. xorriso provides a compatible command-line interface and is present in AZL3 and AZL4.
