### PR TITLE
test(scenario): disable automatic git maintenance

### DIFF
--- a/scenario/internal/projecttest/dynamictestproject.go
+++ b/scenario/internal/projecttest/dynamictestproject.go
@@ -166,6 +166,8 @@ func initProjectGitRepo(t *testing.T, dir string) {
 		{"git", "init"},
 		{"git", "config", "user.email", "test@test.com"},
 		{"git", "config", "user.name", "Test User"},
+		// Avoid transient maintenance files racing with the subsequent container copy.
+		{"git", "config", "maintenance.auto", "false"},
 		{"git", "add", "."},
 		{"git", "-c", "commit.gpgsign=false", "commit", "-m", "Initial commit"},
 	}


### PR DESCRIPTION
## Summary

- disable automatic Git maintenance in generated scenario repositories
- prevent transient `.git/objects/maintenance.lock` files from racing with the recursive container copy
- keep short-lived test repository setup deterministic

## Why

Dynamic scenario repositories are copied into containers immediately after creation. Automatic maintenance can create a transient lock while `AddDirRecursive` snapshots the repository and remove it before testcontainers opens the registered file. Repository maintenance is artificial for these short-lived fixtures, so disabling it removes the race without affecting the behavior under test.

## Validation

- `mage fix all`
- affected `scenario` package, including `TestRenderWithPatchSidecar`, passed under `mage scenario`
- unrelated container-framework packages encountered the existing container image `AlreadyExists` race