### PR TITLE
chore: use github self-repo syntax for workflows

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -27,7 +27,7 @@ jobs:
         with:
           persist-credentials: false
       - name: Get go tools
-        uses: ./.github/getgotools
+        uses: $/.github/getgotools
       - name: Run tests
         run: |
           mage -v gocov

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -27,6 +27,6 @@ jobs:
         with:
           persist-credentials: false
       - name: Get go tools
-        uses: ./.github/getgotools
+        uses: $/.github/getgotools
       - name: Run mage check lint
         run: mage check lint

--- a/.github/workflows/generate.yml
+++ b/.github/workflows/generate.yml
@@ -30,7 +30,7 @@ jobs:
           persist-credentials: false
 
       - name: Get go tools
-        uses: ./.github/getgotools
+        uses: $/.github/getgotools
 
       - name: Run code generation
         run: |

--- a/.github/workflows/license.yml
+++ b/.github/workflows/license.yml
@@ -27,7 +27,7 @@ jobs:
         with:
           persist-credentials: false
       - name: Get go tools
-        uses: ./.github/getgotools
+        uses: $/.github/getgotools
       - name: Run license checks
         run: |
           mage -v check licenses

--- a/.github/workflows/mod.yml
+++ b/.github/workflows/mod.yml
@@ -27,7 +27,7 @@ jobs:
         with:
           persist-credentials: false
       - name: Get go tools
-        uses: ./.github/getgotools
+        uses: $/.github/getgotools
       - name: Run go mod tidy
         run: |
           mage -v check mod

--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -32,7 +32,7 @@ jobs:
           persist-credentials: false
 
       - name: Get go tools
-        uses: ./.github/getgotools
+        uses: $/.github/getgotools
 
       - name: Read pinned git-cliff version
         id: gitcliff

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -27,7 +27,7 @@ jobs:
         with:
           persist-credentials: false
       - name: Get go tools
-        uses: ./.github/getgotools
+        uses: $/.github/getgotools
       - name: Install Python lint tools
         run: pip install -r requirements-lint.txt
       - name: Run mage check python

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,7 +32,7 @@ jobs:
           persist-credentials: false
 
       - name: Get go tools
-        uses: ./.github/getgotools
+        uses: $/.github/getgotools
 
       - name: Create release tag from changelog
         run: |

--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -27,7 +27,7 @@ jobs:
         with:
           persist-credentials: false
       - name: Get go tools
-        uses: ./.github/getgotools
+        uses: $/.github/getgotools
       - name: Run static analysis
         run: |
           mage -v check static

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,7 +27,7 @@ jobs:
         with:
           persist-credentials: false
       - name: Get go tools
-        uses: ./.github/getgotools
+        uses: $/.github/getgotools
       - name: Run tests
         run: |
           mage -v unit
@@ -45,7 +45,7 @@ jobs:
         with:
           persist-credentials: false
       - name: Get go tools
-        uses: ./.github/getgotools
+        uses: $/.github/getgotools
 
       - name: Disable unix_chkpwd policy
         run: |
@@ -81,7 +81,7 @@ jobs:
         with:
           persist-credentials: false
       - name: Get go tools
-        uses: ./.github/getgotools
+        uses: $/.github/getgotools
 
       - name: Disable unix_chkpwd policy
         run: |

--- a/.github/workflows/testpublish.yml
+++ b/.github/workflows/testpublish.yml
@@ -27,7 +27,7 @@ jobs:
         with:
           persist-credentials: false
       - name: Get go tools
-        uses: ./.github/getgotools
+        uses: $/.github/getgotools
       - name: Run publish prep checks
         run: |
           mage -v publishPrep


### PR DESCRIPTION
New zizmor warning flagged these.

Reference: https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-syntax#example-using-an-action-in-the-same-repository-as-the-workflow-at-the-running-commit-recommended