### PR TITLE
feat(image): support distro kiwi config override

### DIFF
--- a/docs/user/how-to/build-image.md
+++ b/docs/user/how-to/build-image.md
@@ -30,6 +30,19 @@ Follow the interactive prompts to select an image definition and target architec
 | `--local-repo <path>` | Add a local RPM repository as a package source |
 | `--remote-repo <url>` | Add a remote RPM repository as a package source |
 | `--remote-repo-no-gpgcheck` | Disable GPG checking for remote repositories |
+## Override KIWI Configuration
+
+Set `kiwi-config-override` on the build distro version to override KIWI settings.
+The path is resolved relative to the TOML file that declares the distro version:
+
+```toml
+[distros.azurelinux.versions.'4.0-stage1']
+kiwi-config-override = "kiwi/azl4/stage1/azurelinux-4.0-kiwi-override.yml"
+```
+
+KIWI merges `--config` after its standard configuration files, giving these overrides
+the highest precedence. Merging is top-level: defining a section replaces that entire
+section from earlier files.
 
 ## Boot an Image
 

--- a/docs/user/reference/cli/azldev_image_build.md
+++ b/docs/user/reference/cli/azldev_image_build.md
@@ -12,6 +12,9 @@ The image must be defined in the project configuration with a kiwi definition ty
 This command invokes kiwi-ng via sudo to build the image. Built image artifacts
 are placed in the project output directory.
 
+The selected distro version's 'kiwi-config-override' file is passed to kiwi-ng with
+'--config'.
+
 ```
 azldev image build [image-name] [flags]
 ```

--- a/docs/user/reference/config/distros.md
+++ b/docs/user/reference/config/distros.md
@@ -55,6 +55,7 @@ Each distro can define multiple versions under `[distros.<name>.versions.<versio
 | Mock config | `mock-config` | string | No | Path to the mock config file for this version (architecture-independent) |
 | Mock config (x86_64) | `mock-config-x86_64` | string | No | Path to the x86_64-specific mock config file |
 | Mock config (aarch64) | `mock-config-aarch64` | string | No | Path to the aarch64-specific mock config file |
+| KIWI config override | `kiwi-config-override` | string | No | Path to KIWI configuration overrides for image builds using this version |
 | Inputs | `inputs` | [DistroVersionInputs](#inputs) | No | Per-use-case input RPM repositories for this version |
 
 ### Default Component Config
@@ -175,16 +176,17 @@ dist-git-branch = "rawhide"
 ```toml
 [distros.azurelinux]
 description = "Azure Linux"
-default-version = "4.0"
+default-version = "4.0-stage1"
 
-[distros.azurelinux.versions.'4.0']
-description = "Azure Linux 4.0"
+[distros.azurelinux.versions.'4.0-stage1']
+description = "Azure Linux 4.0 Stage 1"
 release-ver = "4.0"
-mock-config-x86_64 = "mock/azurelinux-4.0-x86_64.cfg"
-mock-config-aarch64 = "mock/azurelinux-4.0-aarch64.cfg"
+mock-config-x86_64 = "mock/azl4/stage1/azurelinux-4.0-x86_64.cfg"
+mock-config-aarch64 = "mock/azl4/stage1/azurelinux-4.0-aarch64.cfg"
+kiwi-config-override = "kiwi/azl4/stage1/azurelinux-4.0-kiwi-override.yml"
 
 # All components default to using Fedora 43 specs
-[distros.azurelinux.versions.'4.0'.default-component-config]
+[distros.azurelinux.versions.'4.0-stage1'.default-component-config]
 spec = { type = "upstream", upstream-distro = { name = "fedora", version = "43", snapshot = "2026-02-24T00:00:00-08:00" } }
 ```
 

--- a/internal/app/azldev/agentskill/agentskill_test.go
+++ b/internal/app/azldev/agentskill/agentskill_test.go
@@ -119,6 +119,13 @@ func TestUpdateComponentSkillStagesRenderedOutputBeforeAmend(t *testing.T) {
 		"both amend workflows must stage the post-commit render")
 }
 
+func TestImageSkillDocumentsRuntimeConfigOverride(t *testing.T) {
+	doc, err := agentskill.SkillDocument("azldev-image", testParams())
+	require.NoError(t, err)
+
+	assert.Contains(t, doc, "`kiwi-config-override`")
+}
+
 func TestSkillFrontmatterInvariants(t *testing.T) {
 	layout := agentskill.DefaultLayout()
 

--- a/internal/app/azldev/agentskill/content/image.md.tmpl
+++ b/internal/app/azldev/agentskill/content/image.md.tmpl
@@ -23,7 +23,9 @@ Images are selected by their **name as a positional argument** (not `-p`).
 | Customize a pre-built image | `azldev image customize` |
 
 `azldev image build` takes `--local-repo` / `--remote-repo` to add package sources and
-`--arch` to target an architecture. `azldev image boot` takes a built image name, or an
+`--arch` to target an architecture. When the selected distro version defines
+`kiwi-config-override`, azldev passes it to KIWI with `--config`. These top-level
+overrides have highest precedence. `azldev image boot` takes a built image name, or an
 explicit `--image-path` / `--iso`. Confirm current flags with
 `azldev image <command> --help` (there are more subcommands, e.g. `inject-files`).
 

--- a/internal/app/azldev/cmds/image/build.go
+++ b/internal/app/azldev/cmds/image/build.go
@@ -107,7 +107,10 @@ func NewImageBuildCmd() *cobra.Command {
 
 The image must be defined in the project configuration with a kiwi definition type.
 This command invokes kiwi-ng via sudo to build the image. Built image artifacts
-are placed in the project output directory.`,
+are placed in the project output directory.
+
+The selected distro version's 'kiwi-config-override' file is passed to kiwi-ng with
+'--config'.`,
 		Example: `  # Build an image by name
   azldev image build my-image
 
@@ -247,6 +250,22 @@ func createKiwiRunner(
 ) (*kiwi.Runner, error) {
 	runner := kiwi.NewRunner(env, filepath.Dir(imageConfig.Definition.Path)).
 		WithTargetDir(targetDir)
+
+	_, distroVerDef, err := env.Distro()
+	if err != nil {
+		return nil, fmt.Errorf("failed to resolve distro for image build:\n%w", err)
+	}
+
+	configOverridePath := distroVerDef.KiwiConfigOverridePath
+	if configOverridePath != "" {
+		if err := validateFileExists(env.FS(), configOverridePath); err != nil {
+			return nil, fmt.Errorf("invalid KIWI config override %#q:\n%w",
+				configOverridePath, err)
+		}
+
+		slog.Info("Using KIWI config override", "path", configOverridePath)
+		runner.WithConfigOverride(configOverridePath)
+	}
 
 	if imageConfig.Definition.Profile != "" {
 		runner.WithProfile(imageConfig.Definition.Profile)

--- a/internal/app/azldev/cmds/image/build_internal_test.go
+++ b/internal/app/azldev/cmds/image/build_internal_test.go
@@ -1,0 +1,115 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+package image
+
+import (
+	"context"
+	"os/exec"
+	"slices"
+	"testing"
+
+	"github.com/microsoft/azure-linux-dev-tools/internal/app/azldev/core/testutils"
+	"github.com/microsoft/azure-linux-dev-tools/internal/projectconfig"
+	"github.com/microsoft/azure-linux-dev-tools/internal/utils/fileperms"
+	"github.com/microsoft/azure-linux-dev-tools/internal/utils/fileutils"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCreateKiwiRunnerDistroConfigOverride(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name                 string
+		configOverridePath   string
+		createDistroOverride bool
+		createOverrideDir    bool
+		wantConfigPath       string
+		wantError            string
+	}{
+		{
+			name:                 "uses distro override",
+			configOverridePath:   "/project/distro/kiwi/azl4/stage1/azurelinux-4.0-kiwi-override.yml",
+			createDistroOverride: true,
+			wantConfigPath:       "/project/distro/kiwi/azl4/stage1/azurelinux-4.0-kiwi-override.yml",
+		},
+		{
+			name: "omits config without distro override",
+		},
+		{
+			name:               "rejects inaccessible distro override",
+			configOverridePath: "/project/distro/kiwi/missing.yml",
+			wantError:          "file not found",
+		},
+		{
+			name:               "rejects directory as distro override",
+			configOverridePath: "/project/distro/kiwi/override.yml",
+			createOverrideDir:  true,
+			wantError:          "is a directory, expected a file",
+		},
+	}
+
+	for _, testCase := range tests {
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+
+			testEnv := testutils.NewTestEnv(t)
+			require.NoError(t, fileutils.MkdirAll(testEnv.TestFS, "/work"))
+
+			distroName := testEnv.Config.Project.DefaultDistro.Name
+			distro := testEnv.Config.Distros[distroName]
+			versionName := testEnv.Config.Project.DefaultDistro.Version
+			version := distro.Versions[versionName]
+			version.KiwiConfigOverridePath = testCase.configOverridePath
+			distro.Versions[versionName] = version
+			testEnv.Config.Distros[distroName] = distro
+
+			if testCase.createDistroOverride {
+				require.NoError(t, fileutils.MkdirAll(testEnv.TestFS, "/project/distro/kiwi/azl4/stage1"))
+				require.NoError(t, fileutils.WriteFile(
+					testEnv.TestFS,
+					testCase.configOverridePath,
+					[]byte("custom: true\n"),
+					fileperms.PrivateFile,
+				))
+			} else if testCase.createOverrideDir {
+				require.NoError(t, fileutils.MkdirAll(testEnv.TestFS, testCase.configOverridePath))
+			}
+
+			var buildArgs []string
+
+			testEnv.CmdFactory.RunHandler = func(cmd *exec.Cmd) error {
+				buildArgs = cmd.Args
+
+				return nil
+			}
+
+			runner, err := createKiwiRunner(
+				testEnv.Env,
+				&projectconfig.ImageConfig{
+					Definition: projectconfig.ImageDefinition{Path: "/project/image/config.kiwi"},
+				},
+				"/work/output",
+				&ImageBuildOptions{},
+			)
+			if testCase.wantError != "" {
+				require.ErrorContains(t, err, testCase.wantError)
+
+				return
+			}
+
+			require.NoError(t, err)
+			require.NoError(t, runner.Build(context.Background()))
+
+			configFlagIndex := slices.Index(buildArgs, "--config")
+			if testCase.wantConfigPath == "" {
+				assert.Equal(t, -1, configFlagIndex)
+			} else {
+				require.NotEqual(t, -1, configFlagIndex)
+				require.Less(t, configFlagIndex+1, len(buildArgs))
+				assert.Equal(t, testCase.wantConfigPath, buildArgs[configFlagIndex+1])
+			}
+		})
+	}
+}

--- a/internal/projectconfig/distro.go
+++ b/internal/projectconfig/distro.go
@@ -86,6 +86,9 @@ type DistroVersionDefinition struct {
 	MockConfigPathX86_64  string `toml:"mock-config-x86_64,omitempty"  json:"mockConfigX8664,omitempty"   validate:"omitempty,filepath" jsonschema:"title=Mock config file,description=Path to the x86_64 mock config file for this version"`
 	MockConfigPathAarch64 string `toml:"mock-config-aarch64,omitempty" json:"mockConfigAarch64,omitempty" validate:"omitempty,filepath" jsonschema:"title=Mock config file,description=Path to the aarch64 mock config file for this version"`
 
+	// Path to KIWI configuration overrides for image builds.
+	KiwiConfigOverridePath string `toml:"kiwi-config-override,omitempty" json:"kiwiConfigOverride,omitempty" validate:"omitempty,filepath" jsonschema:"title=KIWI config override,description=Path to KIWI configuration overrides for this version"`
+
 	// Inputs maps build use-cases ([UseCaseRPMBuild], [UseCaseImageBuild]) to
 	// ordered lists of input references. Each entry references either a
 	// [RpmRepoResource] or a [RpmRepoSet]; sets are expanded at validation time.
@@ -195,6 +198,7 @@ func (v DistroVersionDefinition) WithAbsolutePaths(referenceDir string) DistroVe
 	result.DefaultComponentConfig = *(result.DefaultComponentConfig.WithAbsolutePaths(referenceDir))
 
 	result.MockConfigPath = makeAbsolute(referenceDir, result.MockConfigPath)
+	result.KiwiConfigOverridePath = makeAbsolute(referenceDir, result.KiwiConfigOverridePath)
 
 	return result
 }

--- a/internal/projectconfig/distro_test.go
+++ b/internal/projectconfig/distro_test.go
@@ -4,12 +4,38 @@
 package projectconfig_test
 
 import (
+	"path/filepath"
 	"testing"
 
 	"github.com/microsoft/azure-linux-dev-tools/internal/projectconfig"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+func TestDistroDefinitionWithAbsolutePaths(t *testing.T) {
+	t.Parallel()
+
+	const referenceDir = "/project/distro"
+
+	distro := projectconfig.DistroDefinition{
+		Versions: map[string]projectconfig.DistroVersionDefinition{
+			"4.0-stage1": {
+				KiwiConfigOverridePath: "kiwi/azl4/stage1/azurelinux-4.0-kiwi-override.yml",
+			},
+		},
+	}
+
+	resolved := distro.WithAbsolutePaths(referenceDir)
+
+	assert.Equal(t,
+		filepath.Join(referenceDir, "kiwi/azl4/stage1/azurelinux-4.0-kiwi-override.yml"),
+		resolved.Versions["4.0-stage1"].KiwiConfigOverridePath,
+	)
+	assert.Equal(t,
+		"kiwi/azl4/stage1/azurelinux-4.0-kiwi-override.yml",
+		distro.Versions["4.0-stage1"].KiwiConfigOverridePath,
+	)
+}
 
 func TestDistroReferenceStringer(t *testing.T) {
 	t.Run("name and version", func(t *testing.T) {

--- a/internal/utils/kiwi/kiwi.go
+++ b/internal/utils/kiwi/kiwi.go
@@ -122,6 +122,9 @@ type Runner struct {
 	// targetDir is the directory where kiwi will write build output.
 	targetDir string
 
+	// configOverridePath contains optional highest-precedence KIWI overrides.
+	configOverridePath string
+
 	// localRepos are local RPM repositories to include during build.
 	localRepos []repoEntry
 
@@ -152,21 +155,29 @@ func NewRunner(ctx opctx.Ctx, descriptionDir string) *Runner {
 // Clone creates a deep copy of the provided [Runner] instance.
 func (r *Runner) Clone() *Runner {
 	return &Runner{
-		fs:             r.fs,
-		cmdFactory:     r.cmdFactory,
-		verbose:        r.verbose,
-		descriptionDir: r.descriptionDir,
-		targetDir:      r.targetDir,
-		localRepos:     deep.MustCopy(r.localRepos),
-		remoteRepos:    deep.MustCopy(r.remoteRepos),
-		profile:        r.profile,
-		targetArch:     r.targetArch,
+		fs:                 r.fs,
+		cmdFactory:         r.cmdFactory,
+		verbose:            r.verbose,
+		descriptionDir:     r.descriptionDir,
+		targetDir:          r.targetDir,
+		configOverridePath: r.configOverridePath,
+		localRepos:         deep.MustCopy(r.localRepos),
+		remoteRepos:        deep.MustCopy(r.remoteRepos),
+		profile:            r.profile,
+		targetArch:         r.targetArch,
 	}
 }
 
 // WithTargetDir sets the target directory where kiwi will write build output.
 func (r *Runner) WithTargetDir(targetDir string) *Runner {
 	r.targetDir = targetDir
+
+	return r
+}
+
+// WithConfigOverride passes configPath to KIWI's '--config' option.
+func (r *Runner) WithConfigOverride(configPath string) *Runner {
+	r.configOverridePath = configPath
 
 	return r
 }
@@ -354,6 +365,10 @@ func (r *Runner) Build(ctx context.Context) error {
 	kiwiArgs := []string{
 		KiwiBinary,
 		"--loglevel", logLevel,
+	}
+
+	if r.configOverridePath != "" {
+		kiwiArgs = append(kiwiArgs, "--config", r.configOverridePath)
 	}
 
 	if r.targetArch != "" {

--- a/internal/utils/kiwi/kiwi_test.go
+++ b/internal/utils/kiwi/kiwi_test.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"errors"
 	"os/exec"
+	"slices"
 	"strings"
 	"testing"
 
@@ -40,7 +41,8 @@ func TestRunner_Clone(t *testing.T) {
 	ctx := testctx.NewCtx()
 
 	original := kiwi.NewRunner(ctx, "/original/description").
-		WithTargetDir("/original/target")
+		WithTargetDir("/original/target").
+		WithConfigOverride("/project/kiwi-override.yml")
 	original.AddLocalRepo("/repo1", nil)
 	original.AddLocalRepo("/repo2", nil)
 
@@ -56,6 +58,21 @@ func TestRunner_Clone(t *testing.T) {
 
 	assert.Equal(t, "/original/target", original.TargetDir())
 	assert.Equal(t, "/cloned/target", cloned.TargetDir())
+
+	var clonedArgs []string
+
+	ctx.CmdFactory.RunHandler = func(cmd *exec.Cmd) error {
+		clonedArgs = cmd.Args
+
+		return nil
+	}
+
+	require.NoError(t, cloned.Build(context.Background()))
+
+	configFlagIndex := slices.Index(clonedArgs, "--config")
+	require.NotEqual(t, -1, configFlagIndex)
+	require.Less(t, configFlagIndex+1, len(clonedArgs))
+	assert.Equal(t, "/project/kiwi-override.yml", clonedArgs[configFlagIndex+1])
 }
 
 func TestRunner_FluentMethods(t *testing.T) {
@@ -240,6 +257,31 @@ func TestRunner_Build(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestRunner_Build_ConfigOverride(t *testing.T) {
+	t.Parallel()
+
+	ctx := testctx.NewCtx()
+
+	var buildArgs []string
+
+	ctx.CmdFactory.RunHandler = func(cmd *exec.Cmd) error {
+		buildArgs = cmd.Args
+
+		return nil
+	}
+
+	runner := kiwi.NewRunner(ctx, "/description").
+		WithTargetDir("/work/output").
+		WithConfigOverride("/project/kiwi-override.yml")
+
+	require.NoError(t, runner.Build(context.Background()))
+
+	configFlagIndex := slices.Index(buildArgs, "--config")
+	require.NotEqual(t, -1, configFlagIndex)
+	require.Less(t, configFlagIndex+1, len(buildArgs))
+	assert.Equal(t, "/project/kiwi-override.yml", buildArgs[configFlagIndex+1])
 }
 
 func TestRunner_Build_LocalRepoFormatting(t *testing.T) {

--- a/scenario/__snapshots__/TestSnapshotsContainer_config_generate-schema_stdout_1.snap
+++ b/scenario/__snapshots__/TestSnapshotsContainer_config_generate-schema_stdout_1.snap
@@ -582,6 +582,11 @@
           "title": "Mock config file",
           "description": "Path to the aarch64 mock config file for this version"
         },
+        "kiwi-config-override": {
+          "type": "string",
+          "title": "KIWI config override",
+          "description": "Path to KIWI configuration overrides for this version"
+        },
         "inputs": {
           "$ref": "#/$defs/DistroVersionInputs",
           "title": "Inputs",

--- a/scenario/__snapshots__/TestSnapshots_config_generate-schema_stdout_1.snap
+++ b/scenario/__snapshots__/TestSnapshots_config_generate-schema_stdout_1.snap
@@ -582,6 +582,11 @@
           "title": "Mock config file",
           "description": "Path to the aarch64 mock config file for this version"
         },
+        "kiwi-config-override": {
+          "type": "string",
+          "title": "KIWI config override",
+          "description": "Path to KIWI configuration overrides for this version"
+        },
         "inputs": {
           "$ref": "#/$defs/DistroVersionInputs",
           "title": "Inputs",

--- a/schemas/azldev.schema.json
+++ b/schemas/azldev.schema.json
@@ -582,6 +582,11 @@
           "title": "Mock config file",
           "description": "Path to the aarch64 mock config file for this version"
         },
+        "kiwi-config-override": {
+          "type": "string",
+          "title": "KIWI config override",
+          "description": "Path to KIWI configuration overrides for this version"
+        },
         "inputs": {
           "$ref": "#/$defs/DistroVersionInputs",
           "title": "Inputs",


### PR DESCRIPTION
## Summary

- add `kiwi-config-override` to distro version configuration, alongside that version’s Mock configuration
- resolve the configured path relative to the TOML file declaring the distro version and pass it to KIWI with `--config`
- validate the configured path and log when the override is used
- update the schema, CLI and user documentation, agent guidance, and tests

## Override location

Each build stage declares its own override on the selected distro version. For example:

```toml
[distros.azurelinux.versions.'4.0-stage1']
kiwi-config-override = "kiwi/azl4/stage1/azurelinux-4.0-kiwi-override.yml"
```

Because the path is relative to `distro/azurelinux.distro.toml`, this resolves to `distro/kiwi/azl4/stage1/azurelinux-4.0-kiwi-override.yml`. Other stages use their corresponding `distro/kiwi/azl4/<stage-name>/<override-file>` path. azldev does not discover files by walking `distro/kiwi`; it uses the exact file declared by the selected distro version.

KIWI loads this file through `--config` after its standard configuration files, so its top-level values have highest precedence.

## Design

Azure Linux needs infrastructure-specific image-build policy such as partition mapping. Keeping each override beside the corresponding staged Mock configuration is deliberate: the distro can version and review its build-environment policy while azldev remains generic.

## Validation

- `mage fix all`
- `mage docs`
- `mage scenarioUpdate`
- `mage all`